### PR TITLE
Use GITHUB_TOKEN provided by GitHub Actions

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -963,10 +963,9 @@ jobs:
       run: chmod +x ./cnf-testsuite
     - name: Publish Release
       env:
-        GITHUB_USER: ${{ secrets.GH_USER }}
-        GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        if [ -z "${GITHUB_USER+x}" ] || [ -z "${GITHUB_TOKEN+x}" ]; then
+        if [ -z "${GITHUB_TOKEN+x}" ]; then
           exit 0
         else
           ./cnf-testsuite upsert_release

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -90,8 +90,7 @@ jobs:
     - name: Run Crystal Spec
       env:
         FALCO_ENV: CI
-        GITHUB_USER: ${{ secrets.GH_USER }}
-        GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         DOCKERHUB_USERNAMES: ${{ secrets.DOCKERHUB_USERNAMES }}
         DOCKERHUB_PASSWORDS: ${{ secrets.DOCKERHUB_PASSWORDS }}
         DOCKERHUB_EMAIL: ${{ secrets.DOCKERHUB_EMAIL }}
@@ -533,14 +532,14 @@ jobs:
         fi
     - name: Create Cluster & Run Tests.
       env:
-        GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         export DIR=$(uuidgen)
         echo "export DIR=$DIR" > dir.env
         mkdir /shared/$DIR
         # Create Airgapped Tar
         #DOTO Use pre-created airgapped.tar.gz
-        # wget --auth-no-challenge --header='Accept:application/octet-stream' https://$GITHUB_TOKEN:@api.github.com/repos/cncf/cnf-testsuite/releases/assets/38092818 -O airgapped.tar.gz
+        # wget --auth-no-challenge --header='Accept:application/octet-stream' -H "Authorization: Bearer $GITHUB_TOKEN" https://api.github.com/repos/cncf/cnf-testsuite/releases/assets/38092818 -O airgapped.tar.gz
         cp -a $(pwd) /shared/$DIR/cnf-testsuite
         cp /tmp/airgapped.tar.gz /shared/$DIR/
         sed -i "/versioned_tag/a \ \ required: true" embedded_files/points.yml
@@ -616,7 +615,7 @@ jobs:
         mkdir /shared/$DIR
         # Create Airgapped Tar
         #DOTO Use pre-created airgapped.tar.gz
-        # wget --auth-no-challenge --header='Accept:application/octet-stream' https://$GITHUB_TOKEN:@api.github.com/repos/cncf/cnf-testsuite/releases/assets/38092818 -O airgapped.tar.gz
+        # wget --auth-no-challenge --header='Accept:application/octet-stream' -H "Authorization: Bearer $GITHUB_TOKEN" https://api.github.com/repos/cncf/cnf-testsuite/releases/assets/38092818 -O airgapped.tar.gz
         cp -a $(pwd) /shared/$DIR/cnf-testsuite
         cp /tmp/airgapped.tar.gz /shared/$DIR/
         docker run --entrypoint=/bin/bash --name $DIR-shards -v /shared/$DIR/cnf-testsuite:/cnf-testsuite -t $OFFLINE_IMAGE -c "shards install"

--- a/spec/utils/release_manager_spec.cr
+++ b/spec/utils/release_manager_spec.cr
@@ -33,16 +33,16 @@ describe "ReleaseManager" do
   end
 
   it "'#ReleaseManager::GithubReleaseManager.github_releases' should return the existing releases", tags: ["release"]  do
-    if ENV["GITHUB_USER"]?.nil?
-      puts "Warning: Set GITHUB_USER and GITHUB_TOKEN to activate release manager tests!".colorize(:red) 
+    if ENV["GITHUB_TOKEN"]?.nil?
+      puts "Warning: Set GITHUB_TOKEN to activate release manager tests!".colorize(:red)
     else 
       ((ReleaseManager::GithubReleaseManager.github_releases.size) > 0).should be_true
     end
   end
 
   it "'#ReleaseManager::GithubReleaseManager.upsert_release' should return the upserted release and asset response", tags: ["release"]  do
-    if ENV["GITHUB_USER"]?.nil?
-      puts "Warning: Set GITHUB_USER and GITHUB_TOKEN to activate release manager tests!".colorize(:red) 
+    if ENV["GITHUB_TOKEN"]?.nil?
+      puts "Warning: Set GITHUB_TOKEN to activate release manager tests!".colorize(:red)
     else 
       found_release, asset = ReleaseManager::GithubReleaseManager.upsert_release("test_version")
       if asset
