### PR TITLE
Fixed the example cnf-testsuite.yml as it was outdated

### DIFF
--- a/example-cnfs/coredns/cnf-testsuite.yml
+++ b/example-cnfs/coredns/cnf-testsuite.yml
@@ -1,23 +1,16 @@
 ---
 git_clone_url: 
-install_script: 
+helm_chart: stable/coredns
 release_name: coredns
 deployment_name: coredns-coredns 
 deployment_label: k8s-app
-service_name: coredns-coredns 
-application_deployment_names: [coredns-coredns]
-docker_repository: coredns/coredns
-helm_repository:
-  name: stable 
-  repo_url: https://cncf.gitlab.io/stable
-helm_chart: stable/coredns
+service_name: coredns-coredns
+application_deployment_names: [coredns]
 helm_chart_container_name: coredns
-allowlist_helm_chart_container_names: [falco, node-cache, nginx, coredns, calico-node, kube-proxy, nginx-proxy, kube-multus]
-
 container_names: 
   - name: coredns 
     rolling_update_test_tag: "1.8.0"
     rolling_downgrade_test_tag: 1.6.7
-    rolling_version_change_test_tag: latest
-    rollback_from_tag: latest
-
+    rolling_version_change_test_tag: 1.8.0
+    rollback_from_tag: 1.8.0 
+allowlist_helm_chart_container_names: []


### PR DESCRIPTION
## Description
Fixes the output during `cnf_setup` of the example cnf yml: `rm: cannot remove '/home/taylor/workspace/taylor/cnfs/coredns/configmap_test.yml': No such file  or directory`

## Issues:
Refs: #776 

## How has this been tested:
 - [ ] Covered by existing integration testing
 - [ ] Added integration testing to cover
 - [ ] Verified all A/C passes
     * [ ] develop
     * [ ] master
     * [ ] tag/other branch
 - [x] Test environment
    * [ ] Shared Packet K8s cluster
    * [ ] New Packet K8s cluster
    * [x] Kind cluster
 - [ ] Have not tested

## Types of changes:
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [ ] Documentation update

## Checklist:
**Documentation**
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] No updates required.

**Code Review**
- [ ] Does the test handle fatal exceptions, ie. rescue block

**Issue**
- [ ] Tasks in issue are checked off
