### PR TITLE
[1168] Add new service_discovery test to microservice category

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -612,6 +612,12 @@ crystal src/cnf-testsuite.cr protected_access
 ./cnf-testsuite single_process_type
 ```
 
+#### :heavy_check_mark: To check if the CNF exposes any of its containers as a service
+
+```
+./cnf-testsuite service_discovery
+```
+
 ---
 
 ### Scalability Tests

--- a/USAGE.md
+++ b/USAGE.md
@@ -614,6 +614,16 @@ crystal src/cnf-testsuite.cr protected_access
 
 #### :heavy_check_mark: To check if the CNF exposes any of its containers as a service
 
+<details> <summary>Details for the service discovery test</summary>
+<p>
+
+<b>Service discovery:</b> For microservices to be accessible to other applications in the cluster, they should be exposed via a Service.
+
+<b>Remediation Steps:</b> Make sure the CNF exposes any of its containers as a Kubernetes Service. You can learn more about Kubernetes Service [here](https://kubernetes.io/docs/concepts/services-networking/service/).
+</p>
+
+</details>
+
 ```
 ./cnf-testsuite service_discovery
 ```

--- a/embedded_files/points.yml
+++ b/embedded_files/points.yml
@@ -13,6 +13,10 @@
   tags: microservice, dynamic, workload
 - name: single_process_type 
   tags: microservice, dynamic, workload
+- name: service_discovery
+  tags: microservice, dynamic, workload
+  pass: 5
+  fail: 0
 
 - name: cni_compatible
   tags: compatibility, dynamic, workload

--- a/spec/utils/cnf_manager_spec.cr
+++ b/spec/utils/cnf_manager_spec.cr
@@ -153,7 +153,7 @@ describe "SampleUtils" do
             "linux_hardening", "resource_policies",
             "immutable_file_systems", "hostpath_mounts", "log_output",
             "prometheus_traffic", "open_metrics",
-            "ingress_egress_blocked", "routed_logs", "tracing", "elastic_volumes", "alpha_k8s_apis"]
+            "ingress_egress_blocked", "routed_logs", "tracing", "elastic_volumes", "alpha_k8s_apis", "service_discovery"]
     (CNFManager::Points.all_task_test_names()).sort.should eq(tags.sort)
   end
 

--- a/spec/workload/microservice_spec.cr
+++ b/spec/workload/microservice_spec.cr
@@ -136,3 +136,29 @@ describe "Microservice" do
     dockerd_name_helper
   end
 end
+
+it "'service_discovery' should pass if any containers in the cnf are exposed as a service", tags: ["service_discovery"]  do
+  begin
+    Log.info { `./cnf-testsuite cnf_setup cnf-path=sample-cnfs/sample_coredns` }
+    response_s = `./cnf-testsuite service_discovery verbose`
+    Log.info { response_s }
+    $?.success?.should be_true
+    (/PASSED: Some containers exposed as a service/ =~ response_s).should_not be_nil
+  ensure
+    Log.info { `./cnf-testsuite cnf_cleanup cnf-path=sample-cnfs/sample_coredns` }
+    $?.success?.should be_true
+  end
+end
+
+it "'service_discovery' should fail if no containers in the cnf are exposed as a service", tags: ["service_discovery"]  do
+  begin
+    Log.info { `./cnf-testsuite cnf_setup cnf-path=sample-cnfs/sample_nonroot` }
+    response_s = `./cnf-testsuite service_discovery verbose`
+    Log.info { response_s }
+    $?.success?.should be_true
+    (/FAILED: No containers exposed as a service/ =~ response_s).should_not be_nil
+  ensure
+    Log.info { `./cnf-testsuite cnf_cleanup cnf-path=sample-cnfs/sample_nonroot` }
+    $?.success?.should be_true
+  end
+end

--- a/src/tasks/workload/microservice.cr
+++ b/src/tasks/workload/microservice.cr
@@ -10,7 +10,7 @@ require "halite"
 require "totem"
 
 desc "The CNF test suite checks to see if CNFs follows microservice principles"
-task "microservice", ["reasonable_image_size", "reasonable_startup_time", "single_process_type"] do |_, args|
+task "microservice", ["reasonable_image_size", "reasonable_startup_time", "single_process_type", "service_discovery"] do |_, args|
   stdout_score("microservice")
 end
 

--- a/utils/kubectl_client/kubectl_client.cr
+++ b/utils/kubectl_client/kubectl_client.cr
@@ -234,6 +234,17 @@ module KubectlClient
       JSON.parse(result[:output])
     end
 
+    def self.endpoints(all_namespaces=false) : K8sManifest
+      option = all_namespaces ? "--all-namespaces" : ""
+      cmd = "kubectl get endpoints #{option} -o json"
+      result = ShellCmd.run(cmd, "KubectlClient::Get.endpoints")
+      response = result[:output]
+      if result[:status].success? && !response.empty?
+        return JSON.parse(response)
+      end
+      JSON.parse(%({}))
+    end
+
     def self.pods(all_namespaces=true) : K8sManifest 
       option = all_namespaces ? "--all-namespaces" : ""
       cmd = "kubectl get pods #{option} -o json"


### PR DESCRIPTION
## Description

This PR:
* Adds new `service_discovery` test to microservice category (pass: 5pts, fail: 0pts)
* Updates documentation for the test
* Updates points.yml
* Adds appropriate positive and negative spec tests

A previous implementation of this test required an endpoints helper in KubectlClient. I've retained it as is for the future.

### Test output with "sample_coredns" CNF

This CNF has a service that exposes a pod and should pass.

<img width="1129" alt="image" src="https://user-images.githubusercontent.com/84005/150548828-7a196e06-d0cc-4107-afcc-5f14cb6bd226.png">

### Test output with "sample_nonroot" CNF

This CNF has no service and should fail.

<img width="1251" alt="image" src="https://user-images.githubusercontent.com/84005/150549324-3c6c418f-eecf-4c4f-a21f-818a4a6bbb08.png">


## Issues:
Refs: #1168

## How has this been tested:
 - [] Covered by existing integration testing
 - [x] Added integration testing to cover
 - [ ] Verified all A/C passes
     * [ ] develop
     * [ ] master
     * [ ] tag/other branch
 - [ ] Test environment
    * [ ] Shared Packet K8s cluster
    * [ ] New Packet K8s cluster
    * [ ] Kind cluster
 - [ ] Have not tested

## Types of changes:
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [x] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [x] Documentation update

## Checklist:
**Documentation**
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] No updates required.

**Code Review**
- [ ] Does the test handle fatal exceptions, ie. rescue block

**Issue**
- [ ] Tasks in issue are checked off
