### PR TITLE
Set default log level to error

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -15,5 +15,5 @@ toggles:
 # kind) will be changed, rebooted, chaos tested, etc
   - name: destructive 
     toggle_on: false
-loglevel: info
+loglevel: error
 


### PR DESCRIPTION
was set to info which has debug info. Change in config.yml locally or
via LOG_LEVEL=<LOG_LEVEL_NAME> eg. LOG_LEVEL=info

## Description
make it less noisy for default checkouts of config.yml

note:  #764 goes into creating the config.yml at runtime and not having in repo

## Issues:
Refs: #764 

## How has this been tested:
 - [x] Covered by existing integration testing
 - [ ] Added integration testing to cover
 - [ ] Verified all A/C passes
     * [ ] develop
     * [ ] master
     * [ ] tag/other branch
 - [ ] Test environment
    * [ ] Shared Packet K8s cluster
    * [ ] New Packet K8s cluster
    * [ ] Kind cluster
 - [ ] Have not tested

## Types of changes:
 - [x] Minor change to default config
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [ ] Documentation update

## Checklist:
**Documentation**
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] No updates required.

**Code Review**
- [ ] Does the test handle fatal exceptions, ie. rescue block

**Issue**
- [ ] Tasks in issue are checked off
