### PR TITLE
Contributor meetings at 15:15 UTC

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Welcome! We gladly accept contributions on new tests, example CNFs, updates to d
   - [#cnf-testsuite-dev](https://cloud-native.slack.com/archives/C014TNCEX8R)
 - Join the weekly developer meetings
 
-  - Meetings every Thursday at 14:15 - 15:00 UTC
+  - Meetings every Thursday at 15:15 - 16:00 UTC
   - Meeting minutes are [here](https://docs.google.com/document/d/1IbrgjqIkOCvrrSG0DRE6X62UUZpBq-818Mn8q0nkkd0/edit)
 
 - Join the weekly [CNF Working Group meetings](https://github.com/cncf/cnf-wg#recurring-meetings)


### PR DESCRIPTION
## Description
- Daylight savings time has ended
- Thursday contributor meetings change from starting at 14:15 UTC to starting at 15:15 UTC

## Issues:
Refs: N/A documentation 

## How has this been tested:
 - [ ] Covered by existing integration testing
 - [ ] Added integration testing to cover
 - [ ] Verified all A/C passes
     * [ ] develop
     * [ ] master
     * [ ] tag/other branch
 - [ ] Test environment
    * [ ] Shared Packet K8s cluster
    * [ ] New Packet K8s cluster
    * [ ] Kind cluster
 - [x] Have not tested

## Types of changes:
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [x] Documentation update

## Checklist:
**Documentation**
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] No updates required.

**Code Review**
- [ ] Does the test handle fatal exceptions, ie. rescue block

**Issue**
- [ ] Tasks in issue are checked off
