### PR TITLE
[bug/307] Updates to platform.cr and configuration_lifecycle.cr

### DIFF
--- a/spec/platform/observability_spec.cr
+++ b/spec/platform/observability_spec.cr
@@ -33,7 +33,7 @@ describe "Observability" do
       pod_ready_timeout = 45
       until (pod_ready == "true" || pod_ready_timeout == 0)
         pod_ready = KubectlClient::Get.pod_status("node-exporter-prometheus").split(",")[2]
-        puts "Pod Ready Status: #{pod_ready}"
+        Log.info { "Pod Ready Status: #{pod_ready}" }
         sleep 1
         pod_ready_timeout = pod_ready_timeout - 1
       end

--- a/src/cnf-testsuite.cr
+++ b/src/cnf-testsuite.cr
@@ -107,7 +107,7 @@ begin
   yaml = File.open("#{CNFManager::Points::Results.file}") do |file|
     YAML.parse(file)
   end
-  LOGGING.debug "results yaml: #{yaml}"
+  Log.debug { "results yaml: #{yaml}" }
   if (yaml["exit_code"]) == 1
     exit 1
   end

--- a/src/tasks/cri_setup.cr
+++ b/src/tasks/cri_setup.cr
@@ -15,12 +15,12 @@ task "install_cri_tools" do |_, args|
   pod_ready_timeout = 45
   until (pod_ready == "true" || pod_ready_timeout == 0)
     pod_ready = KubectlClient::Get.pod_status("cri-tools").split(",")[2]
-    puts "Pod Ready Status: #{pod_ready}"
+    Log.info { "Pod Ready Status: #{pod_ready}" }
     sleep 1
     pod_ready_timeout = pod_ready_timeout - 1
   end
   cri_tools_pod = KubectlClient::Get.pod_status("cri-tools").split(",")[0]
-  LOGGING.debug "cri_tools_pod: #{cri_tools_pod}"
+  Log.debug { "cri_tools_pod: #{cri_tools_pod}" }
 end
 
 desc "Uninstall CNF Test Suite CRI Tools"

--- a/src/tasks/cri_setup.cr
+++ b/src/tasks/cri_setup.cr
@@ -10,7 +10,6 @@ require "./utils/utils.cr"
 desc "Install CNF Test Suite CRI Tools"
 task "install_cri_tools" do |_, args|
   File.write("cri_tools.yml", CRI_TOOLS)
-  # install_cri_tools = `kubectl create -f cri_tools.yml`
   KubectlClient::Apply.file("cri_tools.yml")
   pod_ready = ""
   pod_ready_timeout = 45

--- a/src/tasks/platform/observability.cr
+++ b/src/tasks/platform/observability.cr
@@ -89,7 +89,7 @@ namespace "platform" do
         pod_ready_timeout = 45
         until (pod_ready == "true" || pod_ready_timeout == 0)
           pod_ready = KubectlClient::Get.pod_status("cri-tools").split(",")[2]
-          puts "Pod Ready Status: #{pod_ready}"
+          Log.info { "Pod Ready Status: #{pod_ready}" }
           sleep 1
           pod_ready_timeout = pod_ready_timeout - 1
         end
@@ -272,7 +272,7 @@ end
         pod_ready_timeout = 45
         until (pod_ready == "true" || pod_ready_timeout == 0)
           pod_ready = KubectlClient::Get.pod_status("cri-tools").split(",")[2]
-          puts "Pod Ready Status: #{pod_ready}"
+          Log.info { "Pod Ready Status: #{pod_ready}" }
           sleep 1
           pod_ready_timeout = pod_ready_timeout - 1
         end

--- a/src/tasks/platform/platform.cr
+++ b/src/tasks/platform/platform.cr
@@ -27,23 +27,44 @@ task "k8s_conformance" do |_, args|
     sonobuoy = "#{current_dir}/#{TOOLS_DIR}/sonobuoy/sonobuoy"
 
     # Clean up old results
