### PR TITLE
Chore(docs): Add docs for pod memory and io experiment

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -695,11 +695,32 @@ Stressing the disk with continuous and heavy IO for example can cause degradatio
 
 #### :heavy_check_mark: Test if the CNF crashes when pod memory hog occurs
 
+<details> <summary>Details for litmus pod memory hog experiment</summary>
+<p>
+
+Memory usage within containers is subject to various constraints in Kubernetes. If the limits are specified in their spec, exceeding them can cause termination of the container (due to OOMKill of the primary process, often pid 1) - the restart of the container by kubelet, subject to the policy specified. For containers with no limits placed, the memory usage is uninhibited until such time as the Node level OOM Behaviour takes over. In this case, containers on the node can be killed based on their oom_score and the QoS class a given pod belongs to (bestEffort ones are first to be targeted). This eval is extended to all pods running on the node - thereby causing a bigger blast radius. 
+
+The [pod-memory hog](https://docs.litmuschaos.io/docs/pod-memory-hog/) experiment launches a stress process within the target container - which can cause either the primary process in the container to be resource constrained in cases where the limits are enforced OR eat up available system memory on the node in cases where the limits are not specified. 
+
+</p>
+</details>
+
+
 ```
 ./cnf-testsuite pod_memory_hog
 ```
 
 #### :heavy_check_mark: Test if the CNF crashes when pod io stress occurs
+
+<details> <summary>Details for litmus pod io stress experiment</summary>
+<p>
+
+Sressing the disk with continuous and heavy IO can cause degradation in reads/ writes byt other microservices that use this shared disk.  For example modern storage solutions for Kubernetes use the concept of storage pools out of which virtual volumes/devices are carved out.  Another issue is the amount of scratch space eaten up on a node which leads to  the lack of space for newer containers to get scheduled (kubernetes too gives up by applying an "eviction" taint like "disk-pressure") and causes a wholesale movement of all pods to other nodes.
+
+[This experiment](https://docs.litmuschaos.io/docs/pod-io-stress/) is also useful in determining the performance of the storage device used.  
+</p>
+</details>
+
 
 ```
 ./cnf-testsuite pod_io_stress


### PR DESCRIPTION
Signed-off-by: udit <udit@chaosnative.com>

## Description
This PR will add a brief usage of the litmus experiments in the resiliency category. The docs are added for:
- pod memory hog
- pod io stess


## Issues:
Refs: https://github.com/cncf/cnf-testsuite/issues/929

## How has this been tested:
 - [ ] Covered by existing integration testing
 - [ ] Added integration testing to cover
 - [ ] Verified all A/C passes
     * [ ] develop
     * [ ] master
     * [ ] tag/other branch
 - [ ] Test environment
    * [ ] Shared Packet K8s cluster
    * [ ] New Packet K8s cluster
    * [ ] Kind cluster
 - [ ] Have not tested

## Types of changes:
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [ ] Documentation update

## Checklist:
**Documentation**
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] No updates required.

**Code Review**
- [ ] Does the test handle fatal exceptions, ie. rescue block

**Issue**
- [ ] Tasks in issue are checked off
