### PR TITLE
[bug/634]: cnf_setup and cnf_cleanup should respect cnf-config option as an alias to cnf-path option

### DIFF
--- a/spec/setup_spec.cr
+++ b/spec/setup_spec.cr
@@ -79,14 +79,27 @@ describe "Setup" do
     `rm ./cnf-testsuite-test.yml`
   end
 
-  it "'cnf_setup/cnf_cleanup' should install/cleanup a cnf with a cnf-testsuite.yml", tags: ["setup"]  do
+  it "'cnf_setup/cnf_cleanup' should install/cleanup with cnf-path arg as alias for cnf-config", tags: ["setup"] do
+    begin
+      response_s = `./cnf-testsuite cnf_setup cnf-path=example-cnfs/coredns/cnf-testsuite.yml`
+      LOGGING.info response_s
+      $?.success?.should be_true
+      (/Successfully setup coredns/ =~ response_s).should_not be_nil
+    ensure
+      response_s = `./cnf-testsuite cnf_cleanup cnf-path=example-cnfs/coredns/cnf-testsuite.yml`
+      LOGGING.info response_s
+      $?.success?.should be_true
+      (/Successfully cleaned up/ =~ response_s).should_not be_nil
+    end
+  end
+
+  it "'cnf_setup/cnf_cleanup' should install/cleanup a cnf with a cnf-testsuite.yml", tags: ["setup"] do
     begin
       response_s = `./cnf-testsuite cnf_setup cnf-config=example-cnfs/coredns/cnf-testsuite.yml`
       LOGGING.info response_s
       $?.success?.should be_true
       (/Successfully setup coredns/ =~ response_s).should_not be_nil
     ensure
-
       response_s = `./cnf-testsuite cnf_cleanup cnf-config=example-cnfs/coredns/cnf-testsuite.yml`
       LOGGING.info response_s
       $?.success?.should be_true

--- a/spec/utils/cnf_manager_spec.cr
+++ b/spec/utils/cnf_manager_spec.cr
@@ -35,6 +35,13 @@ describe "SampleUtils" do
     `./cnf-testsuite cnf_cleanup cnf-path=./sample-cnfs/sample-minimal-cnf/ force=true`
   end
 
+  it "'cnf_setup' should support cnf-config as an alias for cnf-path", tags: ["cnf-setup"] do
+    LOGGING.info `./cnf-testsuite cnf_setup cnf-config=./sample-cnfs/sample-minimal-cnf/ wait_count=0`
+    $?.success?.should be_true
+  ensure
+    `./cnf-testsuite cnf_cleanup cnf-path=./sample-cnfs/sample-minimal-cnf/ force=true`
+  end
+
   it "'points_yml' should parse and return the points yaml file", tags: ["points"]  do
     (CNFManager::Points.points_yml.find {|x| x["name"] =="liveness"}).should be_truthy 
   end

--- a/src/tasks/cnf_setup.cr
+++ b/src/tasks/cnf_setup.cr
@@ -13,7 +13,7 @@ task "cnf_setup", ["helm_local_install"] do |_, args|
   input_file =  cli_hash[:input_file]
   if output_file && !output_file.empty?
     puts "cnf tarball generation mode".colorize(:green)
-    tar_info = AirGap.generate_cnf_setup(cli_hash[:extended_config_file], output_file, cli_hash)
+    tar_info = AirGap.generate_cnf_setup(cli_hash[:config_file], output_file, cli_hash)
     puts "cnf tarball generation mode complete".colorize(:green)
   elsif input_file && !input_file.empty?
     puts "cnf setup airgapped mode".colorize(:green)

--- a/src/tasks/cnf_setup.cr
+++ b/src/tasks/cnf_setup.cr
@@ -35,8 +35,7 @@ task "cnf_cleanup" do |_, args|
   VERBOSE_LOGGING.debug "args = #{args.inspect}" if check_verbose(args)
   LOGGING.debug "args = #{args.inspect}"
   if args.named.keys.includes? "cnf-config"
-    yml_file = args.named["cnf-config"].as(String)
-    cnf = File.dirname(yml_file)
+    cnf = args.named["cnf-config"].as(String)
   elsif args.named.keys.includes? "cnf-path"
     cnf = args.named["cnf-path"].as(String)
   else

