### PR TITLE
Feat(Resiliency): Adding litmus pod dns error experiment

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -1057,6 +1057,12 @@ Sressing the disk with continuous and heavy IO can cause degradation in reads/ w
 ./cnf-testsuite node_drain
 ```
 
+#### :heavy_check_mark: Test if the CNF crashes when pod dns error occurs
+
+```
+./cnf-testsuite pod_dns_error
+```
+
 ### Platform Tests
 
 #### :heavy_check_mark: Run all platform tests

--- a/spec/cnf_testsuite_all/cnf_testsuite_config_lifecycle_spec.cr
+++ b/spec/cnf_testsuite_all/cnf_testsuite_config_lifecycle_spec.cr
@@ -15,7 +15,7 @@ describe CnfTestSuite do
 
  it "'testsuite all' should run the configuration lifecycle tests", tags: ["testsuite-config-lifecycle"] do
     `./cnf-testsuite samples_cleanup`
-    response_s = `./cnf-testsuite all ~reasonable_startup_time ~reasonable_image_size ~disk_fill ~pod_delete ~pod_io_stress ~pod_network_latency ~pod_network_corruption ~pod_network_duplication ~pod_memory_hog ~chaos_network_loss ~node_drain ~chaos_cpu_hog ~chaos_container_kill ~platform ~volume_hostpath_not_found ~privileged ~increase_capacity ~decrease_capacity ~install_script_helm ~helm_chart_valid ~helm_chart_published "cnf-config=./sample-cnfs/sample-coredns-cnf/cnf-testsuite.yml" verbose`
+    response_s = `./cnf-testsuite all ~reasonable_startup_time ~reasonable_image_size ~disk_fill ~pod_delete ~pod_io_stress ~pod_network_latency ~pod_network_corruption ~pod_network_duplication ~pod_memory_hog ~chaos_network_loss ~node_drain ~pod_dns_error ~chaos_cpu_hog ~chaos_container_kill ~platform ~volume_hostpath_not_found ~privileged ~increase_capacity ~decrease_capacity ~install_script_helm ~helm_chart_valid ~helm_chart_published "cnf-config=./sample-cnfs/sample-coredns-cnf/cnf-testsuite.yml" verbose`
     LOGGING.info response_s
     (/PASSED: Helm readiness probe found/ =~ response_s).should_not be_nil
     (/PASSED: Helm liveness probe/ =~ response_s).should_not be_nil

--- a/spec/cnf_testsuite_all/cnf_testsuite_microservice_spec.cr
+++ b/spec/cnf_testsuite_all/cnf_testsuite_microservice_spec.cr
@@ -15,7 +15,7 @@ describe CnfTestSuite do
 
   it "'testsuite all' should run all the microservice tests", tags: ["testsuite-microservice"] do
     `./cnf-testsuite samples_cleanup`
-    response_s = `./cnf-testsuite all ~disk_fill ~pod_delete ~pod_network_latency ~pod_network_corruption ~pod_network_duplication ~pod_io_stress ~pod_memory_hog ~node_drain ~chaos_network_loss ~chaos_cpu_hog ~chaos_container_kill ~platform ~volume_hostpath_not_found ~privileged ~increase_capacity ~decrease_capacity ~ip_addresses ~liveness ~readiness ~rolling_update ~rolling_downgrade ~rolling_version_change ~nodeport_not_used ~hostport_not_used ~hardcoded_ip_addresses_in_k8s_runtime_configuration ~install_script_helm ~helm_chart_valid ~helm_chart_published ~rollback ~secrets_used ~immutable_configmap "cnf-config=./sample-cnfs/sample-coredns-cnf/cnf-testsuite.yml" verbose`
+    response_s = `./cnf-testsuite all ~disk_fill ~pod_delete ~pod_network_latency ~pod_network_corruption ~pod_network_duplication ~pod_io_stress ~pod_memory_hog ~node_drain ~pod_dns_error ~chaos_network_loss ~chaos_cpu_hog ~chaos_container_kill ~platform ~volume_hostpath_not_found ~privileged ~increase_capacity ~decrease_capacity ~ip_addresses ~liveness ~readiness ~rolling_update ~rolling_downgrade ~rolling_version_change ~nodeport_not_used ~hostport_not_used ~hardcoded_ip_addresses_in_k8s_runtime_configuration ~install_script_helm ~helm_chart_valid ~helm_chart_published ~rollback ~secrets_used ~immutable_configmap "cnf-config=./sample-cnfs/sample-coredns-cnf/cnf-testsuite.yml" verbose`
     LOGGING.info response_s
     (/Final workload score:/ =~ response_s).should_not be_nil
     (/Final score:/ =~ response_s).should_not be_nil

--- a/spec/cnf_testsuite_all/cnf_testsuite_spec.cr
+++ b/spec/cnf_testsuite_all/cnf_testsuite_spec.cr
@@ -18,7 +18,7 @@ describe CnfTestSuite do
     # the workload resilience tests are run in the chaos specs
     # the ommisions (i.e. ~resilience) are done for performance reasons for the spec suite
     # response_s = `./cnf-testsuite all ~platform ~resilience cnf-config=./sample-cnfs/sample-coredns-cnf/cnf-testsuite.yml verbose`
-    response_s = `./cnf-testsuite all ~disk_fill ~pod_delete ~pod_network_latency ~pod_io_stress ~pod_network_duplication ~pod_network_corruption ~pod_memory_hog ~node_drain ~chaos_network_loss ~chaos_cpu_hog ~chaos_container_kill ~platform ~ip_addresses ~liveness ~readiness ~rolling_update ~rolling_downgrade ~rolling_version_change ~nodeport_not_used ~hostport_not_used ~hardcoded_ip_addresses_in_k8s_runtime_configuration ~rollback ~secrets_used ~immutable_configmap ~reasonable_startup_time ~reasonable_image_size "cnf-config=./sample-cnfs/sample-coredns-cnf/cnf-testsuite.yml" verbose`
+    response_s = `./cnf-testsuite all ~disk_fill ~pod_delete ~pod_network_latency ~pod_io_stress ~pod_network_duplication ~pod_network_corruption ~pod_memory_hog ~node_drain ~pod_dns_error ~chaos_network_loss ~chaos_cpu_hog ~chaos_container_kill ~platform ~ip_addresses ~liveness ~readiness ~rolling_update ~rolling_downgrade ~rolling_version_change ~nodeport_not_used ~hostport_not_used ~hardcoded_ip_addresses_in_k8s_runtime_configuration ~rollback ~secrets_used ~immutable_configmap ~reasonable_startup_time ~reasonable_image_size "cnf-config=./sample-cnfs/sample-coredns-cnf/cnf-testsuite.yml" verbose`
     LOGGING.info response_s
     (/Lint Passed/ =~ response_s).should_not be_nil
     (/PASSED: Replicas increased to 3/ =~ response_s).should_not be_nil

--- a/spec/workload/resilience/pod_dns_error_spec.cr
+++ b/spec/workload/resilience/pod_dns_error_spec.cr
@@ -1,0 +1,30 @@
+require "../../spec_helper"
+require "colorize"
+require "../../../src/tasks/utils/utils.cr"
+require "../../../src/tasks/utils/system_information/helm.cr"
+require "file_utils"
+require "sam"
+
+describe "Resilience pod dns error Chaos" do
+  before_all do
+    `./cnf-testsuite setup`
+    `./cnf-testsuite configuration_file_setup`
+    $?.success?.should be_true
+  end
+
+  it "'pod_dns_error' A 'Good' CNF should not crash when pod dns error occurs", tags: ["pod_dns_error"]  do
+    begin
+      `./cnf-testsuite cnf_setup cnf-config=example-cnfs/envoy/cnf-testsuite.yml`
+      $?.success?.should be_true
+      response_s = `./cnf-testsuite pod_dns_error verbose`
+      LOGGING.info response_s
+      $?.success?.should be_true
+      (/PASSED: pod_dns_error chaos test passed/ =~ response_s).should_not be_nil
+    ensure
+      `./cnf-testsuite cnf_setup cnf-config=example-cnfs/envoy/cnf-testsuite.yml`
+      $?.success?.should be_true
+      `./cnf-testsuite uninstall_litmus`
+      $?.success?.should be_true
+    end
+  end
+end

--- a/src/templates/chaos_templates/pod_dns_error.yml.ecr
+++ b/src/templates/chaos_templates/pod_dns_error.yml.ecr
@@ -1,0 +1,26 @@
+apiVersion: litmuschaos.io/v1alpha1
+kind: ChaosEngine
+metadata:
+  name: <%= @test_name %>
+  namespace: default
+spec:
+  engineState: "active"
+  jobCleanUpPolicy: 'delete'    
+  appinfo:
+    appns: "default"
+    applabel: '<%= @deployment_label %>=<%= @deployment_label_value %>'
+    appkind: "deployment"
+  chaosServiceAccount: <%= @chaos_experiment_name %>-sa
+  experiments:
+    - name: <%= @chaos_experiment_name %>
+      spec:
+        components:
+          env:
+            - name: TARGET_HOSTNAMES
+              value: ''
+
+            - name: TOTAL_CHAOS_DURATION
+              value: '<%= @total_chaos_duration %>'
+              
+            - name: TARGET_CONTAINER
+              value: "coredns"


### PR DESCRIPTION
Signed-off-by: Jonsy13 <vedant.shrotria@chaosnative.com>

## Description

**This PR contains:**

- Add litmus pod dns error experiment to test suite - https://litmuschaos.github.io/litmus/experiments/categories/pods/pod-dns-error/

**About pod dns error experiment and why do we need it?**

pod-dns-error injects chaos to disrupt dns resolution in kubernetes pods. It causes loss of access to services by blocking dns resolution of hostnames/domains. This will help to test if the CNF application survives the pod dns error chaos injection.

## Issues:
Refs: #NNN

## How has this been tested:
 - [ ] Covered by existing integration testing
 - [ ] Added integration testing to cover
 - [ ] Verified all A/C passes
     * [ ] develop
     * [ ] master
     * [ ] tag/other branch
 - [ ] Test environment
    * [ ] Shared Packet K8s cluster
    * [ ] New Packet K8s cluster
    * [ ] Kind cluster
 - [ ] Have not tested

## Types of changes:
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [ ] Documentation update

## Checklist:
**Documentation**
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] No updates required.

**Code Review**
- [ ] Does the test handle fatal exceptions, ie. rescue block

**Issue**
- [ ] Tasks in issue are checked off