-    delete = `#{sonobuoy} delete --all --wait`
-    VERBOSE_LOGGING.info delete if check_verbose(args)
+    delete_cmd = "#{sonobuoy} delete --all --wait"
+    Process.run(
+      delete_cmd,
+      shell: true,
+      output: delete_stdout = IO::Memory.new,
+      error: delete_stderr = IO::Memory.new
+    )
+    Log.for("verbose").info { delete_stdout } if check_verbose(args)
 
     # Run the tests
-    testrun = ""
-    VERBOSE_LOGGING.info ENV["CRYSTAL_ENV"]? if check_verbose(args)
+    testrun_stdout = IO::Memory.new
+    Log.for("verbose").info { "CRYSTAL_ENV: #{ENV["CRYSTAL_ENV"]?}" } if check_verbose(args)
     if ENV["CRYSTAL_ENV"]? == "TEST"
-      LOGGING.info("Running Sonobuoy using Quick Mode")
-      testrun = `#{sonobuoy} run --wait --mode quick`
+      Log.info { "Running Sonobuoy using Quick Mode" }
+      cmd = "#{sonobuoy} run --wait --mode quick"
+      Process.run(
+        cmd,
+        shell: true,
+        output: testrun_stdout,
+        error: testrun_stderr = IO::Memory.new
+      )
     else
-      LOGGING.info("Running Sonobuoy Conformance")
-      testrun = `#{sonobuoy} run --wait`
+      Log.info { "Running Sonobuoy Conformance" }
+      cmd = "#{sonobuoy} run --wait"
+      Process.run(
+        cmd,
+        shell: true,
+        output: testrun_stdout,
+        error: testrun_stderr = IO::Memory.new
+      )
     end
-    VERBOSE_LOGGING.info testrun if check_verbose(args)
+    Log.for("verbose").info { testrun_stdout.to_s } if check_verbose(args)
 
-    results = `results=$(#{sonobuoy} retrieve); #{sonobuoy} results $results`
-    VERBOSE_LOGGING.info results if check_verbose(args)
+    cmd = "results=$(#{sonobuoy} retrieve); #{sonobuoy} results $results"
+    results_stdout = IO::Memory.new
+    Process.run(cmd, shell: true, output: results_stdout, error: results_stdout)
+    results = results_stdout.to_s
+    Log.for("verbose").info { results } if check_verbose(args)
 
     # Grab the failed line from the results
 
@@ -55,13 +76,12 @@ task "k8s_conformance" do |_, args|
       upsert_passed_task("k8s_conformance", "✔️  PASSED: K8s conformance test has no failures")
     end
   rescue ex
-    LOGGING.error ex.message
+    Log.error { ex.message }
     ex.backtrace.each do |x|
-      LOGGING.error x
+      Log.error { x }
     end
   ensure
-    remove_tar = `rm *sonobuoy*.tar.gz`
-    VERBOSE_LOGGING.debug remove_tar if check_verbose(args)
+    FileUtils.rm_rf(Dir.glob("*sonobuoy*.tar.gz"))
   end
 end
 
@@ -69,13 +89,13 @@ desc "Is Cluster Api available and managing a cluster?"
 task "clusterapi_enabled" do |_, args|
   CNFManager::Task.task_runner(args) do
     unless check_poc(args)
-      LOGGING.info "skipping clusterapi_enabled: not in poc mode"
+      Log.info { "skipping clusterapi_enabled: not in poc mode" }
       puts "SKIPPED: ClusterAPI Enabled".colorize(:yellow)
       next
     end
 
-    VERBOSE_LOGGING.info "clusterapi_enabled" if check_verbose(args)
-    LOGGING.info("clusterapi_enabled args #{args.inspect}")
+    Log.for("verbose").info { "clusterapi_enabled" } if check_verbose(args)
+    Log.info { "clusterapi_enabled args #{args.inspect}" }
 
     # We test that the namespaces for cluster resources exist by looking for labels
     # I found those by running
@@ -84,14 +104,20 @@ task "clusterapi_enabled" do |_, args|
     # https://cluster-api.sigs.k8s.io/clusterctl/commands/init.html#additional-information
 
     # this indicates that cluster-api is installed
