### PR TITLE
[feature/633] Handle scenario when release has already been setup

### DIFF
--- a/src/tasks/utils/cnf_manager.cr
+++ b/src/tasks/utils/cnf_manager.cr
@@ -731,25 +731,29 @@ module CNFManager
       stdout_success "Successfully setup #{release_name}"
     end
 
-
+    # Immutable config maps are only supported in Kubernetes 1.19+
+    immutable_configmap = true
     if version_less_than(KubectlClient.server_version, "1.19.0")
-      k8s_ver = false
-    else
-      k8s_ver = true 
+      immutable_configmap = false
     end
 
-    # TODO save to an [preferrably immutable] config map 
     #TODO if helm_install then set helm_deploy = true in template
     LOGGING.info "save config"
-    elapsed_time_template = Crinja.render(configmap_temp, { "helm_install" => helm_used, "release_name" => "cnf-testsuite-#{release_name}-startup-information", "elapsed_time" => "#{elapsed_time.seconds}", "k8s_ver" => "#{k8s_ver}"})
+    elapsed_time_template = Crinja.render(configmap_temp, { "helm_install" => helm_used, "release_name" => "cnf-testsuite-#{release_name}-startup-information", "elapsed_time" => "#{elapsed_time.seconds}", "immutable" => immutable_configmap})
     #TODO find a way to kubectlapply directly without a map
-    LOGGING.debug "elapsed_time_template : #{elapsed_time_template}"
-    write_template= `echo "#{elapsed_time_template}" > "#{destination_cnf_dir}/configmap_test.yml"`
+    Log.debug { "elapsed_time_template : #{elapsed_time_template}" }
+    write_template = File.write("#{destination_cnf_dir}/configmap_test.yml", elapsed_time_template)
     # TODO if the config map exists on install, complain, delete then overwrite?
     KubectlClient::Delete.file("#{destination_cnf_dir}/configmap_test.yml")
     #TODO call kubectl apply on file
     KubectlClient::Apply.file("#{destination_cnf_dir}/configmap_test.yml")
     # TODO when uninstalling, remove config map
+
+  rescue e : Helm::CannotReuseReleaseNameError
+    # Since the release has already been setup:
+    # * Do not wait for resources to be ready
+    # * Do not measure elapsed time to add ConfigMap
+    stdout_warning "Release name #{release_name} has already been setup"
   end
 
 def self.configmap_temp
@@ -758,7 +762,7 @@ def self.configmap_temp
   kind: ConfigMap
   metadata:
     name: '{{ release_name }}'
-  {% if k8s_ver %}
+  {% if immutable %}
   immutable: true
   {% endif %}
   data:

--- a/src/tasks/utils/helm.cr
+++ b/src/tasks/utils/helm.cr
@@ -192,8 +192,13 @@ module Helm
                          shell: true,
                          output: output = IO::Memory.new,
                          error: stderr = IO::Memory.new)
-    LOGGING.info "Helm.install output: #{output.to_s}"
-    LOGGING.info "Helm.install stderr: #{stderr.to_s}"
+    Log.info { "Helm.install output: #{output.to_s}" }
+    Log.info { "Helm.install stderr: #{stderr.to_s}" }
+
+    if CannotReuseReleaseNameError.content_match?(stderr.to_s)
+      raise CannotReuseReleaseNameError.new
+    end
+
     {status: status, output: output, error: stderr}
   end
 
@@ -219,5 +224,11 @@ module Helm
     LOGGING.info "Helm.fetch output: #{output.to_s}"
     LOGGING.info "Helm.fetch stderr: #{stderr.to_s}"
     {status: status, output: output, error: stderr}
+  end
+
+  class CannotReuseReleaseNameError < Exception
+    def self.content_match?(str : String)
+      str.includes? "cannot re-use a name that is still in use"
+    end
   end
 end


### PR DESCRIPTION
## Description

This PR resolves #633 by displaying a warning if CNF with same release name is already setup.

**Helm.install:**
* Define new error to indicate Helm release previously setup
* Raise error if Helm install says release previously setup
* Use `Log.info` with proc instead of `LOGGING` constant
  This change is in line with the comment on top of the LogginGenerator class

**CNFManager.sample_setup:**
* Output a warning if release name already exists (requirement of #633)

### Additional changes to CNFManager.sample_setup:

* Use the File class to write to file instead of shell command
* Assume immutable configmap supported by default
* Rename template var appropriately (k8s_ver to immutable_configmap)
* Remove outdated todo mark

## Test scenarios

### Setup

New kind cluster.
```
export KIND_CLUSTER_NAME="test-633"
export KUBECONFIG="$(pwd)/${KIND_CLUSTER_NAME}.kubeconfig"

kind create cluster \
      --name $KIND_CLUSTER_NAME \
      --kubeconfig "$(pwd)/${KIND_CLUSTER_NAME}.kubeconfig"
```

### Scenario: Should be able to setup cnf on a new cluster

![image](https://user-images.githubusercontent.com/84005/126044290-6895f437-f906-4026-b414-fe5a4f860b4d.png)

### Scenario: Should display a warning when CNF with the same release name is already installed

![CleanShot 2021-07-17 at 22 28 46](https://user-images.githubusercontent.com/84005/126044448-3d49d967-f393-43e5-a8bd-8527053fcbac.png)

### Comparison with main branch build to denote differences

![CleanShot 2021-07-17 at 22 54 24](https://user-images.githubusercontent.com/84005/126045185-76d9c28e-9e73-47a9-bf11-57f5417d75d5.png)

## Issues:
Refs: #633

## How has this been tested:
 - [x] Covered by existing integration testing
 - [ ] Added integration testing to cover
 - [ ] Verified all A/C passes
     * [ ] develop
     * [ ] master
     * [ ] tag/other branch
 - [ ] Test environment
    * [ ] Shared Packet K8s cluster
    * [ ] New Packet K8s cluster
    * [x] Kind cluster
 - [ ] Have not tested

## Types of changes:
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [x] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [ ] Documentation update

## Checklist:
**Documentation**
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] No updates required.

**Code Review**
- [x] Does the test handle fatal exceptions, ie. rescue block

**Issue**
- [ ] Tasks in issue are checked off
