### PR TITLE
Feat(Resiliency): Add litmus pod memory hog experiment.

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -653,9 +653,16 @@ crystal src/cnf-testsuite.cr performance
 ./cnf-testsuite disk_fill
 ```
 
-#### :heavy_check_mark: Test if the CNF crashes when pod delete occurs 
+#### :heavy_check_mark: Test if the CNF crashes when pod delete occurs
+
 ```
-./cnf-conformance pod_delete
+./cnf-testsuite pod_delete
+```
+
+#### :heavy_check_mark: Test if the CNF crashes when pod memory hog occurs
+
+```
+./cnf-testsuite pod_memory_hog
 ```
 
 ---

--- a/spec/cnf_testsuite_all/cnf_testsuite_config_lifecycle_spec.cr
+++ b/spec/cnf_testsuite_all/cnf_testsuite_config_lifecycle_spec.cr
@@ -15,7 +15,7 @@ describe CnfTestSuite do
 
  it "'testsuite all' should run the configuration lifecycle tests", tags: ["testsuite-config-lifecycle"] do
     `./cnf-testsuite samples_cleanup`
-    response_s = `./cnf-testsuite all ~reasonable_startup_time ~reasonable_image_size ~disk_fill ~pod_delete ~pod_network_latency ~chaos_network_loss ~chaos_cpu_hog ~chaos_container_kill ~platform ~volume_hostpath_not_found ~privileged ~increase_capacity ~decrease_capacity ~install_script_helm ~helm_chart_valid ~helm_chart_published "cnf-config=./sample-cnfs/sample-coredns-cnf/cnf-testsuite.yml" verbose`
+    response_s = `./cnf-testsuite all ~reasonable_startup_time ~reasonable_image_size ~disk_fill ~pod_delete ~pod_network_latency ~pod_memory_hog ~chaos_network_loss ~chaos_cpu_hog ~chaos_container_kill ~platform ~volume_hostpath_not_found ~privileged ~increase_capacity ~decrease_capacity ~install_script_helm ~helm_chart_valid ~helm_chart_published "cnf-config=./sample-cnfs/sample-coredns-cnf/cnf-testsuite.yml" verbose`
     LOGGING.info response_s
     (/PASSED: Helm readiness probe found/ =~ response_s).should_not be_nil
     (/PASSED: Helm liveness probe/ =~ response_s).should_not be_nil

--- a/spec/cnf_testsuite_all/cnf_testsuite_microservice_spec.cr
+++ b/spec/cnf_testsuite_all/cnf_testsuite_microservice_spec.cr
@@ -15,7 +15,7 @@ describe CnfTestSuite do
 
   it "'testsuite all' should run all the microservice tests", tags: ["testsuite-microservice"] do
     `./cnf-testsuite samples_cleanup`
-    response_s = `./cnf-testsuite all ~disk_fill ~pod-delete ~pod_network_latency ~chaos_network_loss ~chaos_cpu_hog ~chaos_container_kill ~platform ~volume_hostpath_not_found ~privileged ~increase_capacity ~decrease_capacity ~ip_addresses ~liveness ~readiness ~rolling_update ~rolling_downgrade ~rolling_version_change ~nodeport_not_used ~hardcoded_ip_addresses_in_k8s_runtime_configuration ~install_script_helm ~helm_chart_valid ~helm_chart_published ~rollback ~secrets_used ~immutable_configmap "cnf-config=./sample-cnfs/sample-coredns-cnf/cnf-testsuite.yml" verbose`
+    response_s = `./cnf-testsuite all ~disk_fill ~pod-delete ~pod_network_latency ~pod_memory_hog ~chaos_network_loss ~chaos_cpu_hog ~chaos_container_kill ~platform ~volume_hostpath_not_found ~privileged ~increase_capacity ~decrease_capacity ~ip_addresses ~liveness ~readiness ~rolling_update ~rolling_downgrade ~rolling_version_change ~nodeport_not_used ~hardcoded_ip_addresses_in_k8s_runtime_configuration ~install_script_helm ~helm_chart_valid ~helm_chart_published ~rollback ~secrets_used ~immutable_configmap "cnf-config=./sample-cnfs/sample-coredns-cnf/cnf-testsuite.yml" verbose`
     LOGGING.info response_s
     (/Final workload score:/ =~ response_s).should_not be_nil
     (/Final score:/ =~ response_s).should_not be_nil

--- a/spec/cnf_testsuite_all/cnf_testsuite_spec.cr
+++ b/spec/cnf_testsuite_all/cnf_testsuite_spec.cr
@@ -18,7 +18,7 @@ describe CnfTestSuite do
     # the workload resilience tests are run in the chaos specs
     # the ommisions (i.e. ~resilience) are done for performance reasons for the spec suite
     # response_s = `./cnf-testsuite all ~platform ~resilience cnf-config=./sample-cnfs/sample-coredns-cnf/cnf-testsuite.yml verbose`
-    response_s = `./cnf-testsuite all ~disk_fill ~pod-delete ~pod_network_latency ~chaos_network_loss ~chaos_cpu_hog ~chaos_container_kill ~platform ~ip_addresses ~liveness ~readiness ~rolling_update ~rolling_downgrade ~rolling_version_change ~nodeport_not_used ~hardcoded_ip_addresses_in_k8s_runtime_configuration ~rollback ~secrets_used ~immutable_configmap ~reasonable_startup_time ~reasonable_image_size "cnf-config=./sample-cnfs/sample-coredns-cnf/cnf-testsuite.yml" verbose`
+    response_s = `./cnf-testsuite all ~disk_fill ~pod-delete ~pod_network_latency ~pod_memory_hog ~chaos_network_loss ~chaos_cpu_hog ~chaos_container_kill ~platform ~ip_addresses ~liveness ~readiness ~rolling_update ~rolling_downgrade ~rolling_version_change ~nodeport_not_used ~hardcoded_ip_addresses_in_k8s_runtime_configuration ~rollback ~secrets_used ~immutable_configmap ~reasonable_startup_time ~reasonable_image_size "cnf-config=./sample-cnfs/sample-coredns-cnf/cnf-testsuite.yml" verbose`
     LOGGING.info response_s
     (/Lint Passed/ =~ response_s).should_not be_nil
     (/PASSED: Replicas increased to 3/ =~ response_s).should_not be_nil

--- a/spec/workload/resilience/pod_memory_hog_spec.cr
+++ b/spec/workload/resilience/pod_memory_hog_spec.cr
@@ -1,0 +1,30 @@
+require "../../spec_helper"
+require "colorize"
+require "../../../src/tasks/utils/utils.cr"
+require "../../../src/tasks/utils/system_information/helm.cr"
+require "file_utils"
+require "sam"
+
+describe "Resilience pod memory hog Chaos" do
+  before_all do
+    `./cnf-testsuite setup`
+    `./cnf-testsuite configuration_file_setup`
+    $?.success?.should be_true
+  end
+
+  it "'pod_memory_hog' A 'Good' CNF should not crash when pod memory hog occurs", tags: ["pod_memory_hog"]  do
+    begin
+      `./cnf-testsuite cnf_setup cnf-config=sample-cnfs/sample-coredns-cnf/cnf-testsuite.yml`
+      $?.success?.should be_true
+      response_s = `./cnf-testsuite pod_memory_hog verbose`
+      LOGGING.info response_s
+      $?.success?.should be_true
+      (/PASSED: pod_memory_hog chaos test passed/ =~ response_s).should_not be_nil
+    ensure
+      `./cnf-testsuite cnf_cleanup cnf-config=sample-cnfs/sample-coredns-cnf/cnf-testsuite.yml`
+      $?.success?.should be_true
+      `./cnf-testsuite uninstall_litmus`
+      $?.success?.should be_true
+    end
+  end
+end

--- a/src/tasks/litmus_cleanup.cr
+++ b/src/tasks/litmus_cleanup.cr
@@ -7,12 +7,12 @@ require "./utils/utils.cr"
 desc "Uninstall LitmusChaos"
 task "uninstall_litmus" do |_, args|
     uninstall_chaosengine = `kubectl delete chaosengine --all --all-namespaces`
-    # litmus_uninstall = `kubectl delete -f https://litmuschaos.github.io/litmus/litmus-operator-v1.13.6.yaml`
+    # litmus_uninstall = `kubectl delete -f https://litmuschaos.github.io/litmus/litmus-operator-v1.13.8.yaml`
     if args.named["offline"]?
         LOGGING.info "install litmus offline mode"