-    clusterapi_namespaces_output = `kubectl get namespaces --selector clusterctl.cluster.x-k8s.io -o json`
-    clusterapi_namespaces_json = JSON.parse(clusterapi_namespaces_output)
-
-    LOGGING.info("clusterapi_namespaces_json: #{clusterapi_namespaces_json}")
+    clusterapi_namespaces_json = KubectlClient::Get.namespaces(
+      "--selector clusterctl.cluster.x-k8s.io"
+    )
+    Log.info { "clusterapi_namespaces_json: #{clusterapi_namespaces_json}" }
 
     # check that a node is actually being manageed
     # TODO: suppress msg in the case that this resource does-not-exist which is what happens when cluster-api is not installed
-    clusterapi_control_planes_output = `kubectl get kubeadmcontrolplanes.controlplane.cluster.x-k8s.io -o json`
+    cmd = "kubectl get kubeadmcontrolplanes.controlplane.cluster.x-k8s.io -o json"
+    Process.run(
+      cmd,
+      shell: true,
+      output: clusterapi_control_planes_output = IO::Memory.new,
+      error: stderr = IO::Memory.new
+    )
 
     proc_clusterapi_control_planes_json = -> do
       begin
@@ -103,7 +129,7 @@ task "clusterapi_enabled" do |_, args|
     end
 
     clusterapi_control_planes_json = proc_clusterapi_control_planes_json.call
-    LOGGING.info("clusterapi_control_planes_json: #{clusterapi_control_planes_json}")
+    Log.info { "clusterapi_control_planes_json: #{clusterapi_control_planes_json}" }
 
     emoji_control="✨"
     if clusterapi_namespaces_json["items"]? && clusterapi_namespaces_json["items"].as_a.size > 0 && clusterapi_control_planes_json["items"]? && clusterapi_control_planes_json["items"].as_a.size > 0

--- a/src/tasks/platform/platform.cr
+++ b/src/tasks/platform/platform.cr
@@ -121,7 +121,7 @@ task "clusterapi_enabled" do |_, args|
 
     proc_clusterapi_control_planes_json = -> do
       begin
-        JSON.parse(clusterapi_control_planes_output)
+        JSON.parse(clusterapi_control_planes_output.to_s)
       rescue JSON::ParseException
         # resource does-not-exist rescue to empty json
         JSON.parse("{}")
@@ -132,6 +132,7 @@ task "clusterapi_enabled" do |_, args|
     Log.info { "clusterapi_control_planes_json: #{clusterapi_control_planes_json}" }
 
     emoji_control="✨"
+
     if clusterapi_namespaces_json["items"]? && clusterapi_namespaces_json["items"].as_a.size > 0 && clusterapi_control_planes_json["items"]? && clusterapi_control_planes_json["items"].as_a.size > 0
       resp = upsert_passed_task("clusterapi_enabled", "✔️ Cluster API is enabled #{emoji_control}")
     else

--- a/src/tasks/platform/resilience.cr
+++ b/src/tasks/platform/resilience.cr
@@ -62,9 +62,9 @@ namespace "platform" do
         until (pod_ready == "false" || node_ready == "False" || node_ready == "Unknown" || node_failure_timeout == 0)
           pod_ready = KubectlClient::Get.pod_status("node-failure").split(",")[2]
           node_ready = KubectlClient::Get.node_status("#{worker_node}")
-          puts "Waiting for Node to go offline"
-          puts "Pod Ready Status: #{pod_ready}"
-          puts "Node Ready Status: #{node_ready}"
+          Log.info { "Waiting for Node to go offline" }
+          Log.info { "Pod Ready Status: #{pod_ready}" }
+          Log.info { "Node Ready Status: #{node_ready}" }
           node_failure_timeout = node_failure_timeout - 1
           if node_failure_timeout == 0
             upsert_failed_task("worker_reboot_recovery", "✖️  FAILED: Node failed to go offline")
@@ -80,9 +80,9 @@ namespace "platform" do
         until (pod_ready == "true" && node_ready == "True" || node_online_timeout == 0)
           pod_ready = KubectlClient::Get.pod_status("node-failure", "").split(",")[2]
           node_ready = KubectlClient::Get.node_status("#{worker_node}")
