### PR TITLE
[1202, 1209] Consolidate cluster tools manifests and resolve dockerd manifest issue

### DIFF
--- a/spec/utils/kernel_introspection_spec.cr
+++ b/spec/utils/kernel_introspection_spec.cr
@@ -10,7 +10,6 @@ describe "KernelInstrospection" do
 
   it "'#status_by_proc' should return all statuses for all containers in a pod", tags: ["kernel-introspection"]  do
     AirGap.bootstrap_cluster()
-    # KubectlClient::Apply.file("./tools/cluster-tools/manifest.yml")
     pods = KubectlClient::Get.pods_by_nodes(KubectlClient::Get.schedulable_nodes_list)
     (pods).should_not be_nil
     pods = KubectlClient::Get.pods_by_label(pods, "name", "cri-tools")

--- a/spec/workload/microservice_spec.cr
+++ b/spec/workload/microservice_spec.cr
@@ -96,11 +96,11 @@ describe "Microservice" do
       LOGGING.info "CRI Pod: #{pods[0]}"
       KubectlClient::Get.resource_wait_for_install("DaemonSet", "cluster-tools")
       LOGGING.info "CPU Logs"
-      LOGGING.info "#{KubectlClient.exec("#{pods[0].dig?("metadata", "name")} -ti -- sysbench --test=cpu --num-threads=4 --cpu-max-prime=9999 run")}"
-      LOGGING.info "Memory logs" 
-      LOGGING.info "#{KubectlClient.exec("#{pods[0].dig?("metadata", "name")} -ti -- sysbench --test=memory --memory-block-size=1M --memory-total-size=100G --num-threads=1 run")}"
+      KubectlClient.exec("#{pods[0].dig?("metadata", "name")} -ti -- sysbench --test=cpu --num-threads=4 --cpu-max-prime=9999 run", true)
+      LOGGING.info "Memory logs"
+      KubectlClient.exec("#{pods[0].dig?("metadata", "name")} -ti -- sysbench --test=memory --memory-block-size=1M --memory-total-size=100G --num-threads=1 run", true)
       LOGGING.info "Disk logs"
-      LOGGING.info "#{KubectlClient.exec("#{pods[0].dig?("metadata", "name")} -ti -- /bin/bash -c 'sysbench fileio prepare && sysbench fileio --file-test-mode=rndrw run'")}"
+      KubectlClient.exec("#{pods[0].dig?("metadata", "name")} -ti -- /bin/bash -c 'sysbench fileio prepare && sysbench fileio --file-test-mode=rndrw run'", true)
       `./cnf-testsuite cnf_setup cnf-path=sample-cnfs/sample_coredns`
     begin
       response_s = `./cnf-testsuite reasonable_startup_time verbose`
@@ -128,7 +128,7 @@ describe "Microservice" do
       pods = KubectlClient::Get.pods_by_label(pods, "name", "cluster-tools")
       LOGGING.info "CRI Pod: #{pods[0]}"
       KubectlClient::Get.resource_wait_for_install("DaemonSet", "cluster-tools")
-      LOGGING.info "#{KubectlClient.exec("#{pods[0].dig?("metadata", "name")} -ti -- sysbench --test=cpu --num-threads=4 --cpu-max-prime=9999 run")}"
+      KubectlClient.exec("#{pods[0].dig?("metadata", "name")} -ti -- sysbench --test=cpu --num-threads=4 --cpu-max-prime=9999 run", true)
       (/FAILED: CNF had a startup time of/ =~ response_s).should_not be_nil
     ensure
       `./cnf-testsuite cnf_cleanup cnf-config=sample-cnfs/sample_envoy_slow_startup/cnf-testsuite.yml force=true`

--- a/spec/workload/microservice_spec.cr
+++ b/spec/workload/microservice_spec.cr
@@ -150,22 +150,6 @@ describe "Microservice" do
   ensure
     `./cnf-testsuite cnf_cleanup cnf-path=sample-cnfs/sample_envoy_slow_startup force=true`
   end