-      KubectlClient::Delete.file("#{OFFLINE_MANIFESTS_PATH}/litmus-operator-v1.13.6.yaml")
+      KubectlClient::Delete.file("#{OFFLINE_MANIFESTS_PATH}/litmus-operator-v1.13.8.yaml")
     else
-      KubectlClient::Delete.file("https://litmuschaos.github.io/litmus/litmus-operator-v1.13.6.yaml")
+      KubectlClient::Delete.file("https://litmuschaos.github.io/litmus/litmus-operator-v1.13.8.yaml")
     end
     puts "#{uninstall_chaosengine}" if check_verbose(args)
     # puts "#{litmus_uninstall}" if check_verbose(args)

--- a/src/tasks/litmus_setup.cr
+++ b/src/tasks/litmus_setup.cr
@@ -8,11 +8,11 @@ desc "Install LitmusChaos"
 task "install_litmus" do |_, args|
   if args.named["offline"]?
     LOGGING.info "install litmus offline mode"
-    AirGapUtils.image_pull_policy("#{OFFLINE_MANIFESTS_PATH}/litmus-operator-v1.13.6.yaml")
-    KubectlClient::Apply.file("#{OFFLINE_MANIFESTS_PATH}/litmus-operator-v1.13.6.yaml")
+    AirGapUtils.image_pull_policy("#{OFFLINE_MANIFESTS_PATH}/litmus-operator-v1.13.8.yaml")
+    KubectlClient::Apply.file("#{OFFLINE_MANIFESTS_PATH}/litmus-operator-v1.13.8.yaml")
     KubectlClient::Apply.file("#{OFFLINE_MANIFESTS_PATH}/chaos_crds.yaml")
   else