-          puts "Waiting for Node to come back online"
-          puts "Pod Ready Status: #{pod_ready}"
-          puts "Node Ready Status: #{node_ready}"
+          Log.info { "Waiting for Node to come back online" }
+          Log.info { "Pod Ready Status: #{pod_ready}" }
+          Log.info { "Node Ready Status: #{node_ready}" }
           node_online_timeout = node_online_timeout - 1
           if node_online_timeout == 0
             upsert_failed_task("worker_reboot_recovery", "✖️  FAILED: Node failed to come back online")

--- a/src/tasks/workload/configuration_lifecycle.cr
+++ b/src/tasks/workload/configuration_lifecycle.cr
@@ -407,7 +407,7 @@ task "hardcoded_ip_addresses_in_k8s_runtime_configuration" do |_, args|
     helm = BinarySingleton.helm
     VERBOSE_LOGGING.info "Helm Path: #{helm}" if check_verbose(args)
 
-    create_namespace = `kubectl create namespace hardcoded-ip-test`
+    KubectlClient::Create.command("namespace hardcoded-ip-test")
     unless helm_chart.empty?
       if args.named["offline"]?
         info = AirGap.tar_info_by_config_src(helm_chart)
@@ -432,7 +432,8 @@ task "hardcoded_ip_addresses_in_k8s_runtime_configuration" do |_, args|
     else
       upsert_failed_task("hardcoded_ip_addresses_in_k8s_runtime_configuration", "✖️  FAILED: Hard-coded IP addresses found in the runtime K8s configuration")
     end
-    delete_namespace = `kubectl delete namespace hardcoded-ip-test --force --grace-period 0 2>&1 >/dev/null`
+    result = KubectlClient::Delete.command("namespace hardcoded-ip-test --force --grace-period 0")
+    result[:status].success?
   rescue
     upsert_skipped_task("hardcoded_ip_addresses_in_k8s_runtime_configuration", "✖️  SKIPPED: unknown exception")
   end
@@ -562,24 +563,22 @@ task "immutable_configmap" do |_, args|
     test_config_map_filename = "#{destination_cnf_dir}/test_config_map.yml";
 
     template = Crinja.render(configmap_template, { "test_url" => "doesnt_matter" })
-    LOGGING.debug "test immutable_configmap template: #{template}"
-    test_config_map_create = `echo "#{template}" > "#{test_config_map_filename}"`
-    VERBOSE_LOGGING.debug "#{test_config_map_create}" if check_verbose(args)
-
+    Log.debug { "test immutable_configmap template: #{template}" }
+    File.write(test_config_map_filename, template)
     KubectlClient::Apply.file(test_config_map_filename)
 
     # now we change then apply again
 
     template = Crinja.render(configmap_template, { "test_url" => "doesnt_matter_again" })
-    LOGGING.debug "test immutable_configmap change template: #{template}"
-    test_config_map_create = `echo "#{template}" > "#{test_config_map_filename}"`
-    VERBOSE_LOGGING.debug "test_config_map_create: #{test_config_map_create}" if check_verbose(args)
+    Log.debug { "test immutable_configmap change template: #{template}" }
+    File.write(test_config_map_filename, template)
 
     immutable_configmap_supported = true
     # if the reapply with a change succedes immmutable configmaps is NOT enabled
     # if KubectlClient::Apply.file(test_config_map_filename) == 0
-    if KubectlClient::Apply.file(test_config_map_filename)
-      LOGGING.info "kubectl apply failed for: #{test_config_map_filename}"
+    apply_result = KubectlClient::Apply.file(test_config_map_filename)
+    if apply_result[:status].success?
+      Log.info { "kubectl apply failed for: #{test_config_map_filename}" }
       k8s_ver = KubectlClient.server_version
       if version_less_than(k8s_ver, "1.19.0")
         resp = "✖️  SKIPPED: immmutable configmaps are not supported in this k8s cluster.".colorize(:yellow)
@@ -597,8 +596,8 @@ task "immutable_configmap" do |_, args|
     resp = ""
     emoji_probe="⚖️"
     cnf_manager_workload_resource_task_response = CNFManager.workload_resource_test(args, config, check_containers=false, check_service=true) do |resource, containers, volumes, initialized|
