### PR TITLE
Use full binary execution path for running the help command 

### DIFF
--- a/src/cnf-testsuite.cr
+++ b/src/cnf-testsuite.cr
@@ -99,7 +99,7 @@ end
 
 # Sam.help
 begin
-  puts `./cnf-testsuite help` if ARGV.empty?
+  puts `#{PROGRAM_NAME} help` if ARGV.empty?
   # See issue #426 for exit code requirement
   Sam.process_tasks(ARGV.clone) 
   yaml = File.open("#{CNFManager::Points::Results.file}") do |file|


### PR DESCRIPTION

## Description
Use full binary execution path for running the help command 


## Issues:
Refs: cncf/cnf-testsuite#746


## How has this been tested:
 - [ ] Covered by existing integration testing
 - [ ] Added integration testing to cover
 - [ ] Verified all A/C passes
     * [ ] develop
     * [ ] master
     * [ ] tag/other branch
 - [ ] Test environment
    * [ ] Shared Packet K8s cluster
    * [ ] New Packet K8s cluster
    * [ ] Kind cluster
 - [ ] Have not tested

## Types of changes:
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [ ] Documentation update

## Checklist:
**Documentation**
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] No updates required.

**Code Review**
- [ ] Does the test handle fatal exceptions, ie. rescue block

**Issue**
- [ ] Tasks in issue are checked off