-
-  it "'reasonable_image_size' should skip if dockerd does not install", tags: ["reasonable_image_size"] do
-    cnf="./sample-cnfs/sample-coredns-cnf"
-    LOGGING.info `./cnf-testsuite cnf_setup cnf-path=#{cnf}`
-    LOGGING.info `./cnf-testsuite uninstall_dockerd`
-    dockerd_tempname_helper
-
-    response_s = `./cnf-testsuite reasonable_image_size verbose`
-    LOGGING.info response_s
-    $?.success?.should be_true
-    (/SKIPPED: Skipping reasonable_image_size: Dockerd tool failed to install/ =~ response_s).should_not be_nil
-  ensure
-    LOGGING.info "reasonable_image_size skipped ensure"
-    LOGGING.info `./cnf-testsuite cnf_cleanup cnf-path=#{cnf}`
-    dockerd_name_helper
-  end
 end
 
 it "'service_discovery' should pass if any containers in the cnf are exposed as a service", tags: ["service_discovery"]  do

--- a/spec/workload/microservice_spec.cr
+++ b/spec/workload/microservice_spec.cr
@@ -119,19 +119,10 @@ describe "Microservice" do
       response_s = `./cnf-testsuite reasonable_startup_time verbose`
       LOGGING.info response_s
       $?.success?.should be_true
-
-      ClusterTools.install
-
-      pods = KubectlClient::Get.pods_by_nodes(KubectlClient::Get.schedulable_nodes_list)
-      pods = KubectlClient::Get.pods_by_label(pods, "name", "cluster-tools")
-      LOGGING.info "CRI Pod: #{pods[0]}"
-      KubectlClient::Get.resource_wait_for_install("DaemonSet", "cluster-tools")
-      KubectlClient.exec("#{pods[0].dig?("metadata", "name")} -ti -- sysbench --test=cpu --num-threads=4 --cpu-max-prime=9999 run", true)
       (/FAILED: CNF had a startup time of/ =~ response_s).should_not be_nil
     ensure
       `./cnf-testsuite cnf_cleanup cnf-config=sample-cnfs/sample_envoy_slow_startup/cnf-testsuite.yml force=true`
       $?.success?.should be_true
-      ClusterTools.uninstall
     end
   end
 

--- a/spec/workload/microservice_spec.cr
+++ b/spec/workload/microservice_spec.cr
@@ -89,7 +89,7 @@ describe "Microservice" do
 
   it "'reasonable_startup_time' should pass if the cnf has a reasonable startup time(helm_directory)", tags: ["reasonable_startup_time"]  do
       cluster_tools_install = KubectlClient::Apply.file("#{TOOLS_DIR}/cluster-tools/manifest.yml")
-      cluster_tools_install[:status].success? be_true
+      cluster_tools_install[:status].success?.should be_true
 
       pods = KubectlClient::Get.pods_by_nodes(KubectlClient::Get.schedulable_nodes_list)
       pods = KubectlClient::Get.pods_by_label(pods, "name", "cluster-tools")
@@ -122,7 +122,7 @@ describe "Microservice" do
       $?.success?.should be_true
 
       cluster_tools_install = KubectlClient::Apply.file("#{TOOLS_DIR}/cluster-tools/manifest.yml")
-      cluster_tools_install[:status].success? be_true
+      cluster_tools_install[:status].success?.should be_true
 
       pods = KubectlClient::Get.pods_by_nodes(KubectlClient::Get.schedulable_nodes_list)
       pods = KubectlClient::Get.pods_by_label(pods, "name", "cluster-tools")

--- a/spec/workload/microservice_spec.cr
+++ b/spec/workload/microservice_spec.cr
@@ -88,8 +88,9 @@ describe "Microservice" do
   end
 
   it "'reasonable_startup_time' should pass if the cnf has a reasonable startup time(helm_directory)", tags: ["reasonable_startup_time"]  do