--- a/src/tasks/utils/cnf_manager.cr
+++ b/src/tasks/utils/cnf_manager.cr
@@ -486,8 +486,7 @@ module CNFManager
     yml_file = ""
     cnf_path = ""
     if args.named.keys.includes? "cnf-config"
-      yml_file = args.named["cnf-config"].as(String)
-      cnf_path = File.dirname(yml_file)
+      cnf_path = args.named["cnf-config"].as(String)
     elsif args.named.keys.includes? "cnf-path"
       cnf_path = args.named["cnf-path"].as(String)
     elsif noisy

--- a/src/tasks/utils/cnf_manager.cr
+++ b/src/tasks/utils/cnf_manager.cr
@@ -483,7 +483,6 @@ module CNFManager
   def self.sample_setup_cli_args(args, noisy=true)
     VERBOSE_LOGGING.info "sample_setup_cli_args" if check_verbose(args)
     VERBOSE_LOGGING.debug "args = #{args.inspect}" if check_verbose(args)
-    yml_file = ""
     cnf_path = ""
     if args.named.keys.includes? "cnf-config"
       cnf_path = args.named["cnf-config"].as(String)
@@ -511,7 +510,7 @@ module CNFManager
     airgapped=false
     airgapped=true if args.raw.includes?("airgapped")
 
-    cli_args = {config_file: cnf_path, extended_config_file: yml_file, wait_count: wait_count, verbose: check_verbose(args), output_file: output_file, input_file: input_file}
+    cli_args = {config_file: cnf_path, wait_count: wait_count, verbose: check_verbose(args), output_file: output_file, input_file: input_file}
     LOGGING.debug "cli_args: #{cli_args}"
     cli_args
   end


### PR DESCRIPTION
## Description of changes
1. `cnf_setup` task should respect `cnf-config` option as an alias to `cnf-path` option
2. `cnf_cleanup` task should respect `cnf-config` option as an alias to `cnf-path` option
3. Added tests for both [1] and [2]

> Only [1] fixes an issue reported on #634. But I've added [2] is an extra after reviewing how `cnf_cleanup` behaves.

### Additional change: Change the config file path passed to Airgap cnf setup helper
* In the `cnf_setup` task, there's a call to `CNFManager.sample_setup_cli_args` to process the args to the task and return a hash.
* Along with other keys/options, this helper function returns an `extended_config_file` key. The value of this key was the output of calling `File.dirname` on the config path.
* In the `cnf_setup` task, the call to `AirGap.generate_cnf_setup` is passed the `extended_config_file` key.

**Change:** Pass `config_file` to `AirGap.generate_cnf_setup` helper instead of the `extended_config_file` key.

### Additional change: Remove extended_config_file key

I don't see any use of the `extended_config_file` option throughout the repository. I've assumed this be old/residue code.

**Change:** Removed `extended_config_file` key from the return value of the `CNFManager.sample_setup_cli_args` helper function. 

### Test scenarios
* `cnf_setup` task using `cnf-path` option should work as before
* `cnf_setup` task using `cnf-config` should work as an alias for `cnf-path` option
* `cnf_cleanup` task using `cnf-path` option should work as before
* `cnf_cleanup` task using `cnf-config` should work as an alias for `cnf-path` option

![CleanShot 2021-07-11 at 18 34 26](https://user-images.githubusercontent.com/84005/125196304-081c7380-e277-11eb-8aab-10a108ba35be.png)

## Issues:
Refs: #634

## How has this been tested:
 - [x] Covered by existing integration testing
 - [x] Added integration testing to cover
 - [ ] Verified all A/C passes
     * [ ] develop
     * [ ] master
     * [ ] tag/other branch
 - [ ] Test environment
    * [ ] Shared Packet K8s cluster
    * [ ] New Packet K8s cluster
    * [ ] Kind cluster
 - [ ] Have not tested

## Types of changes:
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [ ] Documentation update

## Checklist:
**Documentation**
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] No updates required.

**Code Review**
- [ ] Does the test handle fatal exceptions, ie. rescue block

**Issue**
- [ ] Tasks in issue are checked off
