### PR TITLE
Fix bug causing binary tests to run for documentation only changes 

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -205,8 +205,9 @@ jobs:
 
   test_binary_configuration_lifecycle:
     name: Test Binary Without Source(config_lifecycle)
-    needs: [build, debug_output]
+    needs: [build, debug_output, skip]
     runs-on: ubuntu-latest
+    if: needs.skip.outputs.skip == 'false'
     steps: 
     - name: Download artifact
       uses: actions/download-artifact@v2
@@ -237,8 +238,9 @@ jobs:
 
   test_binary_microservice:
     name: Test Binary Without Source(microservice)
-    needs: [build, debug_output]
+    needs: [build, debug_output, skip]
     runs-on: ubuntu-latest
+    if: needs.skip.outputs.skip == 'false'
     steps: 
     - name: Download artifact
       uses: actions/download-artifact@v2
@@ -269,8 +271,9 @@ jobs:
 
   test_binary_all:
     name: Test Binary Without Source(all)
-    needs: [build, debug_output]
+    needs: [build, debug_output, skip]
     runs-on: ubuntu-latest
+    if: needs.skip.outputs.skip == 'false'
     steps: 
     - name: Download artifact
       uses: actions/download-artifact@v2


### PR DESCRIPTION
## Description
Fix bug causing binary tests to run for documentation only changes.

## Issues:
Refs: cncf/cnf-testsuite#734


## How has this been tested:
 - [ ] Covered by existing integration testing
 - [ ] Added integration testing to cover
 - [ ] Verified all A/C passes
     * [ ] develop
     * [ ] master
     * [ ] tag/other branch
 - [ ] Test environment
    * [ ] Shared Packet K8s cluster
    * [ ] New Packet K8s cluster
    * [ ] Kind cluster
 - [ ] Have not tested

## Types of changes:
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [ ] Documentation update

## Checklist:
**Documentation**
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] No updates required.

**Code Review**
- [ ] Does the test handle fatal exceptions, ie. rescue block

**Issue**
- [ ] Tasks in issue are checked off