-      LOGGING.info `kubectl apply -f #{TOOLS_DIR}/cluster-tools/manifest.yml`
-      $?.success?.should be_true
+      cluster_tools_install = KubectlClient::Apply.file("#{TOOLS_DIR}/cluster-tools/manifest.yml")
+      cluster_tools_install[:status].success? be_true
+
       pods = KubectlClient::Get.pods_by_nodes(KubectlClient::Get.schedulable_nodes_list)
       pods = KubectlClient::Get.pods_by_label(pods, "name", "cluster-tools")
       LOGGING.info "CRI Pod: #{pods[0]}"
@@ -109,7 +110,7 @@ describe "Microservice" do
     ensure
       LOGGING.info `./cnf-testsuite cnf_cleanup cnf-path=sample-cnfs/sample_coredns`
       $?.success?.should be_true
-      LOGGING.info `kubectl delete -f #{TOOLS_DIR}/cluster-tools/manifest.yml`
+      KubectlClient::Delete.file("#{TOOLS_DIR}/cluster-tools/manifest.yml")
     end
   end
 
@@ -119,8 +120,10 @@ describe "Microservice" do
       response_s = `./cnf-testsuite reasonable_startup_time verbose`
       LOGGING.info response_s
       $?.success?.should be_true
-      LOGGING.info `kubectl apply -f #{TOOLS_DIR}/cluster-tools/manifest.yml`
-      $?.success?.should be_true
+
+      cluster_tools_install = KubectlClient::Apply.file("#{TOOLS_DIR}/cluster-tools/manifest.yml")
+      cluster_tools_install[:status].success? be_true
+
       pods = KubectlClient::Get.pods_by_nodes(KubectlClient::Get.schedulable_nodes_list)
       pods = KubectlClient::Get.pods_by_label(pods, "name", "cluster-tools")
       LOGGING.info "CRI Pod: #{pods[0]}"
@@ -130,7 +133,7 @@ describe "Microservice" do
     ensure
       `./cnf-testsuite cnf_cleanup cnf-config=sample-cnfs/sample_envoy_slow_startup/cnf-testsuite.yml force=true`
       $?.success?.should be_true
-      LOGGING.info `kubectl delete -f #{TOOLS_DIR}/cluster-tools/manifest.yml`
+      KubectlClient::Delete.file("#{TOOLS_DIR}/cluster-tools/manifest.yml")
     end
   end
 

--- a/spec/workload/microservice_spec.cr
+++ b/spec/workload/microservice_spec.cr
@@ -88,8 +88,7 @@ describe "Microservice" do
   end
 
   it "'reasonable_startup_time' should pass if the cnf has a reasonable startup time(helm_directory)", tags: ["reasonable_startup_time"]  do
-      cluster_tools_install = KubectlClient::Apply.file("#{TOOLS_DIR}/cluster-tools/manifest.yml")
-      cluster_tools_install[:status].success?.should be_true
+      ClusterTools.install
 
       pods = KubectlClient::Get.pods_by_nodes(KubectlClient::Get.schedulable_nodes_list)
       pods = KubectlClient::Get.pods_by_label(pods, "name", "cluster-tools")
@@ -110,7 +109,7 @@ describe "Microservice" do
     ensure
       LOGGING.info `./cnf-testsuite cnf_cleanup cnf-path=sample-cnfs/sample_coredns`
       $?.success?.should be_true
-      KubectlClient::Delete.file("#{TOOLS_DIR}/cluster-tools/manifest.yml")
+      ClusterTools.uninstall
     end
   end
 
@@ -121,8 +120,7 @@ describe "Microservice" do
       LOGGING.info response_s
       $?.success?.should be_true
 
