### PR TITLE
Adds support for running the testsuite on microk8s

### DIFF
--- a/spec/utils/system_information/kubectl_spec.cr
+++ b/spec/utils/system_information/kubectl_spec.cr
@@ -40,6 +40,24 @@ describe "Kubectl" do
     acceptable_kubectl_version?(kubectl_response).should eq(true)
   end
 
+  it "'acceptable_kubectl_version?()' should strip plus sign from kubectl and server versions to accommodate microk8s usage'", tags: ["kubectl-utils"] do
+    # Good scenario with plus sign in version
+    kubectl_response = <<-KUBECTL_OUTPUT
+      Client Version: version.Info{Major:"1", Minor:"19+", GitVersion:"v1.19.0", GitCommit:"cb303e613a121a29364f75cc67d3d580833a7479", GitTreeState:"clean", BuildDate:"2021-04-08T16:31:21Z", GoVersion:"go1.16.1", Compiler:"gc", Platform:"linux/amd64"}
+      Server Version: version.Info{Major:"1", Minor:"20+", GitVersion:"v1.20.2", GitCommit:"faecb196815e248d3ecfb03c680a4507229c2a56", GitTreeState:"clean", BuildDate:"2021-01-21T01:11:42Z", GoVersion:"go1.15.5", Compiler:"gc", Platform:"linux/amd64"}
+    KUBECTL_OUTPUT
+
+    acceptable_kubectl_version?(kubectl_response).should eq(true)
+
+    # Bad scenario with plus sign in version
+    kubectl_response = <<-KUBECTL_OUTPUT
+      Client Version: version.Info{Major:"1", Minor:"22+", GitVersion:"v1.21.0", GitCommit:"cb303e613a121a29364f75cc67d3d580833a7479", GitTreeState:"clean", BuildDate:"2021-04-08T16:31:21Z", GoVersion:"go1.16.1", Compiler:"gc", Platform:"linux/amd64"}
+      Server Version: version.Info{Major:"1", Minor:"20+", GitVersion:"v1.20.2", GitCommit:"faecb196815e248d3ecfb03c680a4507229c2a56", GitTreeState:"clean", BuildDate:"2021-01-21T01:11:42Z", GoVersion:"go1.15.5", Compiler:"gc", Platform:"linux/amd64"}
+    KUBECTL_OUTPUT
+
+    acceptable_kubectl_version?(kubectl_response).should eq(false)
+  end
+
   it "'acceptable_kubectl_version?()' should return false if client is more than 1 minor version ahead/behind server version'", tags: ["kubectl-utils"] do
     kubectl_response = <<-KUBECTL_OUTPUT
       Client Version: version.Info{Major:"1", Minor:"22", GitVersion:"v1.21.0", GitCommit:"cb303e613a121a29364f75cc67d3d580833a7479", GitTreeState:"clean", BuildDate:"2021-04-08T16:31:21Z", GoVersion:"go1.16.1", Compiler:"gc", Platform:"linux/amd64"}

--- a/src/tasks/utils/system_information/kubectl.cr
+++ b/src/tasks/utils/system_information/kubectl.cr
@@ -130,8 +130,8 @@ end
 
 # Check if client version is not 3 minor versions behind server version
 def acceptable_kubectl_version?(kubectl_response, verbose = false)
-  client_version = kubectl_version(kubectl_response, "client", verbose).split(".")
-  server_version = kubectl_version(kubectl_response, "server", verbose)
+  client_version = kubectl_version(kubectl_response, "client", verbose).gsub("+", "").split(".")
+  server_version = kubectl_version(kubectl_response, "server", verbose).gsub("+", "")
 
   # Return nil to indicate comparison was not possible due to missing server version.
   if server_version == ""

--- a/src/tasks/utils/utils.cr
+++ b/src/tasks/utils/utils.cr
@@ -311,8 +311,13 @@ end
 
 # compare 2 SemVer strings and return true if v1 is less than v2
 def version_less_than(v1str, v2str)
-  v1 = SemanticVersion.parse(v1str)
-  v2 = SemanticVersion.parse(v2str)
+  # NOTES: This is why the below code attempts to strip the plus sign from the versions.
+  # Versions for microk8s look like this: "1.20+". As a result, the input args to this function may be "1.20+.0"
+  # This results in bad input to the semantic version parser.
+  # To allow microk8s, we strip the plus sign from the versions.
+
+  v1 = SemanticVersion.parse(v1str.gsub("+", ""))
+  v2 = SemanticVersion.parse(v2str.gsub("+", ""))
   less_than = (v1 <=> v2) == -1
   LOGGING.debug "version_less_than: #{v1} < #{v2}: #{less_than}"
   less_than


