### PR TITLE
[1099] Pass --all-containers when fetching logs for the log_output test

### DIFF
--- a/src/tasks/workload/observability.cr
+++ b/src/tasks/workload/observability.cr
@@ -17,7 +17,7 @@ task "log_output" do |_, args|
       test_passed = false
       case resource["kind"].as_s.downcase
       when "replicaset", "deployment", "statefulset", "pod", "daemonset"
-        result = KubectlClient.logs("#{resource["kind"]}/#{resource["name"]}", "--tail=5 --prefix=true")
+        result = KubectlClient.logs("#{resource["kind"]}/#{resource["name"]}", "--all-containers --tail=5 --prefix=true")
         Log.for("Log lines").info { result[:output] }
         if result[:output].size > 0
           test_passed = true


### PR DESCRIPTION
## Description
* Identified #1099 when working on #41 (was fetching logs for a multi-container pod).
* Fixed #1099 in this PR by passing the `--all-containers` flag.

## Issues:
Refs: #1099 

## How has this been tested:
 - [x] Covered by existing integration testing
 - [ ] Added integration testing to cover
 - [ ] Verified all A/C passes
     * [ ] develop
     * [ ] master
     * [ ] tag/other branch
 - [ ] Test environment
    * [ ] Shared Packet K8s cluster
    * [ ] New Packet K8s cluster
    * [ ] Kind cluster
 - [ ] Have not tested

## Types of changes:
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [ ] Documentation update

## Checklist:
**Documentation**
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] No updates required.

**Code Review**
- [ ] Does the test handle fatal exceptions, ie. rescue block

**Issue**
- [ ] Tasks in issue are checked off
