### PR TITLE
Fix bug with the platform:observability test. #971

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -122,7 +122,9 @@ jobs:
         echo "RUNNER RATE LIMIT: $ANONYMOUS_RUNNER_RATE_LIMIT"
         echo "CLUSTER RATE LIMIT: $CLUSTER_RATE_LIMIT" 
         echo "DOCKER USER RATE LIMIT: $AUTH_RATE_LIMIT" 
-        LOG_LEVEL=info crystal spec --warnings none --tag ${{ matrix.spec }} -v
+    - name: Setup tmate session
+      uses: mxschmitt/action-tmate@v3
+        # LOG_LEVEL=info crystal spec --warnings none --tag ${{ matrix.spec }} -v
     - name: Delete Cluster
       if: ${{ always() }}
       run: |

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -122,16 +122,9 @@ jobs:
         echo "RUNNER RATE LIMIT: $ANONYMOUS_RUNNER_RATE_LIMIT"
         echo "CLUSTER RATE LIMIT: $CLUSTER_RATE_LIMIT" 
         echo "DOCKER USER RATE LIMIT: $AUTH_RATE_LIMIT" 
-        echo "export DOCKERHUB_USERNAME=$DOCKERHUB_USERNAME" >> test.file
-        echo "export DOCKERHUB_PASSWORD=$DOCKERHUB_PASSWORD" >> test.file
-        echo "export PROTECTED_IMAGE_REPO=$PROTECTED_IMAGE_REPO" >> test.file
-        echo "export PROTECTED_DOCKERHUB_EMAIL=$PROTECTED_DOCKERHUB_EMAIL" >> test.file
-        echo "export PROTECTED_DOCKERHUB_USERNAME=$DOCKERHUB_USERNAME" >> test.file
-        echo "export PROTECTED_DOCKERHUB_PASSWORD=$DOCKERHUB_PASSWORD" >> test.file
 
-    - name: Setup tmate session
-      uses: mxschmitt/action-tmate@v3
-        # LOG_LEVEL=info crystal spec --warnings none --tag ${{ matrix.spec }} -v
+        LOG_LEVEL=info crystal spec --warnings none --tag ${{ matrix.spec }} -v
+
     - name: Delete Cluster
       if: ${{ always() }}
       run: |

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -122,6 +122,13 @@ jobs:
         echo "RUNNER RATE LIMIT: $ANONYMOUS_RUNNER_RATE_LIMIT"
         echo "CLUSTER RATE LIMIT: $CLUSTER_RATE_LIMIT" 
         echo "DOCKER USER RATE LIMIT: $AUTH_RATE_LIMIT" 
+        echo "export DOCKERHUB_USERNAME=$DOCKERHUB_USERNAME" >> test.file
+        echo "export DOCKERHUB_PASSWORD=$DOCKERHUB_PASSWORD" >> test.file
+        echo "export PROTECTED_IMAGE_REPO=$PROTECTED_IMAGE_REPO" >> test.file
+        echo "export PROTECTED_DOCKERHUB_EMAIL=$PROTECTED_DOCKERHUB_EMAIL" >> test.file
+        echo "export PROTECTED_DOCKERHUB_USERNAME=$DOCKERHUB_USERNAME" >> test.file
+        echo "export PROTECTED_DOCKERHUB_PASSWORD=$DOCKERHUB_PASSWORD" >> test.file
+
     - name: Setup tmate session
       uses: mxschmitt/action-tmate@v3
         # LOG_LEVEL=info crystal spec --warnings none --tag ${{ matrix.spec }} -v

--- a/utils/kubectl_client/kubectl_client.cr
+++ b/utils/kubectl_client/kubectl_client.cr
@@ -483,8 +483,12 @@ module KubectlClient
         return pod_ready == "true"
       when "replicaset", "deployment", "statefulset"
         desired = replica_count(kind, namespace, resource_name, "{.status.replicas}")
+        unavailable = replica_count(kind, namespace, resource_name, "{.status.unavailableReplicas}")
         current = replica_count(kind, namespace, resource_name, "{.status.readyReplicas}")
-        Log.info { "current_replicas: #{current}, desired_replicas: #{desired}" }
+        Log.info { "current_replicas: #{current}, desired_replicas: #{desired}, unavailable_replicas: #{unavailable}"  }
+        if desired == 0 && unavailable >= 1
+          return false
+        end
         return current == desired
       when "daemonset"
         desired = replica_count(kind, namespace, resource_name, "{.status.desiredNumberScheduled}")


### PR DESCRIPTION
## Description
The platform:observability test currently has a bug where the cnf gets initialised too quickly and reports the desired replicas as 0, subsequently resulting in the cnf being incorrectly reported as 'running', causing the spec to fail. This PR fixes this bug by updating the 'ready' check to also watch for 'unavailable' replicas, and if any are found to keep looping.

## Issues:
Refs: cncf/cnf-testsuite#971 

## How has this been tested:
 - [ ] Covered by existing integration testing
 - [ ] Added integration testing to cover
 - [ ] Verified all A/C passes
     * [ ] develop
     * [ ] master
     * [ ] tag/other branch
 - [ ] Test environment
    * [ ] Shared Packet K8s cluster
    * [ ] New Packet K8s cluster
    * [ ] Kind cluster
 - [ ] Have not tested

## Types of changes:
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [ ] Documentation update

## Checklist:
**Documentation**
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] No updates required.

**Code Review**
- [ ] Does the test handle fatal exceptions, ie. rescue block

**Issue**
- [ ] Tasks in issue are checked off