@@ -59,8 +59,8 @@ describe "ReleaseManager" do
   end
 
   it "'#ReleaseManager::GithubReleaseManager.delete_release' should delete the release from the found_id", tags: ["release"]  do
-    if ENV["GITHUB_USER"]?.nil?
-      puts "Warning: Set GITHUB_USER and GITHUB_TOKEN to activate release manager tests!".colorize(:red) 
+    if ENV["GITHUB_TOKEN"]?.nil?
+      puts "Warning: Set GITHUB_TOKEN to activate release manager tests!".colorize(:red)
     else 
       found_release, asset = ReleaseManager::GithubReleaseManager.upsert_release("test_version")
       # wait for upsert to finish
@@ -79,8 +79,8 @@ describe "ReleaseManager" do
   end
 
   it "'#ReleaseManager.latest_release' should return latest release", tags: ["release"] do
-    if ENV["GITHUB_USER"]?.nil?
-      puts "Warning: Set GITHUB_USER and GITHUB_TOKEN to activate release manager tests!".colorize(:red) 
+    if ENV["GITHUB_TOKEN"]?.nil?
+      puts "Warning: Set GITHUB_TOKEN to activate release manager tests!".colorize(:red)
     else 
       issues = ReleaseManager.latest_release
       # https://github.com/semver/semver/blob/master/semver.md#is-v123-a-semantic-version
@@ -89,8 +89,8 @@ describe "ReleaseManager" do
   end
 
   it "'#ReleaseManager.latest_snapshot' should return the latest snapshot", tags: ["release"]  do
-    if ENV["GITHUB_USER"]?.nil?
-      puts "Warning: Set GITHUB_USER and GITHUB_TOKEN to activate release manager tests!".colorize(:red) 
+    if ENV["GITHUB_TOKEN"]?.nil?
+      puts "Warning: Set GITHUB_TOKEN to activate release manager tests!".colorize(:red)
     else 
       issues = ReleaseManager.latest_snapshot
       # https://github.com/semver/semver/blob/master/semver.md#is-v123-a-semantic-version
@@ -100,8 +100,8 @@ describe "ReleaseManager" do
 
 
   it "'#ReleaseManager.issue_title' should return issue title", tags: ["release"]  do
