### PR TITLE
Improvements to #761 to respect kubernetes version skew policy

### DIFF
--- a/spec/prereqs_spec.cr
+++ b/spec/prereqs_spec.cr
@@ -14,7 +14,6 @@ describe "Prereq" do
     # (/wget found/ =~ response_s).should_not be_nil
     # (/curl found/ =~ response_s).should_not be_nil
     (/kubectl found/ =~ response_s).should_not be_nil
-    (/minor versions/ =~ response_s).should_not be_nil
     (/git found/ =~ response_s).should_not be_nil
   end
 
@@ -26,7 +25,6 @@ describe "Prereq" do
     # (/wget found/ =~ response_s).should_not be_nil
     # (/curl found/ =~ response_s).should_not be_nil
     (/kubectl found/ =~ response_s).should_not be_nil
-    (/minor versions/ =~ response_s).should_not be_nil
     (/git found/ =~ response_s).should be_nil
   end
 end

--- a/spec/utils/system_information/kubectl_spec.cr
+++ b/spec/utils/system_information/kubectl_spec.cr
@@ -7,36 +7,49 @@ require "file_utils"
 require "sam"
 
 describe "Kubectl" do
-
-  it "'kubectl_global_response()' should return the information about the kubectl installation", tags: ["kubectl-utils"]  do
+  it "'kubectl_global_response()' should return the information about the kubectl installation", tags: ["kubectl-utils"] do
     (kubectl_global_response(true)).should contain("Client Version")
   end
 
-  it "'kubectl_local_response()' should return the information about the kubectl installation", tags: ["kubectl-utils"]  do
-    (kubectl_local_response(true)).should eq("") 
+  it "'kubectl_local_response()' should return the information about the kubectl installation", tags: ["kubectl-utils"] do
+    (kubectl_local_response(true)).should eq("")
   end
 
-  it "'kubectl_version()' should return the information about the kubectl version", tags: ["kubectl-utils"]  do
+  it "'kubectl_version()' should return the information about the kubectl version", tags: ["kubectl-utils"] do
     (kubectl_version(kubectl_global_response)).should match(/(([0-9]{1,3}[\.]){1,2}[0-9]{1,3}[+]?)/)
     (kubectl_version(kubectl_local_response)).should contain("")
   end
 
-  it "'kubectl_installations()' should return the information about the kubectl installation", tags: ["kubectl-utils"]  do
+  it "'kubectl_installations()' should return the information about the kubectl installation", tags: ["kubectl-utils"] do
     (kubectl_installation(true)).should contain("kubectl found")
   end
 
-  it "'acceptable_kubectl_version?()' should return true if client is within 3 minor versions of server version'", tags: ["kubectl-utils"] do
+  it "'acceptable_kubectl_version?()' should return true if client is within 1 minor version ahead/behind server version'", tags: ["kubectl-utils"] do
     kubectl_response = <<-KUBECTL_OUTPUT
-      Client Version: version.Info{Major:"1", Minor:"18", GitVersion:"v1.21.0", GitCommit:"cb303e613a121a29364f75cc67d3d580833a7479", GitTreeState:"clean", BuildDate:"2021-04-08T16:31:21Z", GoVersion:"go1.16.1", Compiler:"gc", Platform:"linux/amd64"}
+      Client Version: version.Info{Major:"1", Minor:"19", GitVersion:"v1.21.0", GitCommit:"cb303e613a121a29364f75cc67d3d580833a7479", GitTreeState:"clean", BuildDate:"2021-04-08T16:31:21Z", GoVersion:"go1.16.1", Compiler:"gc", Platform:"linux/amd64"}
+      Server Version: version.Info{Major:"1", Minor:"20", GitVersion:"v1.20.2", GitCommit:"faecb196815e248d3ecfb03c680a4507229c2a56", GitTreeState:"clean", BuildDate:"2021-01-21T01:11:42Z", GoVersion:"go1.15.5", Compiler:"gc", Platform:"linux/amd64"}
+    KUBECTL_OUTPUT
+
+    acceptable_kubectl_version?(kubectl_response).should eq(true)
+
+    kubectl_response = <<-KUBECTL_OUTPUT
+      Client Version: version.Info{Major:"1", Minor:"21", GitVersion:"v1.21.0", GitCommit:"cb303e613a121a29364f75cc67d3d580833a7479", GitTreeState:"clean", BuildDate:"2021-04-08T16:31:21Z", GoVersion:"go1.16.1", Compiler:"gc", Platform:"linux/amd64"}
       Server Version: version.Info{Major:"1", Minor:"20", GitVersion:"v1.20.2", GitCommit:"faecb196815e248d3ecfb03c680a4507229c2a56", GitTreeState:"clean", BuildDate:"2021-01-21T01:11:42Z", GoVersion:"go1.15.5", Compiler:"gc", Platform:"linux/amd64"}
     KUBECTL_OUTPUT
 
     acceptable_kubectl_version?(kubectl_response).should eq(true)
   end
 
