### PR TITLE
[BUG] Documentation Updates to add missing desc USAGE

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -233,9 +233,19 @@ crystal src/cnf-testsuite.cr api_snoop_general_apis
 ```
 
 #### :heavy_check_mark: To test if the CNF uses elastic volumes
+<details> <summary>Details for elastic volume</summary>
+<p>
+
+<b>Elastic Volume Details:</b> It's considered best practice to use elastic volumes for storage. Instead of local storage, the CNF should use elastic persistent volumes, which are available to all nodes (based on policy).
+
+<b>Remediation Steps:</b> Setup and use elastic persistent volumes instead of local storage.
+</p>
+
+</details>
+
 
 ```
-./cnf-testsuite elastic_volumes
+./cnf-testsuite elastic_volume
 ```
 
 <details> <summary>Details for State Tests To Do's</summary>

--- a/USAGE.md
+++ b/USAGE.md
@@ -882,7 +882,7 @@ For example, running `kubectl get logs` returns useful information for diagnosin
 </details>
 
 ```
-./cnf-testsuite open_metrics
+./cnf-testsuite tracing
 ```
 <details> <summary>Details for Observability Tests To Do's</summary>
 <p>


### PR DESCRIPTION
## Description
Need to add missing details for USAGE for `tracing` and `elastic_volume` tests.

## Issues:
Refs: #1149 #1150 #1081 #1025

## How has this been tested:
 - [ ] Covered by existing integration testing
 - [ ] Added integration testing to cover
 - [ ] Verified all A/C passes
     * [ ] develop
     * [ ] master
     * [ ] tag/other branch
 - [ ] Test environment
    * [ ] Shared Packet K8s cluster
    * [ ] New Packet K8s cluster
    * [ ] Kind cluster
 - [x] Have not tested

## Types of changes:
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [x] Documentation update

## Checklist:
**Documentation**
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] No updates required.

**Code Review**
- [ ] Does the test handle fatal exceptions, ie. rescue block

**Issue**
- [ ] Tasks in issue are checked off
