### PR TITLE
Improvements to resolve 1151, 1152, 1156 and 1157

### DIFF
--- a/src/tasks/utils/utils.cr
+++ b/src/tasks/utils/utils.cr
@@ -28,6 +28,11 @@ module ShellCmd
   end
 end
 
+def ensure_kubeconfig!
+  puts "KUBECONFIG is not set. Please set a KUBECONFIG, i.p 'export KUBECONFIG=path-to-your-kubeconfig'".colorize(:red) unless ENV.has_key?("KUBECONFIG")
+  raise "KUBECONFIG is not set. Please set a KUBECONFIG, i.p 'export KUBECONFIG=path-to-your-kubeconfig'" unless ENV.has_key?("KUBECONFIG")
+end
+
 def log_formatter
   Log::Formatter.new do |entry, io|
     progname = "cnf-testsuite"

--- a/src/tasks/utils/utils.cr
+++ b/src/tasks/utils/utils.cr
@@ -9,6 +9,25 @@ require "option_parser"
 require "../constants.cr"
 require "semantic_version"
 
+module ShellCmd
+  def self.run(cmd, log_prefix, force_output=false)
+    Log.info { "#{log_prefix} command: #{cmd}" }
+    status = Process.run(
+      cmd,
+      shell: true,
+      output: output = IO::Memory.new,
+      error: stderr = IO::Memory.new
+    )
+    if force_output == false
+      Log.debug { "#{log_prefix} output: #{output.to_s}" }
+    else
+      Log.info { "#{log_prefix} output: #{output.to_s}" }
+    end
+    Log.info { "#{log_prefix} stderr: #{stderr.to_s}" }
+    {status: status, output: output.to_s, error: stderr.to_s}
+  end
+end
+
 def log_formatter
   Log::Formatter.new do |entry, io|
     progname = "cnf-testsuite"

--- a/src/tasks/workload/compatibility.cr
+++ b/src/tasks/workload/compatibility.cr
@@ -10,88 +10,119 @@ task "compatibility", ["cni_compatible"] do |_, args|
   stdout_score("compatibility")
 end
 
-desc "Check if CNF compatible with multiple CNIs"
-task "cni_compatible" do |_, args|
-  # if args.named["offline"]? || args.raw.includes? "offline"
-  #     puts "offline mode cni_compatible skipped".colorize(:yellow) 
-  # else
-    CNFManager::Task.task_runner(args) do |args, config|
-      VERBOSE_LOGGING.info "cni_compatible" if check_verbose(args)
+def setup_calico_cluster(cluster_name : String, offline : Bool) : KindManager::Cluster
+  if offline
+    Log.info { "Running cni_compatible(Cluster Creation) in Offline Mode" }
 
