### PR TITLE
[bug/307] Remove backticks and legacy log lines: Part-4 (Changes to KubectlClient)

### DIFF
--- a/utils/kubectl_client/kubectl_client.cr
+++ b/utils/kubectl_client/kubectl_client.cr
@@ -155,6 +155,7 @@ module KubectlClient
 
   #TODO move this out into its own file
   module Get
+
     def self.privileged_containers(namespace="--all-namespaces")
       privileged_response = `kubectl get pods #{namespace} -o jsonpath='{.items[*].spec.containers[?(@.securityContext.privileged==true)].name}'`
       # TODO parse this as json
@@ -165,16 +166,16 @@ module KubectlClient
 
     def self.nodes : JSON::Any
       # TODO should this be all namespaces?
-      resp = `kubectl get nodes -o json`
-      LOGGING.debug "kubectl get nodes: #{resp}"
-      JSON.parse(resp)
+      cmd = "kubectl get nodes -o json"
+      result = ShellCmd.run(cmd, "KubectlClient::Get.nodes")
+      JSON.parse(result[:output])
     end
 
     def self.pods(all_namespaces=true) : K8sManifest 
       option = all_namespaces ? "--all-namespaces" : ""
-      resp = `kubectl get pods #{option} -o json`
-      # LOGGING.debug "kubectl get pods: #{resp}"
-      JSON.parse(resp)
+      cmd = "kubectl get pods #{option} -o json"
+      result = ShellCmd.run(cmd, "KubectlClient::Get.pods")
+      JSON.parse(result[:output])
     end
    
     # todo put this in a manifest module

--- a/utils/kubectl_client/kubectl_client.cr
+++ b/utils/kubectl_client/kubectl_client.cr
@@ -97,6 +97,14 @@ module KubectlClient
     end
   end
 
+  module Create
+    def self.command(cli : String)
+      cmd = "kubectl create #{cli}"
+      result = ShellCmd.run(cmd, "KubectlClient::Create.command")
+      result[:status].success?
+    end
+  end
+
   module Apply
     def self.file(file_name)
       cmd = "kubectl apply -f #{file_name}"
@@ -108,6 +116,13 @@ module KubectlClient
       cmd = "kubectl apply --validate=true --dry-run=client -f #{file_name}"
       result = ShellCmd.run(cmd, "KubectlClient::Apply.validate")
       result[:status].success?
+    end
+  end
+
+  module Scale
+    def self.command(cli)
+      cmd = "kubectl scale #{cli}"
+      ShellCmd.run(cmd, "KubectlClient::Scale.command")
     end
   end
 

--- a/utils/kubectl_client/kubectl_client.cr
+++ b/utils/kubectl_client/kubectl_client.cr
@@ -16,6 +16,21 @@ module KubectlClient
   # https://www.capitalone.com/tech/cloud/container-runtime/
   OCI_RUNTIME_REGEX = /containerd|docker|runc|railcar|crun|rkt|gviso|nabla|runv|clearcontainers|kata|cri-o/i
 
