### PR TITLE
updated quick install links for download

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -73,7 +73,7 @@ cd tools/ && git clone https://github.com/crosscloudci/k8s-infra.git
 We support the following methods of installing the cnf-conformance suite:
 
 - [Curl installation](#Curl-Binary-Installation) (via latest binary release)
-- [Latest Binary](https://github.com/cncf/cnf-conformance/releases/latest) (manual download)
+- [Latest Binary](https://github.com/cncf/cnf-testsuite/releases/latest) (manual download)
 - From [**Source**](#Source-Install) on github.
 
 
@@ -84,7 +84,7 @@ There are two methods to install via curl, we prefer the first method (the other
 - This first command using curl will download, install, and export the path automatically (recommended method):
 
 ```
-source <(curl https://raw.githubusercontent.com/cncf/cnf-conformance/main/curl_install.sh)
+source <(curl https://raw.githubusercontent.com/cncf/cnf-testsuite/main/curl_install.sh)
 ```
 
 <details><summary>Click here for the alternate curl and manual install method</summary>
@@ -92,12 +92,12 @@ source <(curl https://raw.githubusercontent.com/cncf/cnf-conformance/main/curl_i
 
 - The other curl method to download and install requires you to export the PATH to the location of the executable:
 ```
-curl https://raw.githubusercontent.com/cncf/cnf-conformance/main/curl_install.sh | bash
+curl https://raw.githubusercontent.com/cncf/cnf-testsuite/main/curl_install.sh | bash
 ```
 
 - The Latest Binary (or you can select a previous release if desired) can be pulled down with wget, curl or you're own preferred method. Once downloaded you'll need to make the binary executable and manually add to your path:
 ```
-wget https://github.com/cncf/cnf-conformance/releases/download/latest/latest.tar.gz
+wget https://github.com/cncf/cnf-testsuite/releases/download/latest/latest.tar.gz
 tar xzf latest.tar.gz
 cd cnf-conformance
 chmod +x cnf-conformance
@@ -116,8 +116,8 @@ This is a brief summary for source installations and [does have requirements](#R
 Follow these steps to checkout the source from github and compile a cnf-conformance binary:
 
 ```
-git clone https://github.com/cncf/cnf-conformance.git
-cd cnf-conformance/
+git clone https://github.com/cncf/cnf-testsuite.git
+cd cnf-testsuite/
 shards install
 crystal build src/cnf-conformance.cr
 ```
@@ -180,14 +180,14 @@ Now cnf-conformance is setup, we're ready to configure it to point at a CNF to t
 - If you want to use an example CNF, you can download our CoreDNS example CNF by doing the following:
 
 ```
-wget -O cnf-conformance.yml https://raw.githubusercontent.com/cncf/cnf-conformance/main/example-cnfs/coredns/cnf-conformance.yml
+wget -O cnf-conformance.yml https://raw.githubusercontent.com/cncf/cnf-testsuite/main/example-cnfs/coredns/cnf-conformance.yml
 ```
 - The wget gets a working config file, now tell cnf-conformance to use it by doing the following:
 ```
 cnf-conformance cnf_setup cnf-config=./cnf-conformance.yml
 ```
 
-- There are other examples in the [examples-cnfs](https://github.com/cncf/cnf-conformance/tree/master/example-cnfs) directory that can be used for testing as well.
+- There are other examples in the [examples-cnfs](https://github.com/cncf/cnf-testsuite/tree/master/example-cnfs) directory that can be used for testing as well.
 
 #### Bring Your Own CNF
 

--- a/README.md
+++ b/README.md
@@ -13,9 +13,9 @@ To get the CNF Test Suite up and running, see the [Installation Guide](INSTALL.m
 #### To give it a try immediately you can use these quick install steps
 Prereqs: kubernetes cluster, wget, curl, helm 3.1.1 or greater on your system already.
 
-1. Install the latest test suite binary:  `source <(curl https://raw.githubusercontent.com/cncf/cnf-conformance/main/curl_install.sh)`
+1. Install the latest test suite binary:  `source <(curl https://raw.githubusercontent.com/cncf/cnf-testsuite/main/curl_install.sh)`
 2. Run `setup` to prepare the cnf-conformance suite: `cnf-conformance setup`
-3. Pull down an example CNF configuration to try: `curl -o cnf-conformance.yml https://raw.githubusercontent.com/cncf/cnf-conformance/main/example-cnfs/coredns/cnf-conformance.yml`
+3. Pull down an example CNF configuration to try: `curl -o cnf-conformance.yml https://raw.githubusercontent.com/cncf/cnf-testsuite/main/example-cnfs/coredns/cnf-conformance.yml`
 4. Initialize the test suite for using the CNF: `cnf-conformance cnf_setup cnf-config=./cnf-conformance.yml`
 5. Run all of application/workload tests: `cnf-conformance workload`
 

--- a/SOURCE_INSTALL.md
+++ b/SOURCE_INSTALL.md
@@ -77,7 +77,7 @@ We can assume you have access to a working kubernetes cluster. We recommend only
 - cnf-conformance needs helm-3.1.1 or greater. You can install helm by checking their [installation methods](https://helm.sh/docs/helm/helm_install/) but you can also skip this as cnf-conformance will install if it's not found.
 - Checkout the source code with git:
   ```
-  git clone git@github.com:cncf/cnf-conformance.git
+  git clone git@github.com:cncf/cnf-testsuite.git
   ```
 - Change directory into the source:
   ```
@@ -158,7 +158,7 @@ To use CoreDNS as an example CNF. Download the conformance configuration to test
 
 - Make sure you are in your cnf-conformance/ source repo checkout directory and do the following:
   ```
-  curl -o cnf-conformance.yml https://raw.githubusercontent.com/cncf/cnf-conformance/main/example-cnfs/coredns/cnf-conformance.yml
+  curl -o cnf-conformance.yml https://raw.githubusercontent.com/cncf/cnf-testsuite/main/example-cnfs/coredns/cnf-conformance.yml
   ```
 - Prepare the test suite to use the CNF by running:
   ```
@@ -171,12 +171,12 @@ To use CoreDNS as an example CNF. Download the conformance configuration to test
   crystal src/cnf-conformance.cr cnf_setup cnf-config=./cnf-  conformance.yml
   ```
 
-There are other examples in the [example cnfs](https://github.com/cncf/cnf-conformance/tree/main/example-cnfs) folder if you would like to test others.
+There are other examples in the [example cnfs](https://github.com/cncf/cnf-testsuite/tree/main/example-cnfs) folder if you would like to test others.
 
 #### NOTE: CNF **must** have a [helm chart](https://helm.sh/)
 
 - To pass all current tests
-- To support auto deployment of the CNF from the ([cnf-conformance.yml](https://github.com/cncf/cnf-conformance/blob/main/CNF_CONFORMANCE_YML_USAGE.md)) configuration file.
+- To support auto deployment of the CNF from the ([cnf-conformance.yml](https://github.com/cncf/cnf-testsuite/blob/main/CNF_CONFORMANCE_YML_USAGE.md)) configuration file.
 
 ### Running cnf-conformance for the first time
 
@@ -200,7 +200,7 @@ The following would run only the platform tests:
 ```
 You can also run via `crystal` by replacing the `./cnf-conformance` with `crystal spec src/cnf-conformance.cr` and then the argument.
 
-#### More Example Usage (also see the [complete usage documentation](https://github.com/cncf/cnf-conformance/blob/main/USAGE.md))
+#### More Example Usage (also see the [complete usage documentation](https://github.com/cncf/cnf-testsuite/blob/main/USAGE.md))
 
 ```
 # These assume you've already run the cnf_setup pointing at a cnf-conformance.yml config above. You can always specify your config at the end of each command as well, eg:
@@ -245,7 +245,7 @@ You can also run `cleanall` and cnf-conformance will attempt to cleanup everythi
 _NOTE: Cleanup does not handle manually deployed CNFs_
 
 ### Ready to Bring Your Own CNF?
-You can check out our [CNF_CONFORMANCE_YML_USAGE.md](https://github.com/cncf/cnf-conformance/blob/main/CNF_CONFORMANCE_YML_USAGE.md) document on what is required to bring or use your own CNF.
+You can check out our [CNF_CONFORMANCE_YML_USAGE.md](https://github.com/cncf/cnf-testsuite/blob/main/CNF_CONFORMANCE_YML_USAGE.md) document on what is required to bring or use your own CNF.
 
 - Follow the [INSTALL](https://github.com/cncf/cnf-conformance/blob/main/INSTALL.md) or [SOURCE-INSTALL](https://github.com/cncf/cnf-conformance/blob/main/SOURCE-INSTALL.md) to build the binary.
-- Now head over to [CNF_CONFORMANCE_YML_USAGE.md](https://github.com/cncf/cnf-conformance/blob/main/CNF_CONFORMANCE_YML_USAGE.md) for more detailed steps.
+- Now head over to [CNF_CONFORMANCE_YML_USAGE.md](https://github.com/cncf/cnf-testsuite/blob/main/CNF_CONFORMANCE_YML_USAGE.md) for more detailed steps.


### PR DESCRIPTION
Using cnf-testsuite instead of cnf-conformance for urls in installation docs.

Note:

- Does not update code.
- Does not change the commands to run.


## Issues:
Refs: #555 

## How has this been tested:
 - [ ] Covered by existing integration testing
 - [ ] Added integration testing to cover
 - [ ] Verified all A/C passes
     * [ ] develop
     * [ ] master
     * [ ] tag/other branch
 - [ ] Test environment
    * [ ] Shared Packet K8s cluster
    * [ ] New Packet K8s cluster
    * [ ] Kind cluster
 - [x] Have not tested

## Types of changes:
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [x] Documentation update

## Checklist:
**Documentation**
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] No updates required.

**Code Review**
- [ ] Does the test handle fatal exceptions, ie. rescue block

**Issue**
- [ ] Tasks in issue are checked off
