### PR TITLE
Feat(Resiliency): Add litmus pod network corruption experiment and up…

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -674,7 +674,7 @@ The applications may stall or get corrupted while they wait endlessly for a pack
 
 <b>Disk-Fill(Stress-Chaos):</b> Disk Pressure is another very common and frequent scenario we find in Kubernetes applications that can result in the eviction of the application replica and impact its delivery. Such scenarios can still occur despite whatever availability aids K8s provides. These problems are generally referred to as "Noisy Neighbour" problems.
 
-Stressing the disk with continuous and heavy IO for example can cause degradation in reads written by other microservices that use this shared disk for example modern storage solutions for Kubernetes to use the concept of storage pools out of which virtual volumes/devices are carved out. Another issue is the amount of scratch space eaten up on a node which leads to the lack of space for newer containers to get scheduled (Kubernetes too gives up by applying an "eviction" taint like "disk-pressure") and causes a wholesale movement of all pods to other nodes. Similarly with CPU chaos, by injecting a rogue process into a target container, we starve the main microservice process (typically PID 1) of the resources allocated to it (where limits are defined) causing slowness in application traffic or in other cases unrestrained use can cause the node to exhaust resources leading to the eviction of all pods. So this category of chaos experiment helps to build the immunity on the application undergoing any such stress scenario.
+[Stressing the disk](https://litmuschaos.github.io/litmus/experiments/categories/pods/disk-fill/) with continuous and heavy IO for example can cause degradation in reads written by other microservices that use this shared disk for example modern storage solutions for Kubernetes to use the concept of storage pools out of which virtual volumes/devices are carved out. Another issue is the amount of scratch space eaten up on a node which leads to the lack of space for newer containers to get scheduled (Kubernetes too gives up by applying an "eviction" taint like "disk-pressure") and causes a wholesale movement of all pods to other nodes. Similarly with CPU chaos, by injecting a rogue process into a target container, we starve the main microservice process (typically PID 1) of the resources allocated to it (where limits are defined) causing slowness in application traffic or in other cases unrestrained use can cause the node to exhaust resources leading to the eviction of all pods. So this category of chaos experiment helps to build the immunity on the application undergoing any such stress scenario.
 
 </p>
 </details>
@@ -690,7 +690,7 @@ Stressing the disk with continuous and heavy IO for example can cause degradatio
 
 <b>Pod Delete:</b> In a distributed system like Kubernetes, likely, your application replicas may not be sufficient to manage the traffic (indicated by SLIs) when some of the replicas are unavailable due to any failure (can be system or application) the application needs to meet the SLO(service level objectives) for this, we need to make sure that the applications have a minimum number of available replicas. One of the common application failures is when the pressure on other replicas increases then to how the horizontal pod autoscaler scales based on observed resource utilization and also how much PV mount takes time upon rescheduling. The other important aspects to test are the MTTR for the application replica, re-elections of leader or follower like in Kafka application the selection of broker leader, validating minimum quorum to run the application for example in applications like percona, resync/redistribution of data.
 
-[This experiment](https://docs.litmuschaos.io/docs/pod-delete/) helps to simulate such a scenario with forced/graceful pod failure on specific or random replicas of an application resource and checks the deployment sanity (replica availability & uninterrupted service) and recovery workflow of the application.
+[This experiment](https://litmuschaos.github.io/litmus/experiments/categories/pods/pod-delete/) helps to simulate such a scenario with forced/graceful pod failure on specific or random replicas of an application resource and checks the deployment sanity (replica availability & uninterrupted service) and recovery workflow of the application.
 
 </p>
 </details>
@@ -706,7 +706,7 @@ Stressing the disk with continuous and heavy IO for example can cause degradatio
 
 Memory usage within containers is subject to various constraints in Kubernetes. If the limits are specified in their spec, exceeding them can cause termination of the container (due to OOMKill of the primary process, often pid 1) - the restart of the container by kubelet, subject to the policy specified. For containers with no limits placed, the memory usage is uninhibited until such time as the Node level OOM Behaviour takes over. In this case, containers on the node can be killed based on their oom_score and the QoS class a given pod belongs to (bestEffort ones are first to be targeted). This eval is extended to all pods running on the node - thereby causing a bigger blast radius. 
 
-The [pod-memory hog](https://docs.litmuschaos.io/docs/pod-memory-hog/) experiment launches a stress process within the target container - which can cause either the primary process in the container to be resource constrained in cases where the limits are enforced OR eat up available system memory on the node in cases where the limits are not specified. 
+The [pod-memory hog](https://litmuschaos.github.io/litmus/experiments/categories/pods/pod-memory-hog/) experiment launches a stress process within the target container - which can cause either the primary process in the container to be resource constrained in cases where the limits are enforced OR eat up available system memory on the node in cases where the limits are not specified. 
 
 </p>
 </details>
@@ -723,13 +723,18 @@ The [pod-memory hog](https://docs.litmuschaos.io/docs/pod-memory-hog/) experimen
 
 Sressing the disk with continuous and heavy IO can cause degradation in reads/ writes byt other microservices that use this shared disk.  For example modern storage solutions for Kubernetes use the concept of storage pools out of which virtual volumes/devices are carved out.  Another issue is the amount of scratch space eaten up on a node which leads to  the lack of space for newer containers to get scheduled (kubernetes too gives up by applying an "eviction" taint like "disk-pressure") and causes a wholesale movement of all pods to other nodes.
 
-[This experiment](https://docs.litmuschaos.io/docs/pod-io-stress/) is also useful in determining the performance of the storage device used.  
+[This experiment](https://litmuschaos.github.io/litmus/experiments/categories/pods/pod-io-stress/) is also useful in determining the performance of the storage device used.  
 </p>
 </details>
 
-
 ```
 ./cnf-testsuite pod_io_stress
+```
+
+#### :heavy_check_mark: Test if the CNF crashes when pod network corruption occurs
+
+```
+./cnf-testsuite pod_network_corruption
 ```
 
 ---

--- a/spec/cnf_testsuite_all/cnf_testsuite_config_lifecycle_spec.cr
+++ b/spec/cnf_testsuite_all/cnf_testsuite_config_lifecycle_spec.cr
@@ -15,7 +15,7 @@ describe CnfTestSuite do
 
  it "'testsuite all' should run the configuration lifecycle tests", tags: ["testsuite-config-lifecycle"] do
     `./cnf-testsuite samples_cleanup`
-    response_s = `./cnf-testsuite all ~reasonable_startup_time ~reasonable_image_size ~disk_fill ~pod_delete ~pod_io_stress ~pod_network_latency ~pod_memory_hog ~chaos_network_loss ~chaos_cpu_hog ~chaos_container_kill ~platform ~volume_hostpath_not_found ~privileged ~increase_capacity ~decrease_capacity ~install_script_helm ~helm_chart_valid ~helm_chart_published "cnf-config=./sample-cnfs/sample-coredns-cnf/cnf-testsuite.yml" verbose`
+    response_s = `./cnf-testsuite all ~reasonable_startup_time ~reasonable_image_size ~disk_fill ~pod_delete ~pod_io_stress ~pod_network_latency ~pod_network_corruption ~pod_memory_hog ~chaos_network_loss ~chaos_cpu_hog ~chaos_container_kill ~platform ~volume_hostpath_not_found ~privileged ~increase_capacity ~decrease_capacity ~install_script_helm ~helm_chart_valid ~helm_chart_published "cnf-config=./sample-cnfs/sample-coredns-cnf/cnf-testsuite.yml" verbose`
     LOGGING.info response_s
     (/PASSED: Helm readiness probe found/ =~ response_s).should_not be_nil
     (/PASSED: Helm liveness probe/ =~ response_s).should_not be_nil

--- a/spec/cnf_testsuite_all/cnf_testsuite_microservice_spec.cr
+++ b/spec/cnf_testsuite_all/cnf_testsuite_microservice_spec.cr
@@ -15,7 +15,7 @@ describe CnfTestSuite do
 
   it "'testsuite all' should run all the microservice tests", tags: ["testsuite-microservice"] do
     `./cnf-testsuite samples_cleanup`
-    response_s = `./cnf-testsuite all ~disk_fill ~pod-delete ~pod_network_latency ~pod_io_stress ~pod_memory_hog ~chaos_network_loss ~chaos_cpu_hog ~chaos_container_kill ~platform ~volume_hostpath_not_found ~privileged ~increase_capacity ~decrease_capacity ~ip_addresses ~liveness ~readiness ~rolling_update ~rolling_downgrade ~rolling_version_change ~nodeport_not_used ~hardcoded_ip_addresses_in_k8s_runtime_configuration ~install_script_helm ~helm_chart_valid ~helm_chart_published ~rollback ~secrets_used ~immutable_configmap "cnf-config=./sample-cnfs/sample-coredns-cnf/cnf-testsuite.yml" verbose`
+    response_s = `./cnf-testsuite all ~disk_fill ~pod-delete ~pod_network_latency ~pod_network_corruption ~pod_io_stress ~pod_memory_hog ~chaos_network_loss ~chaos_cpu_hog ~chaos_container_kill ~platform ~volume_hostpath_not_found ~privileged ~increase_capacity ~decrease_capacity ~ip_addresses ~liveness ~readiness ~rolling_update ~rolling_downgrade ~rolling_version_change ~nodeport_not_used ~hardcoded_ip_addresses_in_k8s_runtime_configuration ~install_script_helm ~helm_chart_valid ~helm_chart_published ~rollback ~secrets_used ~immutable_configmap "cnf-config=./sample-cnfs/sample-coredns-cnf/cnf-testsuite.yml" verbose`
     LOGGING.info response_s
     (/Final workload score:/ =~ response_s).should_not be_nil
     (/Final score:/ =~ response_s).should_not be_nil

--- a/spec/workload/resilience/pod_network_corruption_spec.cr
+++ b/spec/workload/resilience/pod_network_corruption_spec.cr
@@ -1,0 +1,30 @@
+require "../../spec_helper"
+require "colorize"
+require "../../../src/tasks/utils/utils.cr"
+require "../../../src/tasks/utils/system_information/helm.cr"
+require "file_utils"
+require "sam"
+
+describe "Resilience Pod Network corruption Chaos" do
+  before_all do
+    `./cnf-testsuite setup`
+    `./cnf-testsuite configuration_file_setup`
+    $?.success?.should be_true
+  end
+
+  it "'pod_network_corruption' A 'Good' CNF should not crash when network corruption occurs", tags: ["pod_network_corruption"]  do
+    begin
+      `./cnf-testsuite cnf_setup cnf-config=sample-cnfs/sample-coredns-cnf/cnf-testsuite.yml`
+      $?.success?.should be_true
+      response_s = `./cnf-testsuite pod_network_corruption verbose`
+      LOGGING.info response_s
+      $?.success?.should be_true
+      (/PASSED: pod_network_corruption chaos test passed/ =~ response_s).should_not be_nil
+    ensure
+      `./cnf-testsuite cnf_cleanup cnf-config=sample-cnfs/sample-coredns-cnf/cnf-testsuite.yml`
+      $?.success?.should be_true
+      `./cnf-testsuite uninstall_litmus`
+      $?.success?.should be_true
+    end
+  end
+end

--- a/src/tasks/litmus_cleanup.cr
+++ b/src/tasks/litmus_cleanup.cr
@@ -15,9 +15,9 @@ task "uninstall_litmus" do |_, args|
     )
     if args.named["offline"]?
       Log.info { "install litmus offline mode" }
-      KubectlClient::Delete.file("#{OFFLINE_MANIFESTS_PATH}/litmus-operator-v1.13.8.yaml")
+      KubectlClient::Delete.file("#{OFFLINE_MANIFESTS_PATH}/litmus-operator-v2.0.0.yaml")
     else
-      KubectlClient::Delete.file("https://litmuschaos.github.io/litmus/litmus-operator-v1.13.8.yaml")
+      KubectlClient::Delete.file("https://litmuschaos.github.io/litmus/litmus-operator-v2.0.0.yaml")
     end
     Log.info { "#{stdout}" if check_verbose(args) }
     Log.info { "#{stderr}" if check_verbose(args) }

--- a/src/tasks/litmus_setup.cr
+++ b/src/tasks/litmus_setup.cr
@@ -8,11 +8,11 @@ desc "Install LitmusChaos"
 task "install_litmus" do |_, args|
   if args.named["offline"]?
     LOGGING.info "install litmus offline mode"
-    AirGap.image_pull_policy("#{OFFLINE_MANIFESTS_PATH}/litmus-operator-v1.13.8.yaml")
-    KubectlClient::Apply.file("#{OFFLINE_MANIFESTS_PATH}/litmus-operator-v1.13.8.yaml")
+    AirGap.image_pull_policy("#{OFFLINE_MANIFESTS_PATH}/litmus-operator-v2.0.0.yaml")
+    KubectlClient::Apply.file("#{OFFLINE_MANIFESTS_PATH}/litmus-operator-v2.0.0.yaml")
     KubectlClient::Apply.file("#{OFFLINE_MANIFESTS_PATH}/chaos_crds.yaml")
   else
-    KubectlClient::Apply.file("https://litmuschaos.github.io/litmus/litmus-operator-v1.13.8.yaml")
+    KubectlClient::Apply.file("https://litmuschaos.github.io/litmus/litmus-operator-v2.0.0.yaml")
   end
 end
 


### PR DESCRIPTION
Signed-off-by: udit <udit@chaosnative.com>

## Description

#### This PR includes:
- Add Litmus Pod Network Corruption Experiment
  - Pod Network Corruption Injects packet corruption on the specified container by starting a traffic control (tc) process with netem rules to add egress packet corruption. The application can test the CNF application's resilience to a lossy/flaky networks.

- Update Litmus to the latest version as of now which is 2.0.0
- Update litmus docs link to point the latest docs.

## Issues:
Refs: https://github.com/cncf/cnf-testsuite/issues/499 && https://github.com/cncf/cnf-testsuite/issues/956

## How has this been tested:
 - [ ] Covered by existing integration testing
 - [ ] Added integration testing to cover
 - [ ] Verified all A/C passes
     * [ ] develop
     * [ ] master
     * [ ] tag/other branch
 - [ ] Test environment
    * [ ] Shared Packet K8s cluster
    * [ ] New Packet K8s cluster
    * [ ] Kind cluster
 - [ ] Have not tested

## Types of changes:
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [ ] Documentation update

## Checklist:
**Documentation**
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] No updates required.

**Code Review**
- [ ] Does the test handle fatal exceptions, ie. rescue block

**Issue**
- [ ] Tasks in issue are checked off