+  module ShellCmd
+    def self.run(cmd, log_prefix)
+      Log.info { "#{log_prefix} command: #{cmd}" }
+      status = Process.run(
+        cmd,
+        shell: true,
+        output: output = IO::Memory.new,
+        error: stderr = IO::Memory.new
+      )
+      Log.debug { "#{log_prefix} output: #{output.to_s}" }
+      Log.debug { "#{log_prefix} stderr: #{stderr.to_s}" }
+      {status: status, output: output.to_s, error: stderr.to_s}
+    end
+  end
+
   def self.logs(pod_name, container_name="")
     status = Process.run("kubectl logs #{pod_name} #{container_name}",
                          shell: true,

--- a/utils/kubectl_client/kubectl_client.cr
+++ b/utils/kubectl_client/kubectl_client.cr
@@ -42,25 +42,15 @@ module KubectlClient
   end
 
   def self.exec(command)
-    LOGGING.info "KubectlClient.exec command: #{command}"
-    status = Process.run("kubectl exec #{command}",
-                         shell: true,
-                         output: output = IO::Memory.new,
-                         error: stderr = IO::Memory.new)
-    LOGGING.info "KubectlClient.exec output: #{output.to_s}"
-    LOGGING.info "KubectlClient.exec stderr: #{stderr.to_s}"
-    {status: status, output: output, error: stderr}
+    cmd = "kubectl exec #{command}"
+    ShellCmd.run(cmd, "KubectlClient.exec")
   end
+
   def self.cp(command)
-    LOGGING.info "KubectlClient.cp command: #{command}"
-    status = Process.run("kubectl cp #{command}",
-                         shell: true,
-                         output: output = IO::Memory.new,
-                         error: stderr = IO::Memory.new)
-    LOGGING.info "KubectlClient.cp output: #{output.to_s}"
-    LOGGING.info "KubectlClient.cp stderr: #{stderr.to_s}"
-    {status: status, output: output, error: stderr}
+    cmd = "kubectl cp #{command}"
+    ShellCmd.run(cmd, "KubectlClient.cp")
   end
+
   def self.server_version()
     LOGGING.debug "KubectlClient.server_version"
     status = Process.run("kubectl version",

--- a/utils/kubectl_client/kubectl_client.cr
+++ b/utils/kubectl_client/kubectl_client.cr
@@ -139,28 +139,17 @@ module KubectlClient
   end
 
   module Set
-    def self.image(deployment_name, container_name, image_name, version_tag=nil)
+    def self.image(deployment_name, container_name, image_name, version_tag=nil) : Bool
+      # use --record when setting image to have history
       #TODO check if image exists in repo? DockerClient::Get.image and image_by_tags
+      cmd = ""
       if version_tag
-        LOGGING.debug "kubectl set image deployment/#{deployment_name} #{container_name}=#{image_name}:#{version_tag} --record"
-        # use --record to have history
-        # resp  = `kubectl set image deployment/#{deployment_name} #{container_name}=#{image_name}:#{version_tag} --record`
-        status = Process.run("kubectl set image deployment/#{deployment_name} #{container_name}=#{image_name}:#{version_tag} --record",
-                             shell: true,
-                             output: output = IO::Memory.new,
-                             error: stderr = IO::Memory.new)
+        cmd = "kubectl set image deployment/#{deployment_name} #{container_name}=#{image_name}:#{version_tag} --record"
       else
-        LOGGING.debug "kubectl set image deployment/#{deployment_name} #{container_name}=#{image_name} --record"
-        # resp  = `kubectl set image deployment/#{deployment_name} #{container_name}=#{image_name} --record`
-        status = Process.run("kubectl set image deployment/#{deployment_name} #{container_name}=#{image_name} --record",
-                             shell: true,
-                             output: output = IO::Memory.new,
-                             error: stderr = IO::Memory.new)
+        cmd = "kubectl set image deployment/#{deployment_name} #{container_name}=#{image_name} --record"
       end
-      LOGGING.info "KubectlClient.set image output: #{output.to_s}"
-      LOGGING.info "KubectlClient.set image stderr: #{stderr.to_s}"
-      # LOGGING.debug "kubectl set image: #{resp}"
-      $?.success?
+      result = ShellCmd.run(cmd, "KubectlClient::Set.image")
+      result[:status].success?
     end
   end
 

--- a/utils/kubectl_client/kubectl_client.cr
+++ b/utils/kubectl_client/kubectl_client.cr
@@ -91,68 +91,38 @@ module KubectlClient
   end
 
   module Annotate
-    def self.run(cli) 
-      LOGGING.info "annotate cli:  #{cli}"
-      status = Process.run("kubectl annotate #{cli}",
-                           shell: true,
-                           output: output = IO::Memory.new,
-                           error: stderr = IO::Memory.new)
-      LOGGING.info "KubectlClient.Annotate.run output: #{output.to_s}"
-      LOGGING.info "KubectlClient.Annotate.run stderr: #{stderr.to_s}"
-      {status: status, output: output, error: stderr}
+    def self.run(cli)
+      cmd = "kubectl annotate #{cli}"
+      ShellCmd.run(cmd, "KubectlClient::Annotate.run")
     end
   end
 
   module Apply
-    def self.file(file_name) : Bool
-      # LOGGING.info "apply file: #{file_name}"
-      # apply = `kubectl apply -f #{file_name}`
-      # apply_status = $?.success?
-      # LOGGING.debug "kubectl apply resp: #{apply}"
-      # LOGGING.debug "apply? #{apply_status}"
-      # apply_status
-      LOGGING.info "apply file: #{file_name}"
-      status = Process.run("kubectl apply -f #{file_name}",
-                           shell: true,
-                           output: output = IO::Memory.new,
-                           error: stderr = IO::Memory.new)
-      LOGGING.info "KubectlClient.apply output: #{output.to_s}"
-      LOGGING.info "KubectlClient.apply stderr: #{stderr.to_s}"
-      # {status: status, output: output, error: stderr}
-      apply_status = $?.success?
+    def self.file(file_name)
+      cmd = "kubectl apply -f #{file_name}"
+      ShellCmd.run(cmd, "KubectlClient::Apply.file")
     end
+
     def self.validate(file_name) : Bool
       # this hits the server btw (so you need a valid K8s cluster)
-      LOGGING.info "apply (validate) file: #{file_name}"
-      status = Process.run("kubectl apply --validate=true --dry-run=client -f #{file_name}",
-                           shell: true,
-                           output: output = IO::Memory.new,
-                           error: stderr = IO::Memory.new)
-      LOGGING.info "KubectlClient.apply output: #{output.to_s}"
-      LOGGING.info "KubectlClient.apply stderr: #{stderr.to_s}"
-      apply_status = $?.success?
+      cmd = "kubectl apply --validate=true --dry-run=client -f #{file_name}"
+      result = ShellCmd.run(cmd, "KubectlClient::Apply.validate")
+      result[:status].success?
     end
   end
+
   module Delete
     def self.command(command)
-      status = Process.run("kubectl delete #{command}",
-                           shell: true,
-                           output: output = IO::Memory.new,
-                           error: stderr = IO::Memory.new)
-      LOGGING.info "KubectlClient.delete output: #{output.to_s}"
-      LOGGING.info "KubectlClient.delete stderr: #{stderr.to_s}"
-      {status: status, output: output, error: stderr}
+      cmd = "kubectl delete #{command}"
+      ShellCmd.run(cmd, "KubectlClient::Delete.command")
     end
+
     def self.file(file_name)
-      status = Process.run("kubectl delete -f #{file_name}",
-                           shell: true,
-                           output: output = IO::Memory.new,
-                           error: stderr = IO::Memory.new)
-      LOGGING.info "KubectlClient.delete output: #{output.to_s}"
-      LOGGING.info "KubectlClient.delete stderr: #{stderr.to_s}"
-      {status: status, output: output, error: stderr}
+      cmd = "kubectl delete -f #{file_name}"
+      ShellCmd.run(cmd, "KubectlClient::Delete.file")
     end
   end
+
   module Set
     def self.image(deployment_name, container_name, image_name, version_tag=nil)
       #TODO check if image exists in repo? DockerClient::Get.image and image_by_tags
@@ -178,6 +148,7 @@ module KubectlClient
       $?.success?
     end
   end
+
   #TODO move this out into its own file
   module Get
     def self.privileged_containers(namespace="--all-namespaces")


### PR DESCRIPTION
## Description

This PR includes some changes to the `KubectlClient` module

* Adds KubectlClient::ShellCmd to run system commands
* Uses the new ShellCmd module in
  * exec, cp and server_version functions
  * Apply, Annotate, Delete and Rollout modules
  * KubectlClient::Set.image helper function
  * KubectlClient::Get module for pods and nodes helpers
* Adds new helpers to use in future PRs
  * KubectlClient::Get.namespaces helper
  * Create and Scale helper modules

Reason for adding Create module is for the new helper to allow creating other resources like namespaces.

## Issues:
Refs: #307 

## How has this been tested:
 - [x] Covered by existing integration testing
 - [ ] Added integration testing to cover
 - [ ] Verified all A/C passes
     * [ ] develop
     * [ ] master
     * [ ] tag/other branch
 - [ ] Test environment
    * [ ] Shared Packet K8s cluster
    * [ ] New Packet K8s cluster
    * [ ] Kind cluster
 - [ ] Have not tested

## Types of changes:
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [ ] Documentation update

## Checklist:
**Documentation**
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] No updates required.

**Code Review**
- [ ] Does the test handle fatal exceptions, ie. rescue block

**Issue**
- [ ] Tasks in issue are checked off
