### PR TITLE
[1079] Remove cleanup all CNFs when samples_cleanup is run

### DIFF
--- a/src/tasks/cleanup.cr
+++ b/src/tasks/cleanup.cr
@@ -17,7 +17,13 @@ task "samples_cleanup" do  |_, args|
   end
 
   CNFManager::Task.all_cnfs_task_runner(args) do |task_args, config|
-    config = CNFManager.parsed_config_file(CNFManager.ensure_cnf_testsuite_yml_path(task_args["cnf-config"]))
+    Log.info { "Task args: #{task_args.inspect}" }
+    next unless task_args["cnf-config"]?
+
+    cnf_config_file = task_args["cnf-config"].as(String)
+    cnf_config_file = CNFManager.ensure_cnf_testsuite_yml_path(cnf_config_file)
+
+    config = CNFManager.parsed_config_file(cnf_config_file)
     install_method = CNFManager.cnf_installation_method(config)
     if install_method[0] == Helm::InstallMethod::ManifestDirectory
       installed_from_manifest = true
@@ -25,8 +31,14 @@ task "samples_cleanup" do  |_, args|
       installed_from_manifest = false
     end
 
-    Log.info { "CNF CONFIG: #{task_args["cnf-config"]}" }
-    # CNFManager.sample_cleanup(config_file: cnf, force: force, installed_from_manifest: installed_from_manifest, verbose: check_verbose(args))
+    Log.info { "CNF CONFIG: #{cnf_config_file}" }
+    CNFManager.sample_cleanup(
+      config_file: cnf_config_file,
+      force: force,
+      installed_from_manifest: installed_from_manifest,
+      verbose: check_verbose(args)
+    )
+    nil
   end
 end
 

--- a/src/tasks/cleanup.cr
+++ b/src/tasks/cleanup.cr
@@ -43,7 +43,7 @@ task "samples_cleanup" do  |_, args|
 end
 
 desc "Cleans up the CNF Test Suite helper tools and containers"
-task "tools_cleanup", ["helm_local_cleanup", "sonobuoy_cleanup", "uninstall_chaosmesh","uninstall_litmus", "uninstall_dockerd", "uninstall_kubescape"] do  |_, args|
+task "tools_cleanup", ["helm_local_cleanup", "sonobuoy_cleanup", "uninstall_chaosmesh","uninstall_litmus", "uninstall_dockerd", "uninstall_kubescape","uninstall_cluster_tools"] do  |_, args|
 end
 
 desc "Cleans up the CNF Test Suite sample projects, helper tools, and containers"

--- a/src/tasks/cluster_setup.cr
+++ b/src/tasks/cluster_setup.cr
@@ -15,7 +15,6 @@ end
 
 desc "Uninstall CNF Test Suite Cluster Tools"
 task "uninstall_cluster_tools" do |_, args|
-  KubectlClient::Delete.file("cluster_tools.yml")
   ClusterTools.uninstall
 end
 

--- a/src/tasks/setup.cr
+++ b/src/tasks/setup.cr
@@ -6,7 +6,6 @@ require "totem"
 desc "Sets up the CNF test suite, the K8s cluster, and upstream projects"
 
 task "setup", ["offline", "helm_local_install", "prereqs", "configuration_file_setup", "install_apisnoop", "install_sonobuoy", "install_chart_testing", "cnf_testsuite_setup", "install_kind"] do  |_, args|
-
   stdout_success "Setup complete"
 end
 

--- a/src/tasks/utils/task.cr
+++ b/src/tasks/utils/task.cr
@@ -19,18 +19,21 @@ module CNFManager
 
     # TODO give example for calling
     def self.all_cnfs_task_runner(args, &block : Sam::Args, CNFManager::Config  -> String | Colorize::Object(String) | Nil)
+      cnf_configs = CNFManager.cnf_config_list(silent: true)
+      Log.info { "CNF configs found: #{cnf_configs.size}" }
 
       # Platforms tests dont have any cnfs
-      if CNFManager.cnf_config_list(silent: true).size == 0
+      if cnf_configs.size == 0
         single_task_runner(args, &block)
       else
-        CNFManager.cnf_config_list(silent: true).map do |x|
+        cnf_configs.map do |x|
           new_args = Sam::Args.new(args.named, args.raw)
           new_args.named["cnf-config"] = x
           single_task_runner(new_args, &block)
         end
       end
     end
+
     # TODO give example for calling
     def self.single_task_runner(args, &block : Sam::Args, CNFManager::Config -> String | Colorize::Object(String) | Nil)
       LOGGING.debug("single_task_runner args: #{args.inspect}")


### PR DESCRIPTION
## Description
* This change removes all installed CNFs when `samples_cleanup` task is run.
* Ensures that cluster-tools is removed when `tools_cleanup` is run.

### Test scenario: Install a few CNFs and clean them up using the samples_cleanup task

#### Setup the cluster with CNFs

![CleanShot 2022-02-01 at 15 46 40@2x](https://user-images.githubusercontent.com/84005/151950964-0538dddf-b7cd-4093-8e9a-601d5747b7a1.png)

#### Cleanup the CNFs using the samples_cleanup task

![CleanShot 2022-02-01 at 15 51 48@2x](https://user-images.githubusercontent.com/84005/151951692-8266384c-9e3a-4c47-bb82-1834915086ff.png)

### Test scenario: Cleanup should not result in errors when there are no CNFs or tools to uninstall

![CleanShot 2022-02-01 at 15 54 34@2x](https://user-images.githubusercontent.com/84005/151951940-6450be28-4e18-45f1-baa6-7c8557895f23.png)


## Issues:
Refs: #1079

## How has this been tested:
 - [x] Covered by existing integration testing
 - [ ] Added integration testing to cover
 - [ ] Verified all A/C passes
     * [ ] develop
     * [ ] master
     * [ ] tag/other branch
 - [ ] Test environment
    * [ ] Shared Packet K8s cluster
    * [ ] New Packet K8s cluster
    * [ ] Kind cluster
 - [ ] Have not tested

## Types of changes:
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [ ] Documentation update

## Checklist:
**Documentation**
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] No updates required.

**Code Review**
- [ ] Does the test handle fatal exceptions, ie. rescue block

**Issue**
- [ ] Tasks in issue are checked off