-    KubectlClient::Apply.file("https://litmuschaos.github.io/litmus/litmus-operator-v1.13.6.yaml")
+    KubectlClient::Apply.file("https://litmuschaos.github.io/litmus/litmus-operator-v1.13.8.yaml")
   end
 end
 


### PR DESCRIPTION
Signed-off-by: Jonsy13 <vedant.shrotria@chaosnative.com>

## Description
This PR contains:

- Add litmus pod memory hog experiment to test suite - https://docs.litmuschaos.io/docs/pod-memory-hog/
- Update litmus to the latest version (as of now) 1.13.8.

About pod memory hog and why do we need it?

Pod Memory Hog simulates conditions where cnf application pods experience Memory spikes either due to expected/undesired processes thereby testing how the overall application stack behaves when this occurs. This will help to test if the CNF application survives the pod memory hog chaos injection.

## Issues:
Refs: #NNN

## How has this been tested:
 - [ ] Covered by existing integration testing
 - [ ] Added integration testing to cover
 - [ ] Verified all A/C passes
     * [ ] develop
     * [ ] master
     * [ ] tag/other branch
 - [ ] Test environment
    * [ ] Shared Packet K8s cluster
    * [ ] New Packet K8s cluster
    * [ ] Kind cluster
 - [ ] Have not tested

## Types of changes:
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [ ] Documentation update

## Checklist:
**Documentation**
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] No updates required.

**Code Review**
- [ ] Does the test handle fatal exceptions, ie. rescue block

**Issue**
- [ ] Tasks in issue are checked off
