### PR TITLE
[BUG] new runner image for gh actions to v2.287.1

### DIFF
--- a/tools/github-runner/Dockerfile
+++ b/tools/github-runner/Dockerfile
@@ -1,4 +1,4 @@
-FROM myoung34/github-runner:2.285.1-ubuntu-bionic
+FROM myoung34/github-runner:2.287.1-ubuntu-bionic
 
 ARG CRYSTAL_VERSION=1.0.0
 ARG CRYSTAL_URL=https://github.com/crystal-lang/crystal/releases/download
@@ -23,7 +23,6 @@ RUN apt-get install apt-transport-https --yes && \
     echo "deb https://baltocdn.com/helm/stable/debian/ all main" | tee /etc/apt/sources.list.d/helm-stable-debian.list && \
     apt-get update && \
     apt-get install helm uuid-runtime && \
-    rm /usr/bin/python && \
     ln -s /usr/bin/python3 /usr/bin/python
 
 RUN wget -O /tmp/kustomize.tar.gz "https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv4.1.3/kustomize_v4.1.3_linux_amd64.tar.gz" && \

--- a/tools/github-runner/create_runners.sh
+++ b/tools/github-runner/create_runners.sh
@@ -29,10 +29,10 @@ VIPS=(
 
 RUNNER_COUNT=0
 for node in "${!RUNNERS[@]}"; do
-    ssh root@${RUNNERS[$node]} "docker pull conformance/github-runner:v2.285.1"
+    ssh root@${RUNNERS[$node]} "docker pull conformance/github-runner:2.287.1"
     RUNNERS_PER_NODE=16
     until [ $RUNNERS_PER_NODE -eq 0 ]; do
-        ssh root@${RUNNERS[$node]} "docker run -d --network host --restart always --name github-runner$RUNNER_COUNT -e REPO_URL="https://github.com/cncf/cnf-testsuite" -e RUNNER_NAME="runner$RUNNER_COUNT" -e RUNNER_TOKEN="$TOKEN" -e RUNNER_WORKDIR="/github-runner-cnf-testsuite" -e LABELS="v1.0.0" -v /var/run/docker.sock:/var/run/docker.sock -v /runner-tmp/runner$RUNNER_COUNT:/tmp -v /github-runner-cnf-testsuite/cnf-testsuite/cnf-testsuite/tools:/docker-host-repo/tools -v /shared:/shared conformance/github-runner:v2.285.1"
+        ssh root@${RUNNERS[$node]} "docker run -d --network host --restart always --name github-runner$RUNNER_COUNT -e REPO_URL="https://github.com/cncf/cnf-testsuite" -e RUNNER_NAME="runner$RUNNER_COUNT" -e RUNNER_TOKEN="$TOKEN" -e RUNNER_WORKDIR="/github-runner-cnf-testsuite" -e LABELS="v1.0.0" -v /var/run/docker.sock:/var/run/docker.sock -v /runner-tmp/runner$RUNNER_COUNT:/tmp -v /github-runner-cnf-testsuite/cnf-testsuite/cnf-testsuite/tools:/docker-host-repo/tools -v /shared:/shared conformance/github-runner:2.287.1"
         RUNNER_COUNT=$(($RUNNER_COUNT + 1))
         RUNNERS_PER_NODE=$(($RUNNERS_PER_NODE - 1))
     done


### PR DESCRIPTION
## Description
The github runner images were old with new API changes made. This was causing no spec jobs from running by grabbing available idle runners.

Discovered when pushing Ref #1165 