### PR TITLE
[Fix #761] Check if kubectl is within 3 minor versions of server

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -211,8 +211,8 @@ jobs:
   test_helm_chart_in_airgapped_env:
     name: Test helm chart In An Airgapped Env.
     needs: [build, debug_output, skip]
-    runs-on: [default]
-    #runs-on: ubuntu-latest
+    # runs-on: [default]
+    runs-on: ubuntu-latest
     if: needs.skip.outputs.skip == 'false'
     steps: 
     - name: Checkout code
@@ -248,8 +248,8 @@ jobs:
   test_helm_directory_in_airgapped_env:
     name: Test helm directory In An Airgapped Env.
     needs: [build, debug_output, skip]
-    runs-on: [default]
-    #runs-on: ubuntu-latest
+    # runs-on: [default]
+    runs-on: ubuntu-latest
     if: needs.skip.outputs.skip == 'false'
     steps: 
     - name: Checkout code
@@ -283,8 +283,8 @@ jobs:
   test_manifest_directory_in_airgapped_env:
     name: Test manifest directory In An Airgapped Env.
     needs: [build, debug_output, skip]
-    runs-on: [default]
-    #runs-on: ubuntu-latest
+    # runs-on: [default]
+    runs-on: ubuntu-latest
     if: needs.skip.outputs.skip == 'false'
     steps: 
     - name: Checkout code

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -211,8 +211,8 @@ jobs:
   test_helm_chart_in_airgapped_env:
     name: Test helm chart In An Airgapped Env.
     needs: [build, debug_output, skip]
-    # runs-on: [default]
-    runs-on: ubuntu-latest
+    runs-on: [default]
+    # runs-on: ubuntu-latest
     if: needs.skip.outputs.skip == 'false'
     steps: 
     - name: Checkout code
@@ -248,8 +248,8 @@ jobs:
   test_helm_directory_in_airgapped_env:
     name: Test helm directory In An Airgapped Env.
     needs: [build, debug_output, skip]
-    # runs-on: [default]
-    runs-on: ubuntu-latest
+    runs-on: [default]
+    # runs-on: ubuntu-latest
     if: needs.skip.outputs.skip == 'false'
     steps: 
     - name: Checkout code
@@ -283,8 +283,8 @@ jobs:
   test_manifest_directory_in_airgapped_env:
     name: Test manifest directory In An Airgapped Env.
     needs: [build, debug_output, skip]
-    # runs-on: [default]
-    runs-on: ubuntu-latest
+    runs-on: [default]
+    # runs-on: ubuntu-latest
     if: needs.skip.outputs.skip == 'false'
     steps: 
     - name: Checkout code

--- a/spec/prereqs_spec.cr
+++ b/spec/prereqs_spec.cr
@@ -14,7 +14,19 @@ describe "Prereq" do
     # (/wget found/ =~ response_s).should_not be_nil
     # (/curl found/ =~ response_s).should_not be_nil
     (/kubectl found/ =~ response_s).should_not be_nil
+    (/minor versions/ =~ response_s).should_not be_nil
     (/git found/ =~ response_s).should_not be_nil
   end
 
+  it "'prereq' with offline option should check the system for prerequisites except git", tags: ["points"]  do
+    response_s = `./cnf-testsuite prereqs verbose offline=1`
+    LOGGING.info response_s
+    $?.success?.should be_true
+    (/helm found/ =~ response_s).should_not be_nil
+    # (/wget found/ =~ response_s).should_not be_nil
+    # (/curl found/ =~ response_s).should_not be_nil
+    (/kubectl found/ =~ response_s).should_not be_nil
+    (/minor versions/ =~ response_s).should_not be_nil
+    (/git found/ =~ response_s).should be_nil
+  end
 end

--- a/spec/utils/system_information/kubectl_spec.cr
+++ b/spec/utils/system_information/kubectl_spec.cr
@@ -24,4 +24,22 @@ describe "Kubectl" do
   it "'kubectl_installations()' should return the information about the kubectl installation", tags: ["kubectl-utils"]  do
     (kubectl_installation(true)).should contain("kubectl found")
   end
+
+  it "'acceptable_kubectl_version?()' should return true if client is within 3 minor versions of server version'" do
+    kubectl_response = <<-KUBECTL_OUTPUT
+      Client Version: version.Info{Major:"1", Minor:"18", GitVersion:"v1.21.0", GitCommit:"cb303e613a121a29364f75cc67d3d580833a7479", GitTreeState:"clean", BuildDate:"2021-04-08T16:31:21Z", GoVersion:"go1.16.1", Compiler:"gc", Platform:"linux/amd64"}
+      Server Version: version.Info{Major:"1", Minor:"20", GitVersion:"v1.20.2", GitCommit:"faecb196815e248d3ecfb03c680a4507229c2a56", GitTreeState:"clean", BuildDate:"2021-01-21T01:11:42Z", GoVersion:"go1.15.5", Compiler:"gc", Platform:"linux/amd64"}
+    KUBECTL_OUTPUT
+
+    acceptable_kubectl_version?(kubectl_response).should eq(true)
+  end
+
+  it "'acceptable_kubectl_version?()' should return false if client is not within 3 minor versions of server version'" do
+    kubectl_response = <<-KUBECTL_OUTPUT
+      Client Version: version.Info{Major:"1", Minor:"16", GitVersion:"v1.21.0", GitCommit:"cb303e613a121a29364f75cc67d3d580833a7479", GitTreeState:"clean", BuildDate:"2021-04-08T16:31:21Z", GoVersion:"go1.16.1", Compiler:"gc", Platform:"linux/amd64"}
+      Server Version: version.Info{Major:"1", Minor:"20", GitVersion:"v1.20.2", GitCommit:"faecb196815e248d3ecfb03c680a4507229c2a56", GitTreeState:"clean", BuildDate:"2021-01-21T01:11:42Z", GoVersion:"go1.15.5", Compiler:"gc", Platform:"linux/amd64"}
+    KUBECTL_OUTPUT
+
+    acceptable_kubectl_version?(kubectl_response).should eq(false)
+  end
 end

--- a/spec/utils/system_information/kubectl_spec.cr
+++ b/spec/utils/system_information/kubectl_spec.cr
@@ -25,7 +25,7 @@ describe "Kubectl" do
     (kubectl_installation(true)).should contain("kubectl found")
   end
 
-  it "'acceptable_kubectl_version?()' should return true if client is within 3 minor versions of server version'" do
+  it "'acceptable_kubectl_version?()' should return true if client is within 3 minor versions of server version'", tags: ["kubectl-utils"] do
     kubectl_response = <<-KUBECTL_OUTPUT
       Client Version: version.Info{Major:"1", Minor:"18", GitVersion:"v1.21.0", GitCommit:"cb303e613a121a29364f75cc67d3d580833a7479", GitTreeState:"clean", BuildDate:"2021-04-08T16:31:21Z", GoVersion:"go1.16.1", Compiler:"gc", Platform:"linux/amd64"}
       Server Version: version.Info{Major:"1", Minor:"20", GitVersion:"v1.20.2", GitCommit:"faecb196815e248d3ecfb03c680a4507229c2a56", GitTreeState:"clean", BuildDate:"2021-01-21T01:11:42Z", GoVersion:"go1.15.5", Compiler:"gc", Platform:"linux/amd64"}
@@ -34,7 +34,7 @@ describe "Kubectl" do
     acceptable_kubectl_version?(kubectl_response).should eq(true)
   end
 
-  it "'acceptable_kubectl_version?()' should return false if client is not within 3 minor versions of server version'" do
+  it "'acceptable_kubectl_version?()' should return false if client is not within 3 minor versions of server version'", tags: ["kubectl-utils"] do
     kubectl_response = <<-KUBECTL_OUTPUT
       Client Version: version.Info{Major:"1", Minor:"16", GitVersion:"v1.21.0", GitCommit:"cb303e613a121a29364f75cc67d3d580833a7479", GitTreeState:"clean", BuildDate:"2021-04-08T16:31:21Z", GoVersion:"go1.16.1", Compiler:"gc", Platform:"linux/amd64"}
       Server Version: version.Info{Major:"1", Minor:"20", GitVersion:"v1.20.2", GitCommit:"faecb196815e248d3ecfb03c680a4507229c2a56", GitTreeState:"clean", BuildDate:"2021-01-21T01:11:42Z", GoVersion:"go1.15.5", Compiler:"gc", Platform:"linux/amd64"}

--- a/spec/utils/system_information/kubectl_spec.cr
+++ b/spec/utils/system_information/kubectl_spec.cr
@@ -26,7 +26,6 @@ describe "Kubectl" do
   end
 
   it "'acceptable_kubectl_version?()' should return true if client is within 3 minor versions of server version'", tags: ["kubectl-utils"] do
-    AirGap.bootstrap_cluster()
     kubectl_response = <<-KUBECTL_OUTPUT
       Client Version: version.Info{Major:"1", Minor:"18", GitVersion:"v1.21.0", GitCommit:"cb303e613a121a29364f75cc67d3d580833a7479", GitTreeState:"clean", BuildDate:"2021-04-08T16:31:21Z", GoVersion:"go1.16.1", Compiler:"gc", Platform:"linux/amd64"}
       Server Version: version.Info{Major:"1", Minor:"20", GitVersion:"v1.20.2", GitCommit:"faecb196815e248d3ecfb03c680a4507229c2a56", GitTreeState:"clean", BuildDate:"2021-01-21T01:11:42Z", GoVersion:"go1.15.5", Compiler:"gc", Platform:"linux/amd64"}
@@ -36,7 +35,6 @@ describe "Kubectl" do
   end
 
   it "'acceptable_kubectl_version?()' should return false if client is not within 3 minor versions of server version'", tags: ["kubectl-utils"] do
-    AirGap.bootstrap_cluster()
     kubectl_response = <<-KUBECTL_OUTPUT
       Client Version: version.Info{Major:"1", Minor:"16", GitVersion:"v1.21.0", GitCommit:"cb303e613a121a29364f75cc67d3d580833a7479", GitTreeState:"clean", BuildDate:"2021-04-08T16:31:21Z", GoVersion:"go1.16.1", Compiler:"gc", Platform:"linux/amd64"}
       Server Version: version.Info{Major:"1", Minor:"20", GitVersion:"v1.20.2", GitCommit:"faecb196815e248d3ecfb03c680a4507229c2a56", GitTreeState:"clean", BuildDate:"2021-01-21T01:11:42Z", GoVersion:"go1.15.5", Compiler:"gc", Platform:"linux/amd64"}

--- a/spec/utils/system_information/kubectl_spec.cr
+++ b/spec/utils/system_information/kubectl_spec.cr
@@ -26,6 +26,7 @@ describe "Kubectl" do
   end
 
   it "'acceptable_kubectl_version?()' should return true if client is within 3 minor versions of server version'", tags: ["kubectl-utils"] do
+    AirGap.bootstrap_cluster()
     kubectl_response = <<-KUBECTL_OUTPUT
       Client Version: version.Info{Major:"1", Minor:"18", GitVersion:"v1.21.0", GitCommit:"cb303e613a121a29364f75cc67d3d580833a7479", GitTreeState:"clean", BuildDate:"2021-04-08T16:31:21Z", GoVersion:"go1.16.1", Compiler:"gc", Platform:"linux/amd64"}
       Server Version: version.Info{Major:"1", Minor:"20", GitVersion:"v1.20.2", GitCommit:"faecb196815e248d3ecfb03c680a4507229c2a56", GitTreeState:"clean", BuildDate:"2021-01-21T01:11:42Z", GoVersion:"go1.15.5", Compiler:"gc", Platform:"linux/amd64"}
@@ -35,6 +36,7 @@ describe "Kubectl" do
   end
 
   it "'acceptable_kubectl_version?()' should return false if client is not within 3 minor versions of server version'", tags: ["kubectl-utils"] do
+    AirGap.bootstrap_cluster()
     kubectl_response = <<-KUBECTL_OUTPUT
       Client Version: version.Info{Major:"1", Minor:"16", GitVersion:"v1.21.0", GitCommit:"cb303e613a121a29364f75cc67d3d580833a7479", GitTreeState:"clean", BuildDate:"2021-04-08T16:31:21Z", GoVersion:"go1.16.1", Compiler:"gc", Platform:"linux/amd64"}
       Server Version: version.Info{Major:"1", Minor:"20", GitVersion:"v1.20.2", GitCommit:"faecb196815e248d3ecfb03c680a4507229c2a56", GitTreeState:"clean", BuildDate:"2021-01-21T01:11:42Z", GoVersion:"go1.15.5", Compiler:"gc", Platform:"linux/amd64"}

--- a/src/tasks/prereqs.cr
+++ b/src/tasks/prereqs.cr
@@ -17,13 +17,9 @@ task "prereqs" do  |_, args|
   # Should be true if kubectl is found
   kubectl_existance = kubectl_checks_output.includes?("kubectl found")
 
-  # Should be true if kubectl version is not more then 3 versions behind
-  kubectl_version_validation = kubectl_checks_output.includes?("kubectl client is not more than 3 minor versions behind")
-
   checks = [
     helm_condition,
-    kubectl_existance,
-    kubectl_version_validation
+    kubectl_existance
   ]
 
   # git installation is optional for offline mode

--- a/src/tasks/prereqs.cr
+++ b/src/tasks/prereqs.cr
@@ -11,31 +11,30 @@ require "./utils/system_information/clusterctl.cr"
 
 task "prereqs" do  |_, args|
   verbose = check_verbose(args)
-  if args.named["offline"]?
+  helm_condition = helm_installation(verbose).includes?("helm found") && !Helm.helm_gives_k8s_warning?(true)
+  kubectl_checks_output = kubectl_installation(verbose)
 
-    if (helm_installation.includes?("helm found") &&
-        !Helm.helm_gives_k8s_warning?(true)) &
-      kubectl_installation.includes?("kubectl found")
+  # Should be true if kubectl is found
+  kubectl_existance = kubectl_checks_output.includes?("kubectl found")
 
-      verbose = check_verbose(args)
+  # Should be true if kubectl version is not more then 3 versions behind
+  kubectl_version_validation = kubectl_checks_output.includes?("kubectl client is not more than 3 minor versions behind")
 
-      stdout_success "All prerequisites found."
-    else
-      stdout_failure "Setup failed. Some prerequisites are missing. Please install all of the prerequisites before continuing."
-      exit 1
-    end
+  checks = [
+    helm_condition,
+    kubectl_existance,
+    kubectl_version_validation
+  ]
 
+  # git installation is optional for offline mode
+  if !args.named["offline"]?
+    checks << git_installation.includes?("git found")
+  end
+
+  if checks.includes?(false)
+    stdout_failure "Setup failed. Some prerequisites are missing. Please install all of the prerequisites before continuing."
+    exit 1
   else
-    if (helm_installation.includes?("helm found") &&
-        !Helm.helm_gives_k8s_warning?(true)) &
-      kubectl_installation.includes?("kubectl found") &
-      git_installation.includes?("git found")
-
-      verbose = check_verbose(args)
-      stdout_success "All prerequisites found."
-    else
-      stdout_failure "Setup failed. Some prerequisites are missing. Please install all of the prerequisites before continuing."
-      exit 1
-    end
+    stdout_success "All prerequisites found."
   end
 end


### PR DESCRIPTION
## Description
Checks that the kubectl client is not lagging behind the server by more than 3 minor versions.

**Output after changes**

```
$ ./cnf-testsuite prereqs verbose
No Global helm version found
Local helm found. Version: v3.1.1
Global kubectl found. Version: 1.21
Global kubectl client is not more than 3 minor versions behind server version
No Local kubectl version found
Global git found. Version: 2.17.1
No Local git version found
All prerequisites found.

$ ./cnf-testsuite prereqs verbose offline=1
No Global helm version found
Local helm found. Version: v3.1.1
Global kubectl found. Version: 1.21
Global kubectl client is not more than 3 minor versions behind server version
No Local kubectl version found
All prerequisites found.
```

### Changes

* Add acceptable_kubectl_version?() to compare server and client versions
* Test for acceptable kubectl version in kubectl_installation
* Add test cases for acceptable_kubectl_version?()

### Changes in src/tasks/prereqs.cr

* Add the version check to prereqs task
* Update relevant test for prereqs task to ensure version check
* Unify checks/conditions into a list - this helps simplify the different offline/online conditional blocks
* Add a test for prereqs with offline mode to ensure offline option is intact after the above change
* Remove duplicate verbosity checks

## Issues:
Refs: #761 

## How has this been tested:
 - [x] Covered by existing integration testing
 - [x] Added integration testing to cover
 - [ ] Verified all A/C passes
     * [ ] develop
     * [ ] master
     * [ ] tag/other branch
 - [ ] Test environment
    * [ ] Shared Packet K8s cluster
    * [ ] New Packet K8s cluster
    * [ ] Kind cluster
 - [ ] Have not tested

## Types of changes:
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [x] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [ ] Documentation update

## Checklist:
**Documentation**
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] No updates required.

**Code Review**
- [ ] Does the test handle fatal exceptions, ie. rescue block

**Issue**
- [x] Tasks in issue are checked off
