### PR TITLE
cnf_setup manifest should populate the exported_chart directory and export a temp_template file

### DIFF
--- a/spec/setup_spec.cr
+++ b/spec/setup_spec.cr
@@ -172,6 +172,7 @@ describe "Setup" do
       LOGGING.info response_s
       $?.success?.should be_true
       (/Successfully setup nginx-webapp/ =~ response_s).should_not be_nil
+      (/exported_chart\" not found/ =~ response_s).should be_nil
     ensure
       `rm ./tmp/airgapped.tar.gz` if File.exists?("./tmp/airgapped.tar.gz")
       AirGap.tmp_cleanup

--- a/src/tasks/cnf_setup.cr
+++ b/src/tasks/cnf_setup.cr
@@ -47,6 +47,7 @@ task "cnf_cleanup" do |_, args|
   else
     force = false
   end
+  # todo make cnf_cleanup deduce if the installation was a manifest installation
   if args.named["installed-from-manifest"]? && args.named["installed-from-manifest"] == "true"
     installed_from_manifest = true
   else

--- a/src/tasks/utils/airgap.cr
+++ b/src/tasks/utils/airgap.cr
@@ -379,6 +379,7 @@ end
     LOGGING.info "cleaning up /tmp directories, binaries, and tar files"
     `rm -rf /tmp/repositories`
     `rm -rf /tmp/images`
+    `rm -rf /tmp/bootstrap_images`
     `rm -rf /tmp/download`
     `rm -rf /tmp/manifests`
     `rm -rf /tmp/bin`

--- a/src/tasks/utils/cnf_manager.cr
+++ b/src/tasks/utils/cnf_manager.cr
@@ -75,13 +75,19 @@ module CNFManager
     manifest_file_path = config.cnf_config[:manifest_file_path]
     test_passed = true
 
-    if release_name.empty? # no helm chart
-      template_ymls = Helm::Manifest.manifest_ymls_from_file_list(Helm::Manifest.manifest_file_list( destination_cnf_dir + "/" + manifest_directory))
-    else
+    install_method = self.cnf_installation_method(config)
+    LOGGING.debug "install_method: #{install_method}"
+    template_ymls = [] of YAML::Any
+    case install_method[0]
+    when :helm_chart, :helm_directory
       Helm.generate_manifest_from_templates(release_name,
                                             helm_chart_path,
                                             manifest_file_path)
       template_ymls = Helm::Manifest.parse_manifest_as_ymls(manifest_file_path)
+    when :manifest_directory
+    # if release_name.empty? # no helm chart
+      template_ymls = Helm::Manifest.manifest_ymls_from_file_list(Helm::Manifest.manifest_file_list( destination_cnf_dir + "/" + manifest_directory))
+    # else
     end
     resource_ymls = Helm.all_workload_resources(template_ymls)
 		resource_resp = resource_ymls.map do | resource |
@@ -289,8 +295,16 @@ module CNFManager
     end
   end
 
+  def self.cnf_installation_method(config : CNFManager::Config)
+    LOGGING.info "cnf_installation_method config : CNFManager::Config"
+    LOGGING.info "config_cnf_config: #{config.cnf_config}"
+    yml_file_path = config.cnf_config[:source_cnf_file]
+    parsed_config_file = CNFManager.parsed_config_file(yml_file_path)
+    cnf_installation_method(parsed_config_file)
+  end
+
   #Determine, for cnf, whether a helm chart, helm directory, or manifest directory is being used for installation
-  def self.cnf_installation_method(config)
+  def self.cnf_installation_method(config : Totem::Config)
     LOGGING.info "cnf_installation_method"
     LOGGING.info "cnf_installation_method config: #{config}"
     LOGGING.info "cnf_installation_method config: #{config.config_paths[0]}/#{config.config_name}.#{config.config_type}"
@@ -539,8 +553,8 @@ module CNFManager
       source_directory = ""
       FileUtils.mkdir_p(Path[destination_cnf_dir].expand.to_s + "/exported_chart")
     end
-    ls_al = `ls -alR #{destination_cnf_dir}`
-    LOGGING.info "ls -alR #{destination_cnf_dir}: #{ls_al}"
+    LOGGING.info "ls -alR #{destination_cnf_dir}:"
+    LOGGING.info = `ls -alR #{destination_cnf_dir}`
 
     LOGGING.info("cp -a #{ensure_cnf_testsuite_yml_path(config_file)} #{destination_cnf_dir}")
     yml_cp = `cp -a #{ensure_cnf_testsuite_yml_path(config_file)} #{destination_cnf_dir}`
@@ -584,12 +598,12 @@ module CNFManager
     TarClient.untar(tgz_name,  "#{destination_cnf_dir}/exported_chart")
 
     VERBOSE_LOGGING.info "mv #{destination_cnf_dir}/exported_chart/#{Helm.chart_name(helm_chart)}/* #{destination_cnf_dir}/exported_chart" if verbose
-    ls_al = `ls -alR #{destination_cnf_dir}`
-    LOGGING.info "ls -alR (before move) destination_cnf_dir: #{ls_al}"
+    LOGGING.info "ls -alR (before move) destination_cnf_dir:"
+    LOGGING.info  `ls -alR #{destination_cnf_dir}`
     move_chart = `mv #{destination_cnf_dir}/exported_chart/#{Helm.chart_name(helm_chart)}/* #{destination_cnf_dir}/exported_chart`
 
-    ls_al = `ls -alR #{destination_cnf_dir}`
-    LOGGING.info "ls -alR (after move) destination_cnf_dir: #{ls_al}"
+    LOGGING.info "ls -alR (after move) destination_cnf_dir:"
+    LOGGING.info `ls -alR #{destination_cnf_dir}`
 
   end
 
@@ -758,12 +772,14 @@ end
     LOGGING.info "sample_cleanup"
     LOGGING.info "sample_cleanup installed_from_manifest: #{installed_from_manifest}"
     destination_cnf_dir = CNFManager.cnf_destination_dir(config_file)
+    LOGGING.info "destination_cnf_dir: #{destination_cnf_dir}"
     config = parsed_config_file(ensure_cnf_testsuite_yml_path(config_file))
 
     VERBOSE_LOGGING.info "cleanup config: #{config.inspect}" if verbose
     KubectlClient::Delete.file("#{destination_cnf_dir}/configmap_test.yml")
     release_name = "#{config.get("release_name").as_s?}"
     manifest_directory = destination_cnf_dir + "/" + "#{config["manifest_directory"]? && config["manifest_directory"].as_s?}"
+    LOGGING.info "manifest_directory: #{manifest_directory}"
 
     LOGGING.info "helm path: #{CNFSingleton.helm}"
     helm = CNFSingleton.helm

--- a/src/tasks/utils/generate_config.cr
+++ b/src/tasks/utils/generate_config.cr
@@ -20,7 +20,9 @@ module CNFManager
                                                generate_tar_mode: generate_tar_mode)
       config = CNFManager.parsed_config_file(output_file)
       release_name = optional_key_as_string(config, "release_name")
