### PR TITLE
Update curl install script to give a non-zero exit code on failures

### DIFF
--- a/curl_install.sh
+++ b/curl_install.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -o errexit
 
 if [[ "$SHELL" == *"bash"* ]]; then
     echo "Shell Type: Bash"

--- a/spec/curl_install_spec.cr
+++ b/spec/curl_install_spec.cr
@@ -19,11 +19,13 @@ describe "CurlInstall" do
   it "'source curl_install.sh' should download a cnf-conformance binary", tags: ["curl"]  do
     response_s = `/bin/bash -c "source ./curl_install.sh"`
     LOGGING.info response_s
+    $?.success?.should be_true
     (/cnf-testsuite/ =~ response_s).should_not be_nil
   end
   it "'curl_install.sh' should download a cnf-testsuite binary", tags: ["curl"]  do
     response_s = `./curl_install.sh`
     LOGGING.info response_s
+    $?.success?.should be_true
     (/To use the cnf-testsuite please restart you terminal session to load the new 'path'/ =~ response_s).should_not be_nil
   end
 end


### PR DESCRIPTION

## Description
Update curl install script to give a non-zero exit code on failures.

## Issues:
Refs: cncf/cnf-testsuite#741



## How has this been tested:
 - [ ] Covered by existing integration testing
 - [ ] Added integration testing to cover
 - [ ] Verified all A/C passes
     * [ ] develop
     * [ ] master
     * [ ] tag/other branch
 - [ ] Test environment
    * [ ] Shared Packet K8s cluster
    * [ ] New Packet K8s cluster
    * [ ] Kind cluster
 - [ ] Have not tested

## Types of changes:
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [ ] Documentation update

## Checklist:
**Documentation**
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] No updates required.

**Code Review**
- [ ] Does the test handle fatal exceptions, ie. rescue block

**Issue**
- [ ] Tasks in issue are checked off