-      puts "KUBECONFIG is not set. Please set a KUBECONFIG, i.p 'export KUBECONFIG=path-to-your-kubeconfig'".colorize(:red) unless ENV.has_key?("KUBECONFIG")
-      raise "KUBECONFIG is not set. Please set a KUBECONFIG, i.p 'export KUBECONFIG=path-to-your-kubeconfig'" unless ENV.has_key?("KUBECONFIG")
-      kubeconfig_orig = ENV["KUBECONFIG"]
-
-      if args.named["offline"]? && args.named["offline"]? != "false"
-        offline = true
-      else
-        offline = false 
-      end
-
-      if offline 
-        Log.info { "Running cni_compatible(Cluster Creation) in Offline Mode" }
-
-        chart_directory = "#{TarClient::TAR_REPOSITORY_DIR}/projectcalico_tigera-operator"
-        chart = Dir.entries("#{chart_directory}")[1]
-        status = `docker image load -i #{AirGap::TAR_BOOTSTRAP_IMAGES_DIR}/kind-node.tar`
-        Log.info { "#{status}" }
-        Log.info { "Installing Airgapped CNI Chart: #{chart_directory}/#{chart}" }
-        kubeconfig = KindManager.create_cluster("calico-test", "#{chart_directory}/#{chart} --namespace calico", true)
-        ENV["KUBECONFIG"]="#{kubeconfig}"
-        #TODO Don't bootstrap all images, only Calico & Cilium are needed.
-        if Dir.exists?("#{AirGap::TAR_BOOTSTRAP_IMAGES_DIR}")
-          AirGap.cache_images(kind_name: "calico-test-control-plane" )
-          AirGap.cache_images(cnf_setup: true, kind_name: "calico-test-control-plane" )
-        else
-          puts "Bootstrap directory is missing, please run ./cnf-testsuite setup offline=<path-to-your-airgapped.tar.gz>".colorize(:red)
-          raise "Bootstrap directory is missing, please run ./cnf-testsuite setup offline=<path-to-your-airgapped.tar.gz>"
-        end
-      else
-        Log.info { "Running cni_compatible(Cluster Creation) in Online Mode" }
-        Helm.helm_repo_add("projectcalico","https://docs.projectcalico.org/charts")
-        kubeconfig = KindManager.create_cluster("calico-test", "projectcalico/tigera-operator --version v3.20.2", false)
-      end
-      Log.info { "kubeconfig: #{kubeconfig}" }
-      calico_cnf_passed = CNFManager.cnf_to_new_cluster(config, kubeconfig, offline)
-      Log.info { "calico_cnf_passed: #{calico_cnf_passed}" }
-      puts "CNF failed to install on Calico CNI cluster".colorize(:red) unless calico_cnf_passed
-
-
-      if offline
-        chart_directory = "#{TarClient::TAR_REPOSITORY_DIR}/cilium_cilium"
-        chart = Dir.entries("#{chart_directory}")[2]
-        Log.info { "Installing Airgapped CNI Chart: #{chart_directory}/#{chart}" }
-
-        kubeconfig = KindManager.create_cluster("cilium-test", "#{chart_directory}/#{chart}  --namespace cilium --set operator.replicas=1 --set image.repository=cilium/cilium --set image.useDigest=false --set operator.image.useDigest=false --set operator.image.repository=cilium/operator", true)
-
-        ENV["KUBECONFIG"]="#{kubeconfig}"
-        if Dir.exists?("#{AirGap::TAR_BOOTSTRAP_IMAGES_DIR}")
-          AirGap.cache_images(kind_name: "cilium-test-control-plane" )
-          AirGap.cache_images(cnf_setup: true, kind_name: "cilium-test-control-plane" )
-        else
-          puts "Bootstrap directory is missing, please run ./cnf-testsuite setup offline=<path-to-your-airgapped.tar.gz>".colorize(:red)
-          raise "Bootstrap directory is missing, please run ./cnf-testsuite setup offline=<path-to-your-airgapped.tar.gz>"
-        end
-      else
-        Helm.helm_repo_add("cilium","https://helm.cilium.io/")
-        kubeconfig = KindManager.create_cluster("cilium-test", "cilium/cilium --version 1.10.5 --set operator.replicas=1 --set image.repository=cilium/cilium --set image.useDigest=false --set operator.image.useDigest=false --set operator.image.repository=cilium/operator", false)
-      end
-      Log.info { "kubeconfig: #{kubeconfig}" }
-      cilium_cnf_passed = CNFManager.cnf_to_new_cluster(config, kubeconfig, offline)
-      Log.info { "cilium_cnf_passed: #{cilium_cnf_passed}" }
-      puts "CNF failed to install on Cilum CNI cluster".colorize(:red) unless cilium_cnf_passed
-
-      emoji_security="🔓🔑"
-      if calico_cnf_passed && cilium_cnf_passed 
-        upsert_passed_task("cni_compatible", "✔️  PASSED: CNF compatible with both Calico and Cilium #{emoji_security}")
-      else
-        upsert_failed_task("cni_compatible", "✖️  FAILED: CNF not compatible with either Calico or Cillium #{emoji_security}")
-      end
-    ensure
-      KindManager.delete_cluster("calico-test")
-      KindManager.delete_cluster("cilium-test")
-      ENV["KUBECONFIG"]="#{kubeconfig_orig}"
+    chart_directory = "#{TarClient::TAR_REPOSITORY_DIR}/projectcalico_tigera-operator"
+    chart = Dir.entries("#{chart_directory}")[1]
+    status = `docker image load -i #{AirGap::TAR_BOOTSTRAP_IMAGES_DIR}/kind-node.tar`
+    Log.info { "#{status}" }
+    Log.info { "Installing Airgapped CNI Chart: #{chart_directory}/#{chart}" }
+    calico_cluster = KindManager.create_cluster_with_chart_and_wait(
+      cluster_name,
+      KindManager.disable_cni_config,
+      "#{chart_directory}/#{chart} --namespace calico",
+      offline
+    )
+    ENV["KUBECONFIG"]="#{calico_cluster.kubeconfig}"
+    #TODO Don't bootstrap all images, only Calico & Cilium are needed.
+    if Dir.exists?("#{AirGap::TAR_BOOTSTRAP_IMAGES_DIR}")
+      AirGap.cache_images(kind_name: "calico-test-control-plane" )
+      AirGap.cache_images(cnf_setup: true, kind_name: "calico-test-control-plane" )
+    else
+      puts "Bootstrap directory is missing, please run ./cnf-testsuite setup offline=<path-to-your-airgapped.tar.gz>".colorize(:red)
+      raise "Bootstrap directory is missing, please run ./cnf-testsuite setup offline=<path-to-your-airgapped.tar.gz>"
     end