-      cluster_tools_install = KubectlClient::Apply.file("#{TOOLS_DIR}/cluster-tools/manifest.yml")
-      cluster_tools_install[:status].success?.should be_true
+      ClusterTools.install
 
       pods = KubectlClient::Get.pods_by_nodes(KubectlClient::Get.schedulable_nodes_list)
       pods = KubectlClient::Get.pods_by_label(pods, "name", "cluster-tools")
@@ -133,7 +131,7 @@ describe "Microservice" do
     ensure
       `./cnf-testsuite cnf_cleanup cnf-config=sample-cnfs/sample_envoy_slow_startup/cnf-testsuite.yml force=true`
       $?.success?.should be_true
-      KubectlClient::Delete.file("#{TOOLS_DIR}/cluster-tools/manifest.yml")
+      ClusterTools.uninstall
     end
   end
 

--- a/spec/workload/registry_spec.cr
+++ b/spec/workload/registry_spec.cr
@@ -9,8 +9,8 @@ require "sam"
 
 describe "Private Registry: Image" do
   before_all do
-    install_registry = `kubectl apply -f #{TOOLS_DIR}/registry/manifest.yml`
-    install_dockerd = `kubectl apply -f #{TOOLS_DIR}/dockerd/manifest.yml`
+    install_registry = KubectlClient::Apply.file("#{TOOLS_DIR}/registry/manifest.yml")
+    install_dockerd = KubectlClient::Apply.file("#{TOOLS_DIR}/dockerd/manifest.yml")
     KubectlClient::Get.resource_wait_for_install("Pod", "registry")
     KubectlClient::Get.resource_wait_for_install("Pod", "dockerd")
 
@@ -62,16 +62,16 @@ describe "Private Registry: Image" do
     LOGGING.info `./cnf-testsuite cnf_cleanup cnf-path=#{cnf}`
   end
 
-	after_all do
-  	  delete_registry = `kubectl delete -f #{TOOLS_DIR}/registry/manifest.yml`
-    	delete_dockerd = `kubectl delete -f #{TOOLS_DIR}/dockerd/manifest.yml`
+  after_all do
+    delete_registry = KubectlClient::Delete.file("#{TOOLS_DIR}/registry/manifest.yml")
+    delete_dockerd = KubectlClient::Delete.file("#{TOOLS_DIR}/dockerd/manifest.yml")
   end	
 end
 
 describe "Private Registry: Rolling" do
   before_all do
-    install_registry = `kubectl apply -f #{TOOLS_DIR}/registry/manifest.yml`
-    install_dockerd = `kubectl apply -f #{TOOLS_DIR}/dockerd/manifest.yml`
+    install_registry = KubectlClient::Apply.file("#{TOOLS_DIR}/registry/manifest.yml")
+    install_dockerd = KubectlClient::Apply.file("#{TOOLS_DIR}/dockerd/manifest.yml")
     KubectlClient::Get.resource_wait_for_install("Pod", "registry")
     KubectlClient::Get.resource_wait_for_install("Pod", "dockerd")
 
@@ -129,8 +129,8 @@ describe "Private Registry: Rolling" do
     end
   end  
 
-	after_all do
-  	  delete_registry = `kubectl delete -f #{TOOLS_DIR}/registry/manifest.yml`
-    	delete_dockerd = `kubectl delete -f #{TOOLS_DIR}/dockerd/manifest.yml`
+  after_all do
+    delete_registry = KubectlClient::Delete.file("#{TOOLS_DIR}/registry/manifest.yml")
+    delete_dockerd = KubectlClient::Delete.file("#{TOOLS_DIR}/dockerd/manifest.yml")
   end	
 end

--- a/src/tasks/cluster_setup.cr
+++ b/src/tasks/cluster_setup.cr
@@ -17,19 +17,3 @@ desc "Uninstall CNF Test Suite Cluster Tools"
 task "uninstall_cluster_tools" do |_, args|
   ClusterTools.uninstall
 end
