### PR TITLE
remove verbose option from tar

### DIFF
--- a/curl_install.sh
+++ b/curl_install.sh
@@ -30,7 +30,7 @@ get_latest_release() {
 LATEST_RELEASE=$(get_latest_release cncf/cnf-testsuite)
 mkdir -p ~/.cnf-testsuite
 curl --silent -L https://github.com/cncf/cnf-testsuite/releases/download/$LATEST_RELEASE/cnf-testsuite-$LATEST_RELEASE.tar.gz -o ~/.cnf-testsuite/cnf-testsuite.tar.gz
-tar -C ~/.cnf-testsuite -xvf ~/.cnf-testsuite/cnf-testsuite.tar.gz
+tar -C ~/.cnf-testsuite -xf ~/.cnf-testsuite/cnf-testsuite.tar.gz
 rm ~/.cnf-testsuite/cnf-testsuite.tar.gz
 
 if [ -z ${SHELL_UNSUPPORTED+x} ]; then


### PR DESCRIPTION
## Description
remove -v option so tar output is not shown

## Issues:
Refs: #745 

## How has this been tested:
 - [x] Covered by existing integration testing
 - [ ] Added integration testing to cover
 - [ ] Verified all A/C passes
     * [ ] develop
     * [ ] master
     * [ ] tag/other branch
 - [ ] Test environment
    * [ ] Shared Packet K8s cluster
    * [ ] New Packet K8s cluster
    * [ ] Kind cluster
 - [ ] Have not tested

## Types of changes:
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [ ] Documentation update

## Checklist:
**Documentation**
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] No updates required.

**Code Review**
- [ ] Does the test handle fatal exceptions, ie. rescue block

**Issue**
- [ ] Tasks in issue are checked off
