### PR TITLE
Feature/#745 clean up binary messaging

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -84,7 +84,7 @@ There are two methods to install via curl, we prefer the first method (the other
 - This first command using curl will download, install, and export the path automatically (recommended method):
 
 ```
-source <(curl https://raw.githubusercontent.com/cncf/cnf-testsuite/main/curl_install.sh)
+source <(curl -s https://raw.githubusercontent.com/cncf/cnf-testsuite/main/curl_install.sh)
 ```
 
 <details><summary>Click here for the alternate curl and manual install method</summary>
@@ -92,7 +92,7 @@ source <(curl https://raw.githubusercontent.com/cncf/cnf-testsuite/main/curl_ins
 
 - The other curl method to download and install requires you to export the PATH to the location of the executable:
 ```
-curl https://raw.githubusercontent.com/cncf/cnf-testsuite/main/curl_install.sh | bash
+curl -s https://raw.githubusercontent.com/cncf/cnf-testsuite/main/curl_install.sh | bash
 ```
 
 - The Latest Binary (or you can select a previous release if desired) can be pulled down with wget, curl or you're own preferred method. Once downloaded you'll need to make the binary executable and manually add to your path:

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ To get the CNF Test Suite up and running, see the [Installation Guide](INSTALL.m
 
 Prereqs: kubernetes cluster, wget, curl, helm 3.1.1 or greater on your system already.
 
-1. Install the latest test suite binary: `source <(curl https://raw.githubusercontent.com/cncf/cnf-testsuite/main/curl_install.sh)`
+1. Install the latest test suite binary: `source <(curl -s https://raw.githubusercontent.com/cncf/cnf-testsuite/main/curl_install.sh)`
 2. Run `setup` to prepare the cnf-testsuite: `cnf-testsuite setup`
 3. Pull down an example CNF configuration to try: `curl -o cnf-testsuite.yml https://raw.githubusercontent.com/cncf/cnf-testsuite/main/example-cnfs/coredns/cnf-testsuite.yml`
 4. Initialize the test suite for using the CNF: `cnf-testsuite cnf_setup cnf-config=./cnf-testsuite.yml`

--- a/curl_install.sh
+++ b/curl_install.sh
@@ -2,17 +2,13 @@
 set -o errexit
 
 if [[ "$SHELL" == *"bash"* ]]; then
-    echo "Shell Type: Bash"
     SHELL_PROFILE=~/.bashrc
     SHELL_DOT_DIR=~/.bash.d/
 elif [[ "$SHELL" == *"zsh"* ]]; then
-    echo "Shell Type: Zsh"
     SHELL_PROFILE=~/.zshrc
     SHELL_DOT_DIR=~/.zsh.d/
 else
     SHELL_UNSUPPORTED=true
-    echo "Unsupported Shell Type Found: $SHELL"
-    echo "Using generic 'path' for setup/cleanup"
 fi
 
 if [ "$1" = "cleanup" ]; then 
@@ -33,7 +29,7 @@ get_latest_release() {
 # Install CNF-TestSuite
 LATEST_RELEASE=$(get_latest_release cncf/cnf-testsuite)
 mkdir -p ~/.cnf-testsuite
-curl -L https://github.com/cncf/cnf-testsuite/releases/download/$LATEST_RELEASE/cnf-testsuite-$LATEST_RELEASE.tar.gz -o ~/.cnf-testsuite/cnf-testsuite.tar.gz
+curl --silent -L https://github.com/cncf/cnf-testsuite/releases/download/$LATEST_RELEASE/cnf-testsuite-$LATEST_RELEASE.tar.gz -o ~/.cnf-testsuite/cnf-testsuite.tar.gz
 tar -C ~/.cnf-testsuite -xvf ~/.cnf-testsuite/cnf-testsuite.tar.gz
 rm ~/.cnf-testsuite/cnf-testsuite.tar.gz
 
@@ -55,16 +51,14 @@ if [ -z ${SHELL_UNSUPPORTED+x} ]; then
 
     if (return 0 2>/dev/null); then
         export PATH=$HOME/.cnf-testsuite:$PATH
-        echo "The cnf-testsuite 'path' has been written to ${SHELL_DOT_DIR}cnf-testsuite"
-        echo "cnf-testsuite has been successfully installed to: ~/.cnf-testsuite"
+        echo "cnf-testsuite has been successfully installed to: ~/.cnf-testsuite and added to your PATH"
     else
-        echo "The cnf-testsuite 'path' has been written to ${SHELL_DOT_DIR}cnf-testsuite"
         echo "cnf-testsuite has been successfully installed to: ~/.cnf-testsuite"
         echo "To use the cnf-testsuite please restart you terminal session to load the new 'path'"
         echo "Or you can manually run 'export PATH=\$HOME/.cnf-testsuite:\$PATH' in your current session"
     fi
 else
-    echo "Because an unsupported shell was detected you will need to manually set you path using something like:"
+    echo "Because an unsupported shell was detected you will need to manually set you path, eg.:"
     echo "'export PATH=\$HOME/.cnf-testsuite:\$PATH'"
 fi
 

--- a/curl_install.sh
+++ b/curl_install.sh
@@ -51,14 +51,14 @@ if [ -z ${SHELL_UNSUPPORTED+x} ]; then
 
     if (return 0 2>/dev/null); then
         export PATH=$HOME/.cnf-testsuite:$PATH
-        echo "cnf-testsuite has been successfully installed to: ~/.cnf-testsuite and added to your PATH"
+        echo "cnf-testsuite has been successfully installed to ~/.cnf-testsuite and added to your PATH"
     else
         echo "cnf-testsuite has been successfully installed to: ~/.cnf-testsuite"
-        echo "To use the cnf-testsuite please restart you terminal session to load the new 'path'"
+        echo "To use the cnf-testsuite please restart you terminal session to load the new PATH"
         echo "Or you can manually run 'export PATH=\$HOME/.cnf-testsuite:\$PATH' in your current session"
     fi
 else
-    echo "Because an unsupported shell was detected you will need to manually set you path, eg.:"
+    echo "Because an unsupported shell was detected you will need to manually set you PATH, eg.:"
     echo "'export PATH=\$HOME/.cnf-testsuite:\$PATH'"
 fi
 

--- a/spec/curl_install_spec.cr
+++ b/spec/curl_install_spec.cr
@@ -26,6 +26,6 @@ describe "CurlInstall" do
     response_s = `./curl_install.sh`
     LOGGING.info response_s
     $?.success?.should be_true
-    (/To use the cnf-testsuite please restart you terminal session to load the new 'path'/ =~ response_s).should_not be_nil
+    (/To use the cnf-testsuite please restart you terminal session to load the new PATH/ =~ response_s).should_not be_nil
   end
 end


### PR DESCRIPTION
## Description
This cleans up the curl binary messaging during install and suppresses messages not necessary during the curl download.

## Issues:
Refs: #745 

## How has this been tested:
 - [ ] Covered by existing integration testing
 - [ ] Added integration testing to cover
 - [x] Verified all A/C passes
     * [ ] develop
     * [ ] master
     * [x] tag/other branch `feature/#745_clean_up_binary_messaging`
 - [ ] Test environment
    * [ ] Shared Packet K8s cluster
    * [ ] New Packet K8s cluster
    * [ ] Kind cluster
 - [x] Have not tested

## Types of changes:
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [x] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [x] Documentation update

## Checklist:
**Documentation**
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] No updates required.

**Code Review**
- [ ] Does the test handle fatal exceptions, ie. rescue block

**Issue**
- [ ] Tasks in issue are checked off