-    if ENV["GITHUB_USER"]?.nil?
-      puts "Warning: Set GITHUB_USER and GITHUB_TOKEN to activate release manager tests!".colorize(:red) 
+    if ENV["GITHUB_TOKEN"]?.nil?
+      puts "Warning: Set GITHUB_TOKEN to activate release manager tests!".colorize(:red)
     else 
       issues = ReleaseManager.issue_title("#318")
       (issues.match(/#206 documentation update/)).should_not be_nil

--- a/src/tasks/cleanup.cr
+++ b/src/tasks/cleanup.cr
@@ -29,7 +29,7 @@ task "samples_cleanup", ["sample_coredns_cleanup", "cleanup_sample_coredns", "ba
 end
 
 desc "Cleans up the CNF Test Suite helper tools and containers"
-task "tools_cleanup", ["helm_local_cleanup", "sonobuoy_cleanup", "uninstall_chaosmesh","uninstall_litmus", "uninstall_dockerd"] do  |_, args|
+task "tools_cleanup", ["helm_local_cleanup", "sonobuoy_cleanup", "uninstall_chaosmesh","uninstall_litmus", "uninstall_dockerd", "uninstall_kubescape"] do  |_, args|
 end
 
 desc "Cleans up the CNF Test Suite sample projects, helper tools, and containers"

--- a/src/tasks/constants.cr
+++ b/src/tasks/constants.cr
@@ -16,6 +16,7 @@ DEFAULT_POINTSFILENAME = "points_v1.yml"
 PRIVILEGED_WHITELIST_CONTAINERS = ["chaos-daemon"]
 SONOBUOY_K8S_VERSION = "0.19.0"
 KUBESCAPE_VERSION = "1.0.97"
+KUBESCAPE_FRAMEWORK_VERSION = "1.0.79"
 KIND_VERSION = "0.11.1"
 SONOBUOY_OS = "linux"
 IGNORED_SECRET_TYPES = ["kubernetes.io/service-account-token", "kubernetes.io/dockercfg", "kubernetes.io/dockerconfigjson", "helm.sh/release.v1"]

--- a/src/tasks/kubescape_setup.cr
+++ b/src/tasks/kubescape_setup.cr
@@ -42,6 +42,7 @@ task "install_kubescape" do |_, args|
 
         # Download framework file using Github token if the GITHUB_TOKEN env var is present
         framework_path = "#{current_dir}/#{TOOLS_DIR}/kubescape/nsa.json"
+        asset_url = "https://github.com/armosec/regolibrary/releases/download/v#{KUBESCAPE_FRAMEWORK_VERSION}/nsa"
         if ENV.has_key?("GITHUB_TOKEN")
           Halite.auth("Bearer #{ENV["GITHUB_TOKEN"]}").get(asset_url) do |response|
             File.write(framework_path, response.body_io)

--- a/src/tasks/kubescape_setup.cr
+++ b/src/tasks/kubescape_setup.cr
@@ -6,7 +6,7 @@ require "./utils/utils.cr"
 require "retriable"
 
 desc "Sets up Kubescape in the K8s Cluster"
-task "install_kubescape", ["uninstall_kubescape"] do |_, args|
+task "install_kubescape" do |_, args|
   Log.info {"install_kubescape"}
   # version = `curl --silent "https://api.github.com/repos/armosec/kubescape/releases/latest" | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/'`
   current_dir = FileUtils.pwd 

--- a/src/tasks/kubescape_setup.cr
+++ b/src/tasks/kubescape_setup.cr
@@ -39,7 +39,19 @@ task "install_kubescape" do |_, args|
         status = Process.run("chmod +x #{write_file}", shell: true, output: stderr, error: stderr)
         success = status.success?
         raise "Unable to make #{write_file} executable" if success == false
-        `#{current_dir}/#{TOOLS_DIR}/kubescape/kubescape download framework nsa --output #{current_dir}/#{TOOLS_DIR}/kubescape/nsa.json`
+
+        # Download framework file using Github token if the GITHUB_TOKEN env var is present
+        framework_path = "#{current_dir}/#{TOOLS_DIR}/kubescape/nsa.json"
+        if ENV.has_key?("GITHUB_TOKEN")
+          Halite.auth("Bearer #{ENV["GITHUB_TOKEN"]}").get(asset_url) do |response|
+            File.write(framework_path, response.body_io)
+          end
+        else
+          Halite.get(asset_url) do |response|
+            File.write(framework_path, response.body_io)
+          end
+        end
+
       end
     end
   end

--- a/src/tasks/utils/release_manager.cr
+++ b/src/tasks/utils/release_manager.cr
@@ -244,7 +244,7 @@ TEMPLATE
       #           "Content-Type" => "application/gzip",
       #           "Content-Length" => File.size("#{cnf_tarball_name}").to_s
       #   }, raw: "#{File.open("#{cnf_tarball_name}")}")A
-    asset_resp = `curl --http1.1 -u #{ENV["GITHUB_USER"]}:#{ENV["GITHUB_TOKEN"]} -H "Content-Type: $(file -b --mime-type #{asset_name})" --data-binary @#{asset_name} "https://uploads.github.com/repos/cncf/cnf-testsuite/releases/#{release_id}/assets?name=$(basename #{asset_name})"`
+    asset_resp = `curl --http1.1 -H "Authorization: Bearer #{ENV["GITHUB_TOKEN"]}" -H "Content-Type: $(file -b --mime-type #{asset_name})" --data-binary @#{asset_name} "https://uploads.github.com/repos/cncf/cnf-testsuite/releases/#{release_id}/assets?name=$(basename #{asset_name})"`
     LOGGING.info "asset_resp: #{asset_resp}"
     asset = JSON.parse(asset_resp.strip)
     LOGGING.info "asset: #{asset}"
@@ -273,14 +273,14 @@ TEMPLATE
   end
 
   def self.latest_release
-    resp = `curl -u #{ENV["GITHUB_USER"]}:#{ENV["GITHUB_TOKEN"]} --silent "https://api.github.com/repos/cncf/cnf-testsuite/releases/latest"`
+    resp = `curl -H "Authorization: Bearer #{ENV["GITHUB_TOKEN"]}" --silent "https://api.github.com/repos/cncf/cnf-testsuite/releases/latest"`
     LOGGING.info "latest_release: #{resp}"
     parsed_resp = JSON.parse(resp)
     parsed_resp["tag_name"]?.not_nil!.to_s
   end
 
   def self.latest_snapshot
-    resp = `curl -u #{ENV["GITHUB_USER"]}:#{ENV["GITHUB_TOKEN"]} --silent "https://api.github.com/repos/cncf/cnf-testsuite/releases"`
+    resp = `curl -H "Authorization: Bearer #{ENV["GITHUB_TOKEN"]}" --silent "https://api.github.com/repos/cncf/cnf-testsuite/releases"`
     LOGGING.info "latest_release: #{resp}"
     parsed_resp = JSON.parse(resp)
     prerelease = parsed_resp.as_a.select{ | x | x["prerelease"]==true && !("#{x["published_at"]?}".empty?) }
@@ -304,7 +304,7 @@ TEMPLATE
 
   def self.issue_title(issue_number)
     pure_issue = issue_number.gsub("#", "")
-    resp = `curl -u #{ENV["GITHUB_USER"]}:#{ENV["GITHUB_TOKEN"]} "https://api.github.com/repos/cncf/cnf-testsuite/issues/#{pure_issue}"`
+    resp = `curl -H "Authorization: Bearer #{ENV["GITHUB_TOKEN"]}" "https://api.github.com/repos/cncf/cnf-testsuite/issues/#{pure_issue}"`
     # LOGGING.info "issue_text: #{resp}"
     parsed_resp = JSON.parse(resp)
     parsed_resp["title"]?.not_nil!.to_s


### PR DESCRIPTION
This PR contains two fixes.

# [[1077](https://github.com/cncf/cnf-testsuite/issues/1077)] Use GitHub token provided by GitHub Actions

* This replaces usage of `GH_USER` and `GH_TOKEN` secrets configured in the GitHub repo.
* This avoids having to use any personal GitHub token and does not require refreshing this token frequently to prevent build failures.

There are commented `curl` lines that have been updated in `actions.yml`. This was intentional to ensure that incase we use them it would still be valid. We could remove these commented lines later if we do not intend to use them.

# [[1034](https://github.com/cncf/cnf-testsuite/issues/1034)] Resolve kubescape framework download errors

This fix for kubescape download errors was required to get the build passing for the primary issue in the PR (1077)

### 1. Remove `uninstall_kubescape` from the dependent tasks for `install_kubescape` (reason explained below)

([Example failing build for reference](https://github.com/cncf/cnf-testsuite/runs/4076895387?check_suite_focus=true))

* The `install_kubescape` task in the main branch depends on the `uninstall_kubescape` task.
  * NEEDS REVIEW: It would help if someone can confirm that removing this dependency is fine (just to ensure that the task dependency wasn't added intentionally).
* This means that for every spec `it "hello world"; end` block that invokes any of the kubescape tests like `./cnf-testsuite insecure_capabilities`,
  + It would uninstall_kubescape first
  + Run `install_kubescape`
  + Then run the `kubescape_scan`

So even though the `install_kubescape` task has a check to not download kubescape if the dir already exists, this code path will never be triggered - because it always uninstalls/deletes kubescape dir before `install_kubescape` is run. Due to this behaviour, the kubescape cli tool and the framework would have to be downloaded all over again for every spec that is run. And therefore making additional calls to github (kubescape and the framework are both downloaded from Github).

### 2. Use direct GitHub asset url to download kubescape framework.

* Using the direct asset url to download the framework allows us to use the `GITHUB_TOKEN` provided by GitHub Actions.
* This does not impact use of `install_kubescape` task outside of GitHub Actions as we now use the GitHub Token for authentication only if available (we check for the GITHUB_TOKEN env var)

## Issues:
Refs: #1034, #1077

## How has this been tested:
 - [x] Covered by existing integration testing
 - [ ] Added integration testing to cover
 - [ ] Verified all A/C passes
     * [ ] develop
     * [ ] master
     * [ ] tag/other branch
 - [ ] Test environment
    * [ ] Shared Packet K8s cluster
    * [ ] New Packet K8s cluster
    * [ ] Kind cluster
 - [ ] Have not tested

## Types of changes:
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [ ] Documentation update

## Checklist:
**Documentation**
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] No updates required.

**Code Review**
- [ ] Does the test handle fatal exceptions, ie. rescue block

**Issue**
- [ ] Tasks in issue are checked off