-      LOGGING.info "resource: #{resource}"
-      LOGGING.info "volumes: #{volumes}"
+      Log.info { "resource: #{resource}" }
+      Log.info { "volumes: #{volumes}" }
 
       config_maps_json = KubectlClient::Get.configmaps
 

--- a/src/tasks/workload/configuration_lifecycle.cr
+++ b/src/tasks/workload/configuration_lifecycle.cr
@@ -432,10 +432,10 @@ task "hardcoded_ip_addresses_in_k8s_runtime_configuration" do |_, args|
     else
       upsert_failed_task("hardcoded_ip_addresses_in_k8s_runtime_configuration", "✖️  FAILED: Hard-coded IP addresses found in the runtime K8s configuration")
     end
-    result = KubectlClient::Delete.command("namespace hardcoded-ip-test --force --grace-period 0")
-    result[:status].success?
   rescue
     upsert_skipped_task("hardcoded_ip_addresses_in_k8s_runtime_configuration", "✖️  SKIPPED: unknown exception")
+  ensure
+    KubectlClient::Delete.command("namespace hardcoded-ip-test --force --grace-period 0")
   end
 end
 

--- a/src/tasks/workload/resilience.cr
+++ b/src/tasks/workload/resilience.cr
@@ -244,10 +244,7 @@ task "pod_network_corruption", ["install_litmus"] do |_, args|
         chaos_result_name = "#{test_name}-#{chaos_experiment_name}"
 
         template = Crinja.render(chaos_template_pod_network_corruption, {"chaos_experiment_name"=> "#{chaos_experiment_name}", "deployment_label" => "#{KubectlClient::Get.resource_spec_labels(resource["kind"], resource["name"]).as_h.first_key}", "deployment_label_value" => "#{KubectlClient::Get.resource_spec_labels(resource["kind"], resource["name"]).as_h.first_value}", "test_name" => test_name,"total_chaos_duration" => total_chaos_duration})
-        chaos_config = `echo "#{template}" > "#{destination_cnf_dir}/#{chaos_experiment_name}-chaosengine.yml"`
-        puts "#{chaos_config}" if check_verbose(args)
-        # run_chaos = `kubectl apply -f "#{destination_cnf_dir}/#{chaos_experiment_name}-chaosengine.yml"`
-        # puts "#{run_chaos}" if check_verbose(args)
+        File.write("#{destination_cnf_dir}/#{chaos_experiment_name}-chaosengine.yml", template)
         KubectlClient::Apply.file("#{destination_cnf_dir}/#{chaos_experiment_name}-chaosengine.yml")
         LitmusManager.wait_for_test(test_name,chaos_experiment_name,total_chaos_duration,args)
         test_passed = LitmusManager.check_chaos_verdict(chaos_result_name,chaos_experiment_name,args)


### PR DESCRIPTION
## Changes to fix #307

* Replace backticks with Process.run in configuration_lifecycle.cr and resilience.cr
* Move namespace deletion to the ensure block to avoid clashing with the Task runner return type

## Changes to fix #987

Fix issues with cluster_api_setup
* Once the commands are run, cd back to current dir.
* Remove duplicate KubectlClient::Apply.file line (wait_for_instlal_by_apply already runs apply).
* When control planes is fetched, convert the output to string before parsing json.

## Issues

* #307
* #987

## How has this been tested:
 - [x] Covered by existing integration testing
 - [ ] Added integration testing to cover
 - [ ] Verified all A/C passes
     * [ ] develop
     * [ ] master
     * [ ] tag/other branch
 - [ ] Test environment
    * [ ] Shared Packet K8s cluster
    * [ ] New Packet K8s cluster
    * [ ] Kind cluster
 - [ ] Have not tested

## Types of changes:
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [ ] Documentation update

## Checklist:
**Documentation**
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] No updates required.

**Code Review**
- [ ] Does the test handle fatal exceptions, ie. rescue block

**Issue**
- [ ] Tasks in issue are checked off