+  else
+    Log.info { "Running cni_compatible(Cluster Creation) in Online Mode" }
+    Helm.helm_repo_add("projectcalico","https://docs.projectcalico.org/charts")
+    calico_cluster = KindManager.create_cluster_with_chart_and_wait(
+      cluster_name,
+      KindManager.disable_cni_config,
+      "projectcalico/tigera-operator --version v3.20.2",
+      offline
+    )
+  end
+
+  return calico_cluster
 end
 
+def setup_cilium_cluster(cluster_name : String, offline : Bool) : KindManager::Cluster
+  chart_opts = [
+    "--set operator.replicas=1",
+    "--set image.repository=cilium/cilium",
+    "--set image.useDigest=false",
+    "--set operator.image.useDigest=false",
+    "--set operator.image.repository=cilium/operator"
+  ]
 
+  kind_manager = KindManager.new
+  cluster = kind_manager.create_cluster(cluster_name, KindManager.disable_cni_config, offline)
+
+  if offline
+    chart_directory = "#{TarClient::TAR_REPOSITORY_DIR}/cilium_cilium"
+    chart = Dir.entries("#{chart_directory}")[2]
+    Log.info { "Installing Airgapped CNI Chart: #{chart_directory}/#{chart}" }
+
+    chart = "#{chart_directory}/#{chart}"
+    Helm.install("#{cluster_name}-plugin #{chart} #{chart_opts.join(" ")} --namespace kube-system --kubeconfig #{cluster.kubeconfig}")
+
+    ENV["KUBECONFIG"]="#{cluster.kubeconfig}"
+    if Dir.exists?("#{AirGap::TAR_BOOTSTRAP_IMAGES_DIR}")
+      AirGap.cache_images(kind_name: "cilium-test-control-plane" )
+      AirGap.cache_images(cnf_setup: true, kind_name: "cilium-test-control-plane" )
+    else
+      puts "Bootstrap directory is missing, please run ./cnf-testsuite setup offline=<path-to-your-airgapped.tar.gz>".colorize(:red)
+      raise "Bootstrap directory is missing, please run ./cnf-testsuite setup offline=<path-to-your-airgapped.tar.gz>"
+    end
+  else
+    Helm.helm_repo_add("cilium","https://helm.cilium.io/")
+    chart = "cilium/cilium"
+    chart_opts.push("--version 1.10.5")
+    Helm.install("#{cluster_name}-plugin #{chart} #{chart_opts.join(" ")} --namespace kube-system --kubeconfig #{cluster.kubeconfig}")
+  end
+
+  cluster.wait_until_pods_ready()
+  Log.info { "cilium kubeconfig: #{cluster.kubeconfig}" }
+  return cluster
+end
+
+desc "Check if CNF compatible with multiple CNIs"
+task "cni_compatible" do |_, args|
+  CNFManager::Task.task_runner(args) do |args, config|
+    Log.for("verbose").info { "cni_compatible" } if check_verbose(args)
+
+    ensure_kubeconfig!
+    kubeconfig_orig = ENV["KUBECONFIG"]
+
+    if args.named["offline"]? && args.named["offline"]? != "false"
+      offline = true
+    else
+      offline = false
+    end
+
+    calico_cluster = setup_calico_cluster("calico-test", offline)
+    Log.info { "calico kubeconfig: #{calico_cluster.kubeconfig}" }
+    calico_cnf_passed = CNFManager.cnf_to_new_cluster(config, calico_cluster.kubeconfig, offline)
+    Log.info { "calico_cnf_passed: #{calico_cnf_passed}" }
+    puts "CNF failed to install on Calico CNI cluster".colorize(:red) unless calico_cnf_passed
+
+    cilium_cluster = setup_cilium_cluster("cilium-test", offline)
+    cilium_cnf_passed = CNFManager.cnf_to_new_cluster(config, cilium_cluster.kubeconfig, offline)
+    Log.info { "cilium_cnf_passed: #{cilium_cnf_passed}" }
+    puts "CNF failed to install on Cilium CNI cluster".colorize(:red) unless cilium_cnf_passed
+
+    emoji_security="🔓🔑"
+    if calico_cnf_passed && cilium_cnf_passed
+      upsert_passed_task("cni_compatible", "✔️  PASSED: CNF compatible with both Calico and Cilium #{emoji_security}")
+    else
+      upsert_failed_task("cni_compatible", "✖️  FAILED: CNF not compatible with either Calico or Cillium #{emoji_security}")
+    end
+  ensure
+    kind_manager = KindManager.new
+    kind_manager.delete_cluster("calico-test")
+    kind_manager.delete_cluster("cilium-test")
+    ENV["KUBECONFIG"]="#{kubeconfig_orig}"
+  end
+end

