### PR TITLE
Refactor helm_deploy to use data from initial test suite CNF deployment and no longer do a new deployment

### DIFF
--- a/spec/workload/installability_spec.cr
+++ b/spec/workload/installability_spec.cr
@@ -19,10 +19,13 @@ describe CnfConformance do
   end
 
 	it "'helm_deploy' should fail on a bad helm chart", tags: ["helm"] do
-    response_s = `./cnf-conformance helm_deploy destructive cnf-config=sample-cnfs/sample-bad-helm-deploy-repo/cnf-conformance.yml verbose`
+    LOGGING.info `./cnf-conformance cnf_setup cnf-path=./sample-cnfs/sample-bad-helm-deploy-repo verbose`
+    response_s = `./cnf-conformance helm_deploy destructive verbose`
     LOGGING.info response_s
     $?.success?.should be_true
     (/FAILED: Helm deploy failed/ =~ response_s).should_not be_nil
+  ensure
+    LOGGING.info `./cnf-conformance cnf_cleanup cnf-path=./sample-cnfs/sample-bad-helm-deploy-repo verbose`
   end
 
   it "'helm_deploy' should fail if command is not supplied cnf-config argument", tags: ["helm"] do
@@ -31,21 +34,6 @@ describe CnfConformance do
     $?.success?.should be_true
     (/No cnf_conformance.yml found! Did you run the setup task/ =~ response_s).should_not be_nil
   end
-
-  it "'helm_deploy' should pass if command is supplied cnf-config argument with helm_chart declared", tags: ["helm"]  do
-    response_s = `./cnf-conformance helm_deploy destructive cnf-config=sample-cnfs/sample_coredns/cnf-conformance.yml verbose`
-    $?.success?.should be_true
-    LOGGING.info response_s
-    (/PASSED: Helm deploy successful/ =~ response_s).should_not be_nil
-  end
-
-  it "'helm_deploy' should pass if command is supplied cnf-config argument without helm_chart declared", tags: ["helm"]  do
-    response_s = `./cnf-conformance helm_deploy destructive cnf-config=sample-cnfs/sample_coredns_chart_directory/cnf-conformance.yml verbose`
-    $?.success?.should be_true
-    LOGGING.info response_s
-    (/PASSED: Helm deploy successful/ =~ response_s).should_not be_nil
-  end
-
 
   it "'helm_chart_valid' should pass on a good helm chart", tags: ["helm"]  do
     LOGGING.info `./cnf-conformance cnf_setup cnf-config=./sample-cnfs/sample-coredns-cnf/cnf-conformance.yml verbose wait_count=0`

--- a/src/tasks/workload/microservice.cr
+++ b/src/tasks/workload/microservice.cr
@@ -31,71 +31,9 @@ task "reasonable_startup_time" do |_, args|
     helm = CNFSingleton.helm
     VERBOSE_LOGGING.info helm if check_verbose(args)
 