-
-module ClusterToolsSetup
-  def self.cluster_tools_pod()
-    KubectlClient::Get.pod_status("cluster-tools").split(",")[0]
-  end
-
-  def self.cluster_tools_pod_by_node(node)
-    resource = KubectlClient::Get.resource("Daemonset", "cluster-tools")
-    pods = KubectlClient::Get.pods_by_resource(resource)
-    cluster_pod = pods.find do |pod| 
-      pod.dig("spec", "nodeName") == node 
-    end
-    cluster_pod.dig("metadata", "name") if cluster_pod
-  end
-end
-

--- a/src/tasks/constants.cr
+++ b/src/tasks/constants.cr
@@ -26,6 +26,7 @@ EMPTY_JSON_ARRAY = JSON.parse(%([]))
 #Embedded global text variables
 EmbeddedFileManager.node_failure_values
 EmbeddedFileManager.cluster_tools
+EmbeddedFileManager.dockerd_manifest
 EmbeddedFileManager.falco_rules
 EmbeddedFileManager.reboot_daemon
 EmbeddedFileManager.chaos_network_loss

--- a/src/tasks/dockerd_setup.cr
+++ b/src/tasks/dockerd_setup.cr
@@ -26,7 +26,9 @@ task "uninstall_dockerd" do |_, args|
 end
 
 def dockerd_filename
-  "./#{TOOLS_DIR}/dockerd/manifest.yml"
+  manifest_path = "./#{TOOLS_DIR}/dockerd-manifest.yml"
+  File.write(manifest_path, DOCKERD_MANIFEST)
+  manifest_path
 end
 
 def dockerd_tempname

--- a/src/tasks/dockerd_setup.cr
+++ b/src/tasks/dockerd_setup.cr
@@ -31,32 +31,6 @@ def dockerd_filename
   manifest_path
 end
 