--- a/utils/kubectl_client/kubectl_client.cr
+++ b/utils/kubectl_client/kubectl_client.cr
@@ -18,7 +18,7 @@ module KubectlClient
   OCI_RUNTIME_REGEX = /containerd|docker|runc|railcar|crun|rkt|gviso|nabla|runv|clearcontainers|kata|cri-o/i
 
   module ShellCmd
-    def self.run(cmd, log_prefix)
+    def self.run(cmd, log_prefix, force_output=false)
       Log.info { "#{log_prefix} command: #{cmd}" }
       status = Process.run(
         cmd,
@@ -26,7 +26,11 @@ module KubectlClient
         output: output = IO::Memory.new,
         error: stderr = IO::Memory.new
       )
-      Log.debug { "#{log_prefix} output: #{output.to_s}" }
+      if force_output == false
+        Log.debug { "#{log_prefix} output: #{output.to_s}" }
+      else
+        Log.info { "#{log_prefix} output: #{output.to_s}" }
+      end
       Log.info { "#{log_prefix} stderr: #{stderr.to_s}" }
       {status: status, output: output.to_s, error: stderr.to_s}
     end

--- a/utils/kubectl_client/kubectl_client.cr
+++ b/utils/kubectl_client/kubectl_client.cr
@@ -75,17 +75,9 @@ module KubectlClient
 
   def self.server_version()
     Log.debug { "KubectlClient.server_version" }
-    result = ShellCmd.run("kubectl version", "KubectlClient.server_version")
-
-    # example
-    # Server Version: version.Info{Major:"1", Minor:"18", GitVersion:"v1.18.16", GitCommit:"7a98bb2b7c9112935387825f2fce1b7d40b76236", GitTreeState:"clean", BuildDate:"2021-02-17T11:52:32Z", GoVersion:"go1.13.15", Compiler:"gc", Platform:"linux/amd64"}
-    resp = result[:output].match /Server Version: version.Info{(Major:"(([0-9]{1,3})"\, )Minor:"([0-9]{1,3}[+]?)")/
-    Log.debug { "KubectlClient.server_version match: #{resp}" }
-    if resp
-      version = "#{resp && resp.not_nil![3]}.#{resp && resp.not_nil![4]}.0"
-    else
-      version = ""
-    end
+    result = ShellCmd.run("kubectl version --output json", "KubectlClient.server_version", true)
+    version = JSON.parse(result[:output])["serverVersion"]["gitVersion"].as_s
+    version = version.gsub("v", "")
     Log.info { "KubectlClient.server_version: #{version}" }
     version
   end


### PR DESCRIPTION
This PR contains code contributions to resolve multiple issues (mentioned below).

## Changes for #1157
* Move to an object-based usage pattern to allow for holding paths as state.
* Add helper to wait for cluster nodes to be ready.
* Rename `KindManager.wait_for_cluster` to `KindManager#wait_until_pods_ready`. This update would impact cni_compatible test.
* Update `cni_compatible` test to use the new KindManager interface.
* Additionally, refactor `cni_compatible` test abstract out cilium and calico setup as functions.
* Add `ensure_kubeconfig!` helper to utils (helper to be re-used for issue-41).

## Changes for #1151
`KubectlClient.wait_until_pods_ready` now counts pods that have multiple instances separately.
This helps be able to detect pod readiness correctly.

## Changes for #1152
* For pod readiness, check pods in all namespaces instead of just kube-system.
* This helps because when kind cluster is started, apisnoop comes pre-installed in the default namespace.

## Changes for #1156
Update `KubectlClient.server_version` to parse server version from JSON output of command

## Other changes
* Add `ShellCmd.run` to main project to help with better logging & to avoid backticks.
* Add a `force_output` option to `KubectlClient::ShellCmd.run` to help with selectively log stdouts.

## Issues:
Refs: #1151, #1152, #1156 and #1157

## How has this been tested:
 - [x] Covered by existing integration testing
 - [ ] Added integration testing to cover
 - [ ] Verified all A/C passes
     * [ ] develop
     * [ ] master
     * [ ] tag/other branch
 - [ ] Test environment
    * [ ] Shared Packet K8s cluster
    * [ ] New Packet K8s cluster
    * [ ] Kind cluster
 - [ ] Have not tested

## Types of changes:
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [x] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [ ] Documentation update

## Checklist:
**Documentation**
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] No updates required.

**Code Review**
- [ ] Does the test handle fatal exceptions, ie. rescue block