### PR TITLE
Rename statelessness to state to fix #744 and #264

### DIFF
--- a/.github/ISSUE_TEMPLATE/new-platform-test.md
+++ b/.github/ISSUE_TEMPLATE/new-platform-test.md
@@ -16,7 +16,7 @@ assignees: ""
 
 **Test Category**
 
-- ADD CATEGORY_NAME (e.g. Statelessness, Security, etc from [README](https://github.com/cncf/cnf-testsuite/blob/main/README.md#cnf-testsuite))
+- ADD CATEGORY_NAME (e.g. State, Security, etc from [README](https://github.com/cncf/cnf-testsuite/blob/main/README.md#cnf-testsuite))
 
 **Proof of Concept** (if available)
 

--- a/.github/ISSUE_TEMPLATE/new-workload-test.md
+++ b/.github/ISSUE_TEMPLATE/new-workload-test.md
@@ -16,7 +16,7 @@ assignees: ""
 
 **Test Category**
 
-- ADD CATEGORY_NAME (e.g. Statelessness, Security, etc from [README](https://github.com/cncf/cnf-testsuite/blob/main/README.md#cnf-testsuite))
+- ADD CATEGORY_NAME (e.g. State, Security, etc from [README](https://github.com/cncf/cnf-testsuite/blob/main/README.md#cnf-testsuite))
 
 **Type of test (static or runtime)**
 

--- a/PSEUDO-CODE.md
+++ b/PSEUDO-CODE.md
@@ -21,7 +21,7 @@ kind create cluster --name kind-$USER --config kind-cluster-config.yaml
 kubectl apply -f https://raw.githubusercontent.com/cncf/apisnoop/master/deployment/k8s/raiinbow.yaml
 ```
 
-## Statelessness Tests
+## State Tests
 
 ####  To test if the CNF responds properly [when being restarted](//https://github.com/litmuschaos/litmus)
 ```

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Check out the [usage documentation](USAGE.md) for more info about invoking comma
 The CNF Test Suite will inspect CNFs for the following characteristics:
 
 - **Compatibility** - CNFs should work with any Certified Kubernetes product and any CNI-compatible network that meet their functionality requirements.
-- **Statelessness** - The CNF's state should be stored in a custom resource definition or a separate database (e.g. etcd) rather than requiring local storage. The CNF should also be resilient to node failure.
+- **State** - The CNF's state should be stored in a custom resource definition or a separate database (e.g. etcd) rather than requiring local storage. The CNF should also be resilient to node failure.
 - **Security** - CNF containers should be isolated from one another and the host.
 - **Microservice** - The CNF should be developed and delivered as a microservice.
 - **Scalability** - CNFs should support horizontal scaling (across multiple machines) and vertical scaling (between sizes of machines).

--- a/TEST-CATEGORIES.md
+++ b/TEST-CATEGORIES.md
@@ -18,7 +18,7 @@ The CNF Test Suite program validates interoperability of CNF **workloads** suppl
   - Checks beta endpoint usage
   - Checks generally available (GA) endpoint usage
 
-## Statelessness Tests
+## State Tests
 
 #### The CNF test suite checks if state is stored in a [custom resource definition](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/) or a separate database (e.g. [etcd](https://github.com/etcd-io/etcd)) rather than requiring local storage. It also checks to see if state is resilient to node failure:
 

--- a/USAGE.md
+++ b/USAGE.md
@@ -7,7 +7,7 @@
 - [Common Examples](USAGE.md#common-example-commands)
 - [Logging Options](USAGE.md#logging-options)
 - [Compatibility Tests](USAGE.md#compatibility-tests)
-- [Statelessness Tests](USAGE.md#statelessness-tests)
+- [State Tests](USAGE.md#state-tests)
 - [Security Tests](USAGE.md#security-tests)
 - [Microservice Tests](USAGE.md#microservice-tests)
 - [Scalability Tests](USAGE.md#scalability-tests)
@@ -196,12 +196,12 @@ crystal src/cnf-testsuite.cr api_snoop_general_apis
 
 ---
 
-### Statelessness Tests
+### State Tests
 
-#### :heavy_check_mark: To run all of the statelessness tests
+#### :heavy_check_mark: To run all of the state tests
 
 ```
-./cnf-testsuite stateless
+./cnf-testsuite state
 ```
 
 #### :heavy_check_mark: To test if the CNF uses a volume host path
@@ -216,7 +216,7 @@ crystal src/cnf-testsuite.cr api_snoop_general_apis
 ./cnf-testsuite no_local_volume_configuration
 ```
 
-<details> <summary>Details for Statelessness Tests To Do's</summary>
+<details> <summary>Details for State Tests To Do's</summary>
 <p>
 
 #### :memo: (To Do) To test if the CNF responds properly [when being restarted](//https://github.com/litmuschaos/litmus)

--- a/embedded_files/points.yml
+++ b/embedded_files/points.yml
@@ -21,9 +21,9 @@
 #  tags: compatibility, dynamic
 
 #- name: reset_cnf 
-#  tags: statelessness, dynamic, configuration_lifecycle
+#  tags: state, dynamic, configuration_lifecycle
 #- name: check_reaped 
-#  tags: statelessness, dynamic, configuration_lifecycle
+#  tags: state, dynamic, configuration_lifecycle
 
 - name: privileged 
   tags: security, dynamic, workload
@@ -115,9 +115,9 @@
   tags: resilience, dynamic, workload
 
 - name: volume_hostpath_not_found
-  tags: statelessness, dynamic, workload
+  tags: state, dynamic, workload
 - name: no_local_volume_configuration 
-  tags: statelessness, dynamic, workload
+  tags: state, dynamic, workload
 #- name: hardware_and_scheduling
 #  tags: hardware, dynamic, workload
 #- name: static_accessing_hardware 

--- a/points-all.yml
+++ b/points-all.yml
@@ -20,11 +20,11 @@
   tags: compatibility, dynamic
 
 - name: reset_cnf 
-  tags: statelessness, dynamic, configuration_lifecycle
+  tags: state, dynamic, configuration_lifecycle
 - name: check_reaped 
-  tags: statelessness, dynamic, configuration_lifecycle
+  tags: state, dynamic, configuration_lifecycle
 - name: volume_hostpath_not_found
-  tags: statelessness, dynamic
+  tags: state, dynamic
 
 - name: privileged 
   tags: security, dynamic

--- a/spec/cnf_testsuite_all/cnf_testsuite_container_chaos_spec.cr
+++ b/spec/cnf_testsuite_all/cnf_testsuite_container_chaos_spec.cr
@@ -13,9 +13,9 @@ describe "CNF Test Suite all Container Chaos" do
   #   $?.success?.should be_true
   # end
 
-  # it "'all ~platform ~compatibilty ~statelessness ~security ~scalability ~configuration_lifecycle ~observability ~installability ~hardware_and_scheduling ~microservice ~chaos_network_loss' should run the chaos tests" do
+  # it "'all ~platform ~compatibilty ~state ~security ~scalability ~configuration_lifecycle ~observability ~installability ~hardware_and_scheduling ~microservice ~chaos_network_loss' should run the chaos tests" do
   #   `./cnf-testsuite samples_cleanup`
-  #   response_s = `./cnf-testsuite all ~platform ~compatibilty ~statelessness ~security ~scalability ~configuration_lifecycle ~observability ~installability ~hardware_and_scheduling ~microservice ~chaos_network_loss cnf-config=./sample-cnfs/k8s-multiple-deployments/cnf-testsuite.yml deploy_with_chart=false verbose`
+  #   response_s = `./cnf-testsuite all ~platform ~compatibilty ~state ~security ~scalability ~configuration_lifecycle ~observability ~installability ~hardware_and_scheduling ~microservice ~chaos_network_loss cnf-config=./sample-cnfs/k8s-multiple-deployments/cnf-testsuite.yml deploy_with_chart=false verbose`
   #   LOGGING.info response_s
   #   (/Final workload score:/ =~ response_s).should_not be_nil
   #   (/Final score:/ =~ response_s).should_not be_nil

--- a/spec/cnf_testsuite_all/cnf_testsuite_network_chaos_spec.cr
+++ b/spec/cnf_testsuite_all/cnf_testsuite_network_chaos_spec.cr
@@ -16,8 +16,8 @@ describe "CNF Test Suite all Network Chaos" do
   # it "'all' should run the whole test suite" do
     # `./cnf-testsuite samples_cleanup`
 
-    # response_s = `./cnf-testsuite all ~platform ~compatibilty ~statelessness ~security ~scalability ~configuration_lifecycle ~observability ~installability ~hardware_and_scheduling ~microservice ~chaos_cpu_hog ~chaos_container_kill cnf-config=./sample-cnfs/k8s-multiple-deployments/cnf-testsuite.yml deploy_with_chart=false verbose`
-  #   response_s = `./cnf-testsuite all ~platform ~compatibilty ~statelessness ~security ~scalability ~configuration_lifecycle ~observability ~installability ~hardware_and_scheduling ~microservice ~chaos_network_loss ~chaos_cpu_hog ~chaos_container_kill cnf-config=./sample-cnfs/k8s-multiple-deployments/cnf-testsuite.yml deploy_with_chart=false verbose`
+  # response_s = `./cnf-testsuite all ~platform ~compatibilty ~state ~security ~scalability ~configuration_lifecycle ~observability ~installability ~hardware_and_scheduling ~microservice ~chaos_cpu_hog ~chaos_container_kill cnf-config=./sample-cnfs/k8s-multiple-deployments/cnf-testsuite.yml deploy_with_chart=false verbose`
+  #   response_s = `./cnf-testsuite all ~platform ~compatibilty ~state ~security ~scalability ~configuration_lifecycle ~observability ~installability ~hardware_and_scheduling ~microservice ~chaos_network_loss ~chaos_cpu_hog ~chaos_container_kill cnf-config=./sample-cnfs/k8s-multiple-deployments/cnf-testsuite.yml deploy_with_chart=false verbose`
   #   LOGGING.info response_s
   #   (/Final workload score:/ =~ response_s).should_not be_nil
   #   (/Final score:/ =~ response_s).should_not be_nil

--- a/spec/workload/statelessness_spec.cr
+++ b/spec/workload/statelessness_spec.cr
@@ -6,7 +6,7 @@ require "../../src/tasks/utils/system_information/helm.cr"
 require "file_utils"
 require "sam"
 
-describe "Statelessness" do
+describe "State" do
   before_all do
     `./cnf-testsuite configuration_file_setup`
   end

--- a/src/cnf-testsuite.cr
+++ b/src/cnf-testsuite.cr
@@ -24,7 +24,7 @@ task "all", ["workload", "platform"] do  |_, args|
 end
 
 desc "The CNF Test Suite program enables interoperability of CNFs from multiple vendors running on top of Kubernetes supplied by different vendors. The goal is to provide an open source test suite to enable both open and closed source CNFs to demonstrate conformance and implementation of best practices."
-task "workload", ["automatic_cnf_install", "ensure_cnf_installed", "configuration_file_setup", "compatibility","statelessness", "security", "scalability", "configuration_lifecycle", "observability", "installability", "hardware_and_scheduling", "microservice", "resilience"] do  |_, args|
+task "workload", ["automatic_cnf_install", "ensure_cnf_installed", "configuration_file_setup", "compatibility","state", "security", "scalability", "configuration_lifecycle", "observability", "installability", "hardware_and_scheduling", "microservice", "resilience"] do  |_, args|
   VERBOSE_LOGGING.info "workload" if check_verbose(args)
 
   total = CNFManager::Points.total_points("workload")

--- a/src/tasks/workload/statelessness.cr
+++ b/src/tasks/workload/statelessness.cr
@@ -7,8 +7,8 @@ require "../utils/utils.cr"
 require "../utils/kubectl_client.cr"
 
 desc "The CNF test suite checks if state is stored in a custom resource definition or a separate database (e.g. etcd) rather than requiring local storage.  It also checks to see if state is resilient to node failure"
-task "statelessness", ["volume_hostpath_not_found"] do |_, args|
-  stdout_score("statelessness")
+task "state", ["volume_hostpath_not_found"] do |_, args|
+  stdout_score("state")
 end
 
 desc "Does the CNF use a non-cloud native data store: hostPath volume"


### PR DESCRIPTION
## Description
* Renames "statelessness" to "state" in both code and docs
* Verified non-existence of statelessness across repo by grepping for statelessness `grep -nri "statelessness" .`
* Build is green (atleast the build for the branch I was pushing to)

## Issues:
Refs: #744 and #264 

## How has this been tested:
 - [x] Covered by existing integration testing
 - [ ] Added integration testing to cover
 - [ ] Verified all A/C passes
     * [ ] develop
     * [ ] master
     * [ ] tag/other branch
 - [ ] Test environment
    * [ ] Shared Packet K8s cluster
    * [ ] New Packet K8s cluster
    * [ ] Kind cluster
 - [ ] Have not tested

## Types of changes:
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [x] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [x] Documentation update

## Checklist:
**Documentation**
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] No updates required.

**Code Review**
- [ ] Does the test handle fatal exceptions, ie. rescue block