-def dockerd_tempname
-  "./#{TOOLS_DIR}/dockerd/manifest.tmp"
-end
-
-def dockerd_tempname_helper
-  Log.info { "dockerd_tempname_helper" }
-  Log.info { "Contents of #{TOOLS_DIR} before moving dockerd manifest to tempfile" }
-  Log.info { "ls #{TOOLS_DIR}: #{Dir.children(TOOLS_DIR)}" }
-  Log.info { "ls #{TOOLS_DIR}/dockerd: #{Dir.children("#{TOOLS_DIR}/dockerd")}" }
-  FileUtils.mv(dockerd_filename, dockerd_tempname)
-  Log.info { "Contents of #{TOOLS_DIR} after moving dockerd manifest to tempfile" }
-  Log.info { "ls #{TOOLS_DIR}: #{Dir.children(TOOLS_DIR)}" }
-  Log.info { "ls #{TOOLS_DIR}/dockerd: #{Dir.children("#{TOOLS_DIR}/dockerd")}" }
-end
-
-def dockerd_name_helper
-  Log.info { "dockerd_name_helper" }
-  Log.info { "Contents of #{TOOLS_DIR} before moving dockerd manifest from tempfile to it's place" }
-  Log.info { "ls #{TOOLS_DIR}: #{Dir.children(TOOLS_DIR)}" }
-  Log.info { "ls #{TOOLS_DIR}/dockerd: #{Dir.children("#{TOOLS_DIR}/dockerd")}" }
-  FileUtils.mv(dockerd_tempname, dockerd_filename)
-  Log.info { "Contents of #{TOOLS_DIR} after moving dockerd manifest from tempfile to it's place" }
-  Log.info { "ls #{TOOLS_DIR}: #{Dir.children(TOOLS_DIR)}" }
-  Log.info { "ls #{TOOLS_DIR}/dockerd: #{Dir.children("#{TOOLS_DIR}/dockerd")}" }
-end
-
 ### Checks to see if dockerd is already installed.  Alternatively
 ### can be used to wait for dockerd is installed by passing a higher wait_count)
 def check_dockerd(wait_count = 1) 

--- a/src/tasks/platform/observability.cr
+++ b/src/tasks/platform/observability.cr
@@ -76,36 +76,20 @@ namespace "platform" do
     Log.info { "Running POC: node_exporter" }
     Retriable.retry do
       task_response = CNFManager::Task.task_runner(args) do |args|
-
         #Select the first node that isn't a master and is also schedulable
         #worker_nodes = `kubectl get nodes --selector='!node-role.kubernetes.io/master' -o 'go-template={{range .items}}{{$taints:=""}}{{range .spec.taints}}{{if eq .effect "NoSchedule"}}{{$taints = print $taints .key ","}}{{end}}{{end}}{{if not $taints}}{{.metadata.name}}{{ "\\n"}}{{end}}{{end}}'`
         #worker_node = worker_nodes.split("\n")[0]
 
-        # Install and find CRI Tools name
-        File.write("cluster_tools.yml", CLUSTER_TOOLS)
-        #TODO use kubectlclient
-        install_cluster_tools = `kubectl create -f cluster_tools.yml`
-        pod_ready = ""
-        pod_ready_timeout = 45
-        until (pod_ready == "true" || pod_ready_timeout == 0)
-          pod_ready = KubectlClient::Get.pod_status("cluster-tools").split(",")[2]
-          Log.info { "Pod Ready Status: #{pod_ready}" }
-          sleep 1
-          pod_ready_timeout = pod_ready_timeout - 1
-        end
-        cluster_tools_pod = KubectlClient::Get.pod_status("cluster-tools").split(",")[0]
-        #, "--field-selector spec.nodeName=#{worker_node}")
-        LOGGING.debug "cluster_tools_pod: #{cluster_tools_pod}"
+        ClusterTools.install
+        cluster_tools_pod = ClusterTools.pod_name
+        Log.debug { "cluster_tools_pod: #{cluster_tools_pod}" }
 
         # Fetch id sha256 sums for all repo_digests https://github.com/docker/distribution/issues/1662
         repo_digest_list = KubectlClient::Get.all_container_repo_digests
         Log.info { "container_repo_digests: #{repo_digest_list}" }
         id_sha256_list = repo_digest_list.reduce([] of String) do |acc, repo_digest|
           Log.info { "repo_digest: #{repo_digest}" }
-          #TODO use kubectlclient
-          # cricti = `kubectl exec -ti #{CRIToolsSetup.cluster_tools_pod} -- crictl inspecti #{repo_digest}`
-          # LOGGING.info "cricti: #{cricti}"
-          resp = KubectlClient.exec("#{ClusterToolsSetup.cluster_tools_pod} -- crictl inspecti #{repo_digest}")
+          resp = KubectlClient.exec("#{ClusterTools.pod_name} -- crictl inspecti #{repo_digest}")
           cricti = resp[:output].to_s
           begin
             parsed_json = JSON.parse(cricti)
@@ -266,18 +250,8 @@ end
         #worker_node = worker_nodes.split("\n")[0]
 
         # Install and find CRI Tools name
-        File.write("cluster_tools.yml", CLUSTER_TOOLS)
-        KubectlClient::Apply.file("cluster_tools.yml")
-        pod_ready = ""
-        pod_ready_timeout = 45
-        until (pod_ready == "true" || pod_ready_timeout == 0)
-          pod_ready = KubectlClient::Get.pod_status("cluster-tools").split(",")[2]
-          Log.info { "Pod Ready Status: #{pod_ready}" }
-          sleep 1
-          pod_ready_timeout = pod_ready_timeout - 1
-        end
-        cluster_tools_pod = KubectlClient::Get.pod_status("cluster-tools").split(",")[0]
-        #, "--field-selector spec.nodeName=#{worker_node}")
+        ClusterTools.install
+        cluster_tools_pod = ClusterTools.pod_name
         Log.debug { "cluster_tools_pod: #{cluster_tools_pod}" }
 
         # Fetch id sha256 sums for all repo_digests https://github.com/docker/distribution/issues/1662

--- a/src/tasks/utils/cluster_utils.cr
+++ b/src/tasks/utils/cluster_utils.cr
@@ -2,12 +2,13 @@ module ClusterTools
   def self.install
     Log.info { "ClusterTools install" }
     File.write("cluster_tools.yml", CLUSTER_TOOLS)
-    KubectlClient::Apply.file("#{TOOLS_DIR}/cluster-tools/manifest.yml")
+    KubectlClient::Apply.file("cluster_tools.yml")
     wait_for_cluster_tools
   end
   def self.uninstall
     Log.info { "ClusterTools uninstall" }
-    KubectlClient::Delete.file("#{TOOLS_DIR}/cluster-tools/manifest.yml")
+    File.write("cluster_tools.yml", CLUSTER_TOOLS)
+    KubectlClient::Delete.file("cluster_tools.yml")
     KubectlClient::Get.resource_wait_for_uninstall("Daemonset", "cluster-tools")
   end
 

--- a/src/tasks/utils/embedded_file_manager.cr
+++ b/src/tasks/utils/embedded_file_manager.cr
@@ -7,6 +7,9 @@ module EmbeddedFileManager
   macro cluster_tools
     CLUSTER_TOOLS = Base64.decode_string("{{ `cat ./tools/cluster-tools/manifest.yml | base64` }}")
   end
+  macro dockerd_manifest
+    DOCKERD_MANIFEST = Base64.decode_string("{{ `cat ./tools/dockerd/manifest.yml | base64` }}")
+  end
   macro falco_rules
     FALCO_RULES = Base64.decode_string("{{ `cat ./embedded_files/falco_rule.yaml | base64` }}")
   end

--- a/src/tasks/workload/microservice.cr
+++ b/src/tasks/workload/microservice.cr
@@ -100,7 +100,7 @@ task "shared_database" do |_, args|
     database_container_statuses.each do |status|
       Log.info { "Container Info: #{status}"}
       # get network information on the node for each database pod
-      cluster_tools = ClusterToolsSetup.cluster_tools_pod_by_node("#{status["nodeName"]}")
+      cluster_tools = ClusterTools.pod_by_node("#{status["nodeName"]}")
       Log.info { "Container Tools Pod: #{cluster_tools}"}
       pids = status["ids"].map do |id| 
         inspect = KubectlClient.exec("#{cluster_tools} -ti -- crictl inspect #{id}")


### PR DESCRIPTION
# Description

### Changes to resolve #1202

* Consolidate clustertools manifests into one as a a precursor to #1199.
* Consolidate helper functions from `ClusterToolsSetup` into `ClusterTools`. Replace usage across codebase appropriately.
* Consolidate kubectl create/apply/delete calls with helper functions from `KubectlClient` or `ClusterTools`.

### Changes to resolve #1209

* Identified and resolved issue with dockerd manifest when testing 1202 in a cleanroom dir.

### Removed outdated test for `reasonable_image_size`

That test will not pass due to the nature of the fix for 1209.
* Remove `LOGGING` wrapper for `KubectlClient.exec` - the helper is already capable of logging output on its own.
* Remove outdated & unused helper code from `dockerd_setup.cr`

# Issues
Refs: #1202, #1209

# How has this been tested
 - [x] Covered by existing integration testing
 - [ ] Added integration testing to cover
 - [ ] Verified all A/C passes
     * [ ] develop
     * [ ] master
     * [ ] tag/other branch
 - [ ] Test environment
    * [ ] Shared Packet K8s cluster
    * [ ] New Packet K8s cluster
    * [ ] Kind cluster
 - [ ] Have not tested

# Types of changes
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [ ] Documentation update

# Checklist
**Documentation**
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] No updates required.

**Code Review**
- [ ] Does the test handle fatal exceptions, ie. rescue block