-    # create_namespace = `kubectl create namespace startup-test`
-    # helm_template_orig = ""
-    # helm_template_test = ""
-    # kubectl_apply = ""
-    # is_kubectl_applied = ""
-    # is_kubectl_deployed = ""
-    # # TODO make this work with a manifest installation
-    # elapsed_time = Time.measure do
-    #   LOGGING.info("reasonable_startup_time helm_chart.empty?: #{helm_chart.empty?}")
-    #   if install_method[0] == :helm_chart
-    #   # unless helm_chart.empty? #TODO make this work for a manifest
-    #     LOGGING.info("reasonable_startup_time #{helm} template #{release_name} #{helm_chart} > #{yml_file_path}/reasonable_startup_orig.yml")
-    #     LOGGING.info "helm_template_orig command: #{helm} template #{release_name} #{helm_chart} > #{yml_file_path}/reasonable_startup_orig.yml}"
-    #     helm_template_orig = `#{helm} template #{release_name} #{helm_chart} > #{yml_file_path}/reasonable_startup_orig.yml`
-    #     LOGGING.info("reasonable_startup_time #{helm} template --namespace=startup-test #{release_name} #{helm_chart} > #{yml_file_path}/reasonable_startup_test.yml")
-    #     helm_template_test = `#{helm} template --namespace=startup-test #{release_name} #{helm_chart} > #{yml_file_path}/reasonable_startup_test.yml`
-    #     VERBOSE_LOGGING.info "helm_chart: #{helm_chart}" if check_verbose(args)
-    #   elsif install_method[0] == :helm_directory
-    #     LOGGING.info("reasonable_startup_time #{helm} template #{release_name} #{yml_file_path}/#{helm_directory} > #{yml_file_path}/reasonable_startup_orig.yml")
-    #     helm_template_orig = `#{helm} template #{release_name} #{yml_file_path}/#{helm_directory} > #{yml_file_path}/reasonable_startup_orig.yml`
-    #     LOGGING.info("reasonable_startup_time #{helm} template --namespace=startup-test #{release_name} #{yml_file_path}/#{helm_directory} > #{yml_file_path}/reasonable_startup_test.yml")
-    #     helm_template_test = `#{helm} template --namespace=startup-test #{release_name} #{yml_file_path}/#{helm_directory} > #{yml_file_path}/reasonable_startup_test.yml`
-    #     VERBOSE_LOGGING.info "helm_directory: #{helm_directory}" if check_verbose(args)
-    #   else # manifest file installation not supported
-    #     puts "Manifest file not supported for reasonable startup time yet".colorize(:yellow)
-    #     raise "Manifest file not supported yet"
-    #   end
-    #
-    #   # kubectl_apply = `kubectl apply -f #{yml_file_path}/reasonable_startup_test.yml --namespace=startup-test`
-    #   KubectlClient::Apply.file("#{yml_file_path}/reasonable_startup_test.yml --namespace=startup-test")
-    #   is_kubectl_applied = $?.success?
-    #
-    #   template_ymls = Helm::Manifest.parse_manifest_as_ymls("#{yml_file_path}/reasonable_startup_test.yml")
-    #
-    #   LOGGING.debug "template_ymls: #{template_ymls}"
-    #   task_response = template_ymls.map do |resource|
-    #     LOGGING.debug "Waiting on resource: #{resource["metadata"]["name"]} of type #{resource["kind"]}"
-    #     if resource["kind"].as_s.downcase == "deployment" ||
-    #         resource["kind"].as_s.downcase == "pod" ||
-    #         resource["kind"].as_s.downcase == "daemonset" ||
-    #         resource["kind"].as_s.downcase == "statefulset" ||
-    #         resource["kind"].as_s.downcase == "replicaset"
-    #
-    #       KubectlClient::Get.resource_wait_for_install(resource["kind"].as_s, resource["metadata"]["name"].as_s, wait_count=180, "startup-test")
-    #       $?.success?
-    #     else
-    #       true
-    #     end
-    #   end
-    #   is_kubectl_deployed = task_response.none?{|x| x == false}
-    # end
-    #
-    # VERBOSE_LOGGING.info helm_template_test if check_verbose(args)
-    # VERBOSE_LOGGING.info kubectl_apply if check_verbose(args)
-    # VERBOSE_LOGGING.info "installed? #{is_kubectl_applied}" if check_verbose(args)
-    # VERBOSE_LOGGING.info "deployed? #{is_kubectl_deployed}" if check_verbose(args)
-
-
-    #TODO create a way to retrieve the config map as json yml
     configmap = KubectlClient::Get.configmap("cnf-testsuite-#{release_name}-startup-information")
     #TODO check if json is empty
     startup_time = configmap["data"].as_h["startup_time"].as_s
-    #TODO create a way to parse the config map
-    #TODO display pass or fail based on time in config map
-    # TODO retrieve config map data in reasonable start time test and display it
 
     emoji_fast="🚀"
     emoji_slow="🐢"


### PR DESCRIPTION
## Description
Refactor helm_deploy to use data from initial test suite CNF deployment and no longer do a new deployment

## Issues:
Refs: #564

## How has this been tested:
 - [x] Covered by existing integration testing
 - [ ] Added integration testing to cover
 - [ ] Verified all A/C passes
     * [ ] develop
     * [ ] master
     * [ ] tag/other branch
 - [ ] Test environment
    * [ ] Shared Packet K8s cluster
    * [ ] New Packet K8s cluster
    * [ ] Kind cluster
 - [ ] Have not tested

## Types of changes:
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [x] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [ ] Documentation update

## Checklist:
**Documentation**
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] No updates required.

**Code Review**
- [ ] Does the test handle fatal exceptions, ie. rescue block

**Issue**
- [ ] Tasks in issue are checked off