-  it "'acceptable_kubectl_version?()' should return false if client is not within 3 minor versions of server version'", tags: ["kubectl-utils"] do
+  it "'acceptable_kubectl_version?()' should return false if client is more than 1 minor version ahead/behind server version'", tags: ["kubectl-utils"] do
     kubectl_response = <<-KUBECTL_OUTPUT
-      Client Version: version.Info{Major:"1", Minor:"16", GitVersion:"v1.21.0", GitCommit:"cb303e613a121a29364f75cc67d3d580833a7479", GitTreeState:"clean", BuildDate:"2021-04-08T16:31:21Z", GoVersion:"go1.16.1", Compiler:"gc", Platform:"linux/amd64"}
+      Client Version: version.Info{Major:"1", Minor:"22", GitVersion:"v1.21.0", GitCommit:"cb303e613a121a29364f75cc67d3d580833a7479", GitTreeState:"clean", BuildDate:"2021-04-08T16:31:21Z", GoVersion:"go1.16.1", Compiler:"gc", Platform:"linux/amd64"}
+      Server Version: version.Info{Major:"1", Minor:"20", GitVersion:"v1.20.2", GitCommit:"faecb196815e248d3ecfb03c680a4507229c2a56", GitTreeState:"clean", BuildDate:"2021-01-21T01:11:42Z", GoVersion:"go1.15.5", Compiler:"gc", Platform:"linux/amd64"}
+    KUBECTL_OUTPUT
+
+    acceptable_kubectl_version?(kubectl_response).should eq(false)
+
+    kubectl_response = <<-KUBECTL_OUTPUT
+      Client Version: version.Info{Major:"1", Minor:"18", GitVersion:"v1.21.0", GitCommit:"cb303e613a121a29364f75cc67d3d580833a7479", GitTreeState:"clean", BuildDate:"2021-04-08T16:31:21Z", GoVersion:"go1.16.1", Compiler:"gc", Platform:"linux/amd64"}
       Server Version: version.Info{Major:"1", Minor:"20", GitVersion:"v1.20.2", GitCommit:"faecb196815e248d3ecfb03c680a4507229c2a56", GitTreeState:"clean", BuildDate:"2021-01-21T01:11:42Z", GoVersion:"go1.15.5", Compiler:"gc", Platform:"linux/amd64"}
     KUBECTL_OUTPUT
 

--- a/src/tasks/prereqs.cr
+++ b/src/tasks/prereqs.cr
@@ -9,17 +9,20 @@ require "./utils/system_information/kubectl.cr"
 require "./utils/system_information/git.cr"
 require "./utils/system_information/clusterctl.cr"
 
-task "prereqs" do  |_, args|
+task "prereqs" do |_, args|
+  offline_mode = false
+  offline_mode = true if args.named["offline"]?
+
   verbose = check_verbose(args)
   helm_condition = helm_installation(verbose).includes?("helm found") && !Helm.helm_gives_k8s_warning?(true)
-  kubectl_checks_output = kubectl_installation(verbose)
+  kubectl_checks_output = kubectl_installation(verbose, offline_mode)
 
   # Should be true if kubectl is found
   kubectl_existance = kubectl_checks_output.includes?("kubectl found")
 
   checks = [
     helm_condition,
-    kubectl_existance
+    kubectl_existance,
   ]
 
   # git installation is optional for offline mode

--- a/src/tasks/utils/system_information/kubectl.cr
+++ b/src/tasks/utils/system_information/kubectl.cr
@@ -2,52 +2,47 @@ require "file_utils"
 require "colorize"
 require "totem"
 
-def kubectl_installation(verbose=false)
+def kubectl_installation(verbose = false, offline_mode = false)
   gmsg = "No Global kubectl version found"
   lmsg = "No Local kubectl version found"
   gkubectl = kubectl_global_response
   VERBOSE_LOGGING.info gkubectl if verbose
-  
+
   global_kubectl_version = kubectl_version(gkubectl, "client", verbose)
-   
+
   if !global_kubectl_version.empty?
     gmsg = "Global kubectl found. Version: #{global_kubectl_version}"
     stdout_success gmsg
 
     version_test = acceptable_kubectl_version?(gkubectl, verbose)