### PR DESCRIPTION
## Description

* Adds support for running the testsuite on microk8s. #824 
* This is done by stripping off the "+" signs from microk8s kubectl and server versions during version checks.

Changes to following tasks:
* `prereqs`
* `cnf_setup`

Also adds appropriate tests for `acceptable_kubectl_version?/2` to support the microk8s scenario.

### Reproduce issue

```shell
# Use microk8s server
$ microk8s config > microk8s.config
$ export KUBECONFIG="$(pwd)/microk8s.config"

# Alias microk8s.kubectl  to kubectl
$ sudo snap alias microk8s.kubectl kubectl
Added:
  - microk8s.kubectl as kubectl
```

**Reproduce issue**

```shell
$ PATH="/snap/bin:$PATH" ./cnf-testsuite prereqs
No Global helm version found
Local helm found. Version: v3.1.1
Global kubectl found. Version: 1.21+
../../../../.crenv/versions/0.35.1/share/crystal/src/string.cr:424:5 in 'to_i32'
../../../../.crenv/versions/0.35.1/share/crystal/src/string.cr:325:5 in 'to_i'
src/tasks/utils/system_information/kubectl.cr:147:3 in 'acceptable_kubectl_version?'
src/tasks/utils/system_information/kubectl.cr:17:20 in 'kubectl_installation'
src/tasks/prereqs.cr:18:27 in '->'
../../../../.crenv/versions/0.35.1/share/crystal/src/primitives.cr:255:3 in 'call'
lib/sam/src/sam/execution.cr:20:7 in 'invoke'
lib/sam/src/sam.cr:35:5 in 'invoke'
lib/sam/src/sam.cr:53:7 in 'process_tasks'
src/cnf-testsuite.cr:104:3 in '__crystal_main'
../../../../.crenv/versions/0.35.1/share/crystal/src/crystal/main.cr:105:5 in 'main_user_code'
../../../../.crenv/versions/0.35.1/share/crystal/src/crystal/main.cr:91:7 in 'main'
../../../../.crenv/versions/0.35.1/share/crystal/src/crystal/main.cr:114:3 in 'main'
__libc_start_main
_start
???
Invalid Int32: 21+
```

### Test scenarios with the proposed fix

**Setup: Configure to use microk8s server to run the test scenarios**
```shell
$ microk8s config > microk8s.config
$ export KUBECONFIG="$(pwd)/microk8s.config"
```

#### Scenario: prereqs task should succeed on microk8s

> Note: In the output, note the "+" in the verison. We display the microk8s non-semantic version as is.

```shell
$ PATH="/snap/bin:$PATH" ./cnf-testsuite prereqs
No Global helm version found
Local helm found. Version: v3.1.1
Global kubectl found. Version: 1.21+
No Local kubectl version found
Global git found. Version: 2.17.1
No Local git version found
All prerequisites found.
```

#### Scenario: cnf_setup task should succeed on microk8s
```shell
$ PATH="/snap/bin:$PATH" ./cnf-testsuite cnf_setup cnf-config=sample-cnfs/sample_local_registry
Successfully created directories for cnf-testsuite
cnf setup online mode
cnf setup online mode complete
```

#### Scenario: cnf_cleanup task should succeed on microk8s

```shell
$ PATH="/snap/bin:$PATH" ./cnf-testsuite cnf_cleanup cnf-config=sample-cnfs/sample_local_registry
Successfully cleaned up coredns
```

### Screenshots

![image](https://user-images.githubusercontent.com/84005/125789243-8237ce90-9dc4-41c0-88f3-4de42af8fe54.png)

![image](https://user-images.githubusercontent.com/84005/125789291-ff1310b2-2b5a-4b7d-ac9e-129685cc97d1.png)


## Issues:
Refs: #824 

## How has this been tested:
 - [x] Covered by existing integration testing
 - [x] Added integration testing to cover
 - [ ] Verified all A/C passes
     * [ ] develop
     * [ ] master
     * [ ] tag/other branch
 - [ ] Test environment
    * [ ] Shared Packet K8s cluster
    * [ ] New Packet K8s cluster
    * [ ] Kind cluster
 - [ ] Have not tested

## Types of changes:
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [x] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [ ] Documentation update

## Checklist:
**Documentation**
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] No updates required.

**Code Review**
- [ ] Does the test handle fatal exceptions, ie. rescue block

**Issue**
- [ ] Tasks in issue are checked off
