### PR TITLE
Run no_local_volume_configuration as a dependency for state workload task

### DIFF
--- a/src/tasks/workload/statelessness.cr
+++ b/src/tasks/workload/statelessness.cr
@@ -7,7 +7,7 @@ require "../utils/utils.cr"
 require "kubectl_client"
 
 desc "The CNF test suite checks if state is stored in a custom resource definition or a separate database (e.g. etcd) rather than requiring local storage.  It also checks to see if state is resilient to node failure"
-task "state", ["volume_hostpath_not_found"] do |_, args|
+task "state", ["volume_hostpath_not_found", "no_local_volume_configuration"] do |_, args|
   stdout_score("state")
 end
 


### PR DESCRIPTION
## Description
State task was not running the no_local_volume_configuration test. This fixes it by adding the test/task as a dependency of the state test.

![CleanShot 2021-10-04 at 20 01 23@2x](https://user-images.githubusercontent.com/84005/135870665-c11a6e4a-a375-42ca-a145-8addb47a5776.png)


## Issues:
Refs: #984

## How has this been tested:
 - [x] Covered by existing integration testing
 - [ ] Added integration testing to cover
 - [ ] Verified all A/C passes
     * [ ] develop
     * [ ] master
     * [ ] tag/other branch
 - [ ] Test environment
    * [ ] Shared Packet K8s cluster
    * [ ] New Packet K8s cluster
    * [ ] Kind cluster
 - [ ] Have not tested

## Types of changes:
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [ ] Documentation update

## Checklist:
**Documentation**
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] No updates required.

**Code Review**
- [ ] Does the test handle fatal exceptions, ie. rescue block

**Issue**
- [ ] Tasks in issue are checked off