-      if CNFManager.install_method_by_config_src(config_src) == :manifest_directory
+      install_method = CNFManager.install_method_by_config_src(config_src)
+      LOGGING.info "install_method: #{install_method}"
+      if install_method == :manifest_directory
         template_ymls = Helm::Manifest.manifest_ymls_from_file_list(Helm::Manifest.manifest_file_list( config_src))
       else
         # todo if success false, raise error

--- a/src/tasks/utils/kubectl_client.cr
+++ b/src/tasks/utils/kubectl_client.cr
@@ -190,7 +190,7 @@ module KubectlClient
     def self.pods(all_namespaces=true) : K8sManifest 
       option = all_namespaces ? "--all-namespaces" : ""
       resp = `kubectl get pods #{option} -o json`
-      LOGGING.debug "kubectl get pods: #{resp}"
+      # LOGGING.debug "kubectl get pods: #{resp}"
       JSON.parse(resp)
     end
   # def self.cnf_workload_resources(args, config, &block)
@@ -484,7 +484,7 @@ module KubectlClient
           desired_replicas = `kubectl get #{kind} --namespace=#{namespace} #{resource_name} -o=jsonpath='{.status.replicas}'`
         end
         LOGGING.debug "desired_replicas: #{desired_replicas}"
-        LOGGING.debug "pod_read: #{pod_ready}"
+        LOGGING.debug "pod_ready: #{pod_ready}"
         LOGGING.info(all_kind)
         second_count = second_count + 1
       end
@@ -669,6 +669,9 @@ module KubectlClient
       status = "#{pod_name_prefix},NotFound,false"
       if pod != "not found"
         status = `kubectl get pods #{pod} -o jsonpath='{.metadata.name},{.status.phase},{.status.containerStatuses[*].ready}'`
+        LOGGING.debug "pod_status status before parse: #{status}"
+        status = status.gsub(" ", ",") # handle mutiple containers
+        LOGGING.debug "pod_status status after parse: #{status}"
       else
         LOGGING.info "pod: #{pod_name_prefix} is NOT found"
       end


### PR DESCRIPTION
## Description
cnf_setup manifest should populate the exported_chart directory and export a temp_template file
## Issues:
Refs: #827

## How has this been tested:
 - [ ] Covered by existing integration testing
 - [x] Added integration testing to cover
 - [ ] Verified all A/C passes
     * [ ] develop
     * [ ] master
     * [ ] tag/other branch
 - [ ] Test environment
    * [ ] Shared Packet K8s cluster
    * [ ] New Packet K8s cluster
    * [ ] Kind cluster
 - [ ] Have not tested

## Types of changes:
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [ ] Documentation update

## Checklist:
**Documentation**
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] No updates required.

**Code Review**
- [ ] Does the test handle fatal exceptions, ie. rescue block

**Issue**
- [ ] Tasks in issue are checked off