-    if version_test
-      version_msg = "Global kubectl client is not more than 3 minor versions behind server version"
-      stdout_success version_msg
-      gmsg = "#{gmsg} #{version_msg}"
-    elsif version_test.nil?
-      stdout_warning "Global kubectl client version could not be checked for compatibility with server. (Running in airgapped mode?)"
-    else
-      stdout_warning "Global kubectl client is more than 3 minor versions behind server version"
+    if version_test == false
+      stdout_warning "Global kubectl client is more than 1 minor version ahead/behind server version"
+    elsif version_test.nil? && offline_mode == false
+      stdout_warning "Global kubectl client version could not be checked for compatibility with server. (Server not configured?)"
+    elsif version_test.nil? && offline_mode == true
+      stdout_warning "Global kubectl client version could not be checked for compatibility with server. Running in offline mode"
     end
-
   else
     stdout_warning gmsg
   end
 
   lkubectl = kubectl_local_response
   VERBOSE_LOGGING.info lkubectl if verbose
-  
+
   local_kubectl_version = kubectl_version(lkubectl, "client", verbose)
-   
+
   if !local_kubectl_version.empty?
     lmsg = "Local kubectl found. Version: #{local_kubectl_version}"
     stdout_success lmsg
 
     version_test = acceptable_kubectl_version?(lkubectl, verbose)
-    if version_test
-      version_msg = "Local kubectl client is not more than 3 minor versions behind server version"
-      lmsg = "#{lmsg} #{version_msg}"
-    elsif version_test.nil?
-      stdout_warning "Local kubectl client version could not be checked for compatibility with server. (Running in airgapped mode?)"
-    else
-      stdout_warning "Local kubectl client is more than 3 minor versions behind server version"
+    if version_test == false
+      stdout_warning "Local kubectl client is more than 1 minor version ahead/behind server version"
+    elsif version_test.nil? && offline_mode == false
+      stdout_warning "Local kubectl client version could not be checked for compatibility with server. (Server not configured?)"
+    elsif version_test.nil? && offline_mode == true
+      stdout_warning "Local kubectl client version could not be checked for compatibility with server. Running in offline mode"
     end
-
   else
     stdout_warning lmsg
   end
@@ -60,7 +55,7 @@ def kubectl_installation(verbose=false)
   if global_kubectl_version.empty? && local_kubectl_version.empty?
     stdout_failure "Kubectl not found"
     stdout_failure %Q(
-    Linux installation instructions for Kubectl can be found here: https://kubernetes.io/docs/tasks/tools/install-kubectl/ 
+    Linux installation instructions for Kubectl can be found here: https://kubernetes.io/docs/tasks/tools/install-kubectl/
 
     Install kubectl binary with curl on Linux
     Download the latest release with the command:
@@ -83,7 +78,7 @@ def kubectl_installation(verbose=false)
     )
   end
   "#{lmsg} #{gmsg}"
-end 
+end
 
 def kubectl_global_response(verbose = false)
   status = Process.run("kubectl version", shell: true, output: kubectl_response = IO::Memory.new, error: stderr = IO::Memory.new)
@@ -91,9 +86,9 @@ def kubectl_global_response(verbose = false)
   kubectl_response.to_s
 end
 
-def kubectl_local_response(verbose=false)
-  current_dir = FileUtils.pwd 
-  VERBOSE_LOGGING.info current_dir if verbose 
+def kubectl_local_response(verbose = false)
+  current_dir = FileUtils.pwd
+  VERBOSE_LOGGING.info current_dir if verbose
   kubectl = "#{current_dir}/#{TOOLS_DIR}/kubectl/linux-amd64/kubectl"
   # kubectl_response = `#{kubectl} version`
   status = Process.run("#{kubectl} version", shell: true, output: kubectl_response = IO::Memory.new, error: stderr = IO::Memory.new)
@@ -121,7 +116,7 @@ end
 # TODO Function could be updated to rely on the JSON output of "kubectl version -o json" instead of regex parsing
 #
 # Returns the version as a string (Example: 1.12, 1.20, etc)
-def kubectl_version(kubectl_response, version_for="client", verbose=false)
+def kubectl_version(kubectl_response, version_for = "client", verbose = false)
   # version_for can be "client" or "server"
   resp = kubectl_response.match /#{version_for.capitalize} Version: version.Info{(Major:"(([0-9]{1,3})"\, )Minor:"([0-9]{1,3}[+]?)")/
   VERBOSE_LOGGING.info resp if verbose
@@ -149,6 +144,11 @@ def acceptable_kubectl_version?(kubectl_response, verbose = false)
   return false if server_version[0].to_i != client_version[0].to_i
 
   # This checks for minor versions
-  return false if (server_version[1].to_i - client_version[1].to_i) > 3
+  server_minor_version = server_version[1].to_i
+  client_minor_version = client_version[1].to_i
+
+  # https://kubernetes.io/releases/version-skew-policy/
+  # kubectl cannot be more than +/- 1 minor version away from the server
+  return false if client_minor_version < (server_minor_version - 1) || client_minor_version > (server_minor_version + 1)
   return true
 end


### PR DESCRIPTION
## Description
This PR is based on @agentpoyo's feedback on #761 for the earlier PR.

**Summary of changes:**
* Version check respects [Kubernetes version skew policy for kubectl](https://kubernetes.io/releases/version-skew-policy/)
* Warnings are only displayed incase the version check fails - so stdout doesn't get extra messages
* Adds explicitly check for missing server version and hint that the server config might be missing
* Adds explicit check for `offline` flag. Previously this was just a hint at air-gapped mode.

The test scenarios below directly use the `prereqs` task that is run when `setup` is invoked.

## Test scenarios

### Scenario: Client is more than 1 minor version behind server version

* kubectl v1.15 and server v1.17
* **Output**: Warns about version incompatibility.

![3FD9CAD4-A7B6-4234-A120-A32A9F17CB02](https://user-images.githubusercontent.com/84005/124753299-6d562900-df46-11eb-8350-16f93e54ecc5.png)

### Scenario: Client is 1 minor version behind server version

* kubectl v1.16 and server v1.17
* **Output**: No warning about version incompatibility.

![F2A553D5-1036-4D9C-A269-5124FBCE58CE](https://user-images.githubusercontent.com/84005/124753324-77782780-df46-11eb-8f36-f787f0cbf10d.png)

### Scenario: Same client and server versions

* kubectl v1.17 and server v1.17
* **Output**: No warning about version incompatibility.

![53576206-4AEA-4813-ACEE-04F79FF10FFA](https://user-images.githubusercontent.com/84005/124753363-84951680-df46-11eb-8d9e-bacfebbeb3c0.png)

### Scenario: Client is 1 minor version ahead of server version

* kubectl v1.18 and server v1.17
* **Output**: No warning about version incompatibility.

![796FA123-68E2-419D-B06E-BD988FCB451E](https://user-images.githubusercontent.com/84005/124753523-b4441e80-df46-11eb-921e-53ac6a66eb36.png)

### Scenario: Client is more than 1 minor version ahead of server version

* kubectl v1.19 and server v1.17
* **Output**: Warns about version incompatibility.

![BF220A3C-CB13-4486-83DE-92A4C5A23D81](https://user-images.githubusercontent.com/84005/124753670-e48bbd00-df46-11eb-93e5-1b6d6c8438fe.png)

### Scenario: Server version not available

* Using kubectl v1.19
* **Output**: Warns missing server version and hints about server not being configured.

![5F179F84-136F-4015-8BE8-EA52DF2EF94D](https://user-images.githubusercontent.com/84005/124753448-a2627b80-df46-11eb-86ec-c1ca10c6d7b9.png)

### Scenario: Offline mode and server version not available

* Using kubectl v1.19
* **Output**: Version check warning with hint about offline mode.

![D53CAD85-94F0-4407-A296-45DABD39D86B](https://user-images.githubusercontent.com/84005/124753959-3df3ec00-df47-11eb-86f2-0630752ec707.png)


### Scenario: Offline mode and server version available

* Using kubectl v1.19. Outputs an appropriate warning because the server version was available (1.17) and the version check was carried out.
* **Output**: Warns about version incompatibility.

![FA15C7CB-58D6-4E3F-9195-2287514A9DB2](https://user-images.githubusercontent.com/84005/124753965-40564600-df47-11eb-8693-89ab9b90f58d.png)

## Issues:
Refs: #761

## How has this been tested:
 - [x] Covered by existing integration testing
 - [x] Added integration testing to cover
 - [ ] Verified all A/C passes
     * [ ] develop
     * [ ] master
     * [ ] tag/other branch
 - [ ] Test environment
    * [ ] Shared Packet K8s cluster
    * [ ] New Packet K8s cluster
    * [ ] Kind cluster
 - [ ] Have not tested

## Types of changes:
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [ ] Documentation update

## Checklist:
**Documentation**
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] No updates required.

**Code Review**
- [ ] Does the test handle fatal exceptions, ie. rescue block

**Issue**
- [x] Tasks in issue are checked off
