### PR TITLE
[1199, 1220, 1221] Move cluster-tools to a separate namespace to avoid causing test failures

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@
 /tools/sonobuoy
 /tools/cluster-api
 /tools/airgapped_kind/kind_node/node.tar.gz
+/tools/dockerd-manifest.yml
 admin.conf
 cnf-testsuite
 results.yml

--- a/spec/platform/observability_spec.cr
+++ b/spec/platform/observability_spec.cr
@@ -4,6 +4,10 @@ require "./../../src/tasks/utils/utils.cr"
 require "kubectl_client"
 
 describe "Platform Observability" do
+  before_all do
+    `./cnf-testsuite setup`
+    $?.success?.should be_true
+  end
 
   it "'kube_state_metrics' should return some json", tags: ["platform:observability"] do
 

--- a/spec/utils/k8s_instrumentation_spec.cr
+++ b/spec/utils/k8s_instrumentation_spec.cr
@@ -6,7 +6,10 @@ require "file_utils"
 require "sam"
 
 describe "K8sInstrumentation" do
-
+  before_all do
+    `./cnf-testsuite setup`
+    $?.success?.should be_true
+  end
 
   it "'#disk_speed' should return all responses for the sysbench disk speed call on a pod", tags: ["k8s-instrumentation"]  do
     LOGGING.info `./cnf-testsuite install_cluster_tools`
@@ -15,6 +18,4 @@ describe "K8sInstrumentation" do
     (resp["95th percentile"].to_f).should_not be_nil
   end
 
-
 end
-

--- a/spec/utils/k8s_instrumentation_spec.cr
+++ b/spec/utils/k8s_instrumentation_spec.cr
@@ -12,7 +12,7 @@ describe "K8sInstrumentation" do
   end
 
   it "'#disk_speed' should return all responses for the sysbench disk speed call on a pod", tags: ["k8s-instrumentation"]  do
-    LOGGING.info `./cnf-testsuite install_cluster_tools`
+    ClusterTools.install
     resp = K8sInstrumentation.disk_speed
     (resp["95th percentile"]).should_not be_nil
     (resp["95th percentile"].to_f).should_not be_nil

--- a/spec/utils/utils_spec.cr
+++ b/spec/utils/utils_spec.cr
@@ -7,6 +7,11 @@ require "file_utils"
 require "sam"
 
 describe "Utils" do
+  before_all do
+    `./cnf-testsuite setup`
+    $?.success?.should be_true
+  end
+
   before_each do
     `./cnf-testsuite results_yml_cleanup`
   end

--- a/spec/workload/microservice_spec.cr
+++ b/spec/workload/microservice_spec.cr
@@ -88,28 +88,15 @@ describe "Microservice" do
   end
 
   it "'reasonable_startup_time' should pass if the cnf has a reasonable startup time(helm_directory)", tags: ["reasonable_startup_time"]  do
-      ClusterTools.install
-
-      pods = KubectlClient::Get.pods_by_nodes(KubectlClient::Get.schedulable_nodes_list)
-      pods = KubectlClient::Get.pods_by_label(pods, "name", "cluster-tools")
-      LOGGING.info "CRI Pod: #{pods[0]}"
-      KubectlClient::Get.resource_wait_for_install("DaemonSet", "cluster-tools")
-      LOGGING.info "CPU Logs"
-      KubectlClient.exec("#{pods[0].dig?("metadata", "name")} -ti -- sysbench --test=cpu --num-threads=4 --cpu-max-prime=9999 run", force_output: true)
-      LOGGING.info "Memory logs"
-      KubectlClient.exec("#{pods[0].dig?("metadata", "name")} -ti -- sysbench --test=memory --memory-block-size=1M --memory-total-size=100G --num-threads=1 run", force_output: true)
-      LOGGING.info "Disk logs"
-      KubectlClient.exec("#{pods[0].dig?("metadata", "name")} -ti -- /bin/bash -c 'sysbench fileio prepare && sysbench fileio --file-test-mode=rndrw run'", force_output: true)
-      `./cnf-testsuite cnf_setup cnf-path=sample-cnfs/sample_coredns`
     begin
+      `./cnf-testsuite cnf_setup cnf-path=sample-cnfs/sample_coredns`
       response_s = `./cnf-testsuite reasonable_startup_time verbose`
-      LOGGING.info response_s
+      Log.info { response_s }
       
       (/PASSED: CNF had a reasonable startup time/ =~ response_s).should_not be_nil
     ensure
-      LOGGING.info `./cnf-testsuite cnf_cleanup cnf-path=sample-cnfs/sample_coredns`
+      Log.info { `./cnf-testsuite cnf_cleanup cnf-path=sample-cnfs/sample_coredns` }
       $?.success?.should be_true
-      ClusterTools.uninstall
     end
   end
 

--- a/spec/workload/microservice_spec.cr
+++ b/spec/workload/microservice_spec.cr
@@ -8,6 +8,10 @@ require "file_utils"
 require "sam"
 
 describe "Microservice" do
+  before_all do
+    `./cnf-testsuite setup`
+    $?.success?.should be_true
+  end
 
   it "'shared_database' should pass if no database is used by two microservices", tags: ["shared_database"]  do
     begin

--- a/spec/workload/microservice_spec.cr
+++ b/spec/workload/microservice_spec.cr
@@ -95,11 +95,11 @@ describe "Microservice" do
       LOGGING.info "CRI Pod: #{pods[0]}"
       KubectlClient::Get.resource_wait_for_install("DaemonSet", "cluster-tools")
       LOGGING.info "CPU Logs"
-      KubectlClient.exec("#{pods[0].dig?("metadata", "name")} -ti -- sysbench --test=cpu --num-threads=4 --cpu-max-prime=9999 run", true)
+      KubectlClient.exec("#{pods[0].dig?("metadata", "name")} -ti -- sysbench --test=cpu --num-threads=4 --cpu-max-prime=9999 run", force_output: true)
       LOGGING.info "Memory logs"
-      KubectlClient.exec("#{pods[0].dig?("metadata", "name")} -ti -- sysbench --test=memory --memory-block-size=1M --memory-total-size=100G --num-threads=1 run", true)
+      KubectlClient.exec("#{pods[0].dig?("metadata", "name")} -ti -- sysbench --test=memory --memory-block-size=1M --memory-total-size=100G --num-threads=1 run", force_output: true)
       LOGGING.info "Disk logs"
-      KubectlClient.exec("#{pods[0].dig?("metadata", "name")} -ti -- /bin/bash -c 'sysbench fileio prepare && sysbench fileio --file-test-mode=rndrw run'", true)
+      KubectlClient.exec("#{pods[0].dig?("metadata", "name")} -ti -- /bin/bash -c 'sysbench fileio prepare && sysbench fileio --file-test-mode=rndrw run'", force_output: true)
       `./cnf-testsuite cnf_setup cnf-path=sample-cnfs/sample_coredns`
     begin
       response_s = `./cnf-testsuite reasonable_startup_time verbose`

--- a/spec/workload/observability_spec.cr
+++ b/spec/workload/observability_spec.cr
@@ -4,6 +4,11 @@ require "../../src/tasks/utils/utils.cr"
 require "../../src/tasks/jaeger_setup.cr"
 
 describe "Observability" do
+  before_all do
+    `./cnf-testsuite setup`
+    $?.success?.should be_true
+  end
+
   it "'log_output' should pass with a cnf that outputs logs to stdout", tags: ["observability"]  do
     begin
       LOGGING.info `./cnf-testsuite cnf_setup cnf-config=sample-cnfs/sample-coredns-cnf/cnf-testsuite.yml`

--- a/spec/workload/observability_spec.cr
+++ b/spec/workload/observability_spec.cr
@@ -72,7 +72,7 @@ describe "Observability" do
   it "'prometheus_traffic' should fail if the cnf is not registered with prometheus", tags: ["observability"] do
 
       LOGGING.info `./cnf-testsuite cnf_setup cnf-config=sample-cnfs/sample-coredns-cnf/cnf-testsuite.yml`
-      LOGGING.info "Installing prometheus server" 
+      Log.info { "Installing prometheus server" }
       helm = BinarySingleton.helm
       LOGGING.info `helm repo add prometheus-community https://prometheus-community.github.io/helm-charts`
       # resp = `#{helm} install prometheus prometheus-community/prometheus`
@@ -91,120 +91,117 @@ describe "Observability" do
       LOGGING.info resp
       $?.success?.should be_true
   end
-end
 
-it "'open_metrics' should fail if there is not a valid open metrics response from the cnf", tags: ["observability"] do
+  it "'open_metrics' should fail if there is not a valid open metrics response from the cnf", tags: ["observability"] do
+    LOGGING.info `./cnf-testsuite cnf_setup cnf-config=sample-cnfs/sample-prom-pod-discovery/cnf-testsuite.yml`
+    LOGGING.info `helm repo add prometheus-community https://prometheus-community.github.io/helm-charts`
+    Log.info { "Installing prometheus server" }
+    helm = BinarySingleton.helm
+    # resp = `#{helm} install prometheus prometheus-community/prometheus`
+    resp = `#{helm} install --set alertmanager.persistentVolume.enabled=false --set server.persistentVolume.enabled=false --set pushgateway.persistentVolume.enabled=false prometheus prometheus-community/prometheus`
+    LOGGING.info resp
+    KubectlClient::Get.wait_for_install("prometheus-server")
+    LOGGING.info `kubectl describe deployment prometheus-server`
+    #todo logging on prometheus pod
 
-  LOGGING.info `./cnf-testsuite cnf_setup cnf-config=sample-cnfs/sample-prom-pod-discovery/cnf-testsuite.yml`
-  LOGGING.info `helm repo add prometheus-community https://prometheus-community.github.io/helm-charts`
-  LOGGING.info "Installing prometheus server" 
-  helm = BinarySingleton.helm
-  # resp = `#{helm} install prometheus prometheus-community/prometheus`
-  resp = `#{helm} install --set alertmanager.persistentVolume.enabled=false --set server.persistentVolume.enabled=false --set pushgateway.persistentVolume.enabled=false prometheus prometheus-community/prometheus`
-  LOGGING.info resp
-  KubectlClient::Get.wait_for_install("prometheus-server")
-  LOGGING.info `kubectl describe deployment prometheus-server`
-  #todo logging on prometheus pod
+    response_s = `./cnf-testsuite open_metrics`
+    LOGGING.info response_s
+    (/FAILED: Your cnf's metrics traffic is not Open Metrics compatible/ =~ response_s).should_not be_nil
+  ensure
+    LOGGING.info `./cnf-testsuite cnf_cleanup cnf-config=sample-cnfs/sample-prom-pod-discovery/cnf-testsuite.yml`
+    resp = `#{helm} delete prometheus`
+    LOGGING.info resp
+    $?.success?.should be_true
+  end
 
-  response_s = `./cnf-testsuite open_metrics`
-  LOGGING.info response_s
-  (/FAILED: Your cnf's metrics traffic is not Open Metrics compatible/ =~ response_s).should_not be_nil
-ensure
-  LOGGING.info `./cnf-testsuite cnf_cleanup cnf-config=sample-cnfs/sample-prom-pod-discovery/cnf-testsuite.yml`
-  resp = `#{helm} delete prometheus`
-  LOGGING.info resp
-  $?.success?.should be_true
-end
+  it "'open_metrics' should pass if there is a valid open metrics response from the cnf", tags: ["observability"] do
+    LOGGING.info `./cnf-testsuite cnf_setup cnf-config=sample-cnfs/sample-openmetrics/cnf-testsuite.yml`
+    LOGGING.info `helm repo add prometheus-community https://prometheus-community.github.io/helm-charts`
+    LOGGING.info "Installing prometheus server"
+    helm = BinarySingleton.helm
+    # resp = `#{helm} install prometheus prometheus-community/prometheus`
+    resp = `#{helm} install --set alertmanager.persistentVolume.enabled=false --set server.persistentVolume.enabled=false --set pushgateway.persistentVolume.enabled=false prometheus prometheus-community/prometheus`
+    LOGGING.info resp
+    KubectlClient::Get.wait_for_install("prometheus-server")
+    LOGGING.info `kubectl describe deployment prometheus-server`
+    #todo logging on prometheus pod
 
-it "'open_metrics' should pass if there is a valid open metrics response from the cnf", tags: ["observability"] do
+    response_s = `./cnf-testsuite open_metrics`
+    LOGGING.info response_s
+    (/PASSED: Your cnf's metrics traffic is Open Metrics compatible/ =~ response_s).should_not be_nil
+  ensure
+    LOGGING.info `./cnf-testsuite cnf_cleanup cnf-config=sample-cnfs/sample-openmetrics/cnf-testsuite.yml`
+    resp = `#{helm} delete prometheus`
+    LOGGING.info resp
+    $?.success?.should be_true
+  end
 
-  LOGGING.info `./cnf-testsuite cnf_setup cnf-config=sample-cnfs/sample-openmetrics/cnf-testsuite.yml`
-  LOGGING.info `helm repo add prometheus-community https://prometheus-community.github.io/helm-charts`
-  LOGGING.info "Installing prometheus server" 
-  helm = BinarySingleton.helm
-  # resp = `#{helm} install prometheus prometheus-community/prometheus`
-  resp = `#{helm} install --set alertmanager.persistentVolume.enabled=false --set server.persistentVolume.enabled=false --set pushgateway.persistentVolume.enabled=false prometheus prometheus-community/prometheus`
-  LOGGING.info resp
-  KubectlClient::Get.wait_for_install("prometheus-server")
-  LOGGING.info `kubectl describe deployment prometheus-server`
-  #todo logging on prometheus pod
+  it "'routed_logs' should pass if cnfs logs are captured", tags: ["observability"] do
+    LOGGING.info `./cnf-testsuite cnf_setup cnf-config=sample-cnfs/sample-coredns-cnf/cnf-testsuite.yml`
+    resp = `./cnf-testsuite install_fluentd`
+    LOGGING.info resp
+    response_s = `./cnf-testsuite routed_logs`
+    LOGGING.info response_s
+    (/PASSED: Your cnf's logs are being captured/ =~ response_s).should_not be_nil
+  ensure
+    LOGGING.info `./cnf-testsuite cnf_cleanup cnf-config=sample-cnfs/sample-coredns-cnf/cnf-testsuite.yml`
+    resp = `./cnf-testsuite uninstall_fluentd`
+    LOGGING.info resp
+    $?.success?.should be_true
+  end
 
-  response_s = `./cnf-testsuite open_metrics`
-  LOGGING.info response_s
-  (/PASSED: Your cnf's metrics traffic is Open Metrics compatible/ =~ response_s).should_not be_nil
-ensure
-  LOGGING.info `./cnf-testsuite cnf_cleanup cnf-config=sample-cnfs/sample-openmetrics/cnf-testsuite.yml`
-  resp = `#{helm} delete prometheus`
-  LOGGING.info resp
-  $?.success?.should be_true
-end
-
-it "'routed_logs' should pass if cnfs logs are captured", tags: ["observability"] do
-
-  LOGGING.info `./cnf-testsuite cnf_setup cnf-config=sample-cnfs/sample-coredns-cnf/cnf-testsuite.yml`
-  resp = `./cnf-testsuite install_fluentd`
-  LOGGING.info resp
-  response_s = `./cnf-testsuite routed_logs`
-  LOGGING.info response_s
-  (/PASSED: Your cnf's logs are being captured/ =~ response_s).should_not be_nil
-ensure
-  LOGGING.info `./cnf-testsuite cnf_cleanup cnf-config=sample-cnfs/sample-coredns-cnf/cnf-testsuite.yml`
-  resp = `./cnf-testsuite uninstall_fluentd`
-  LOGGING.info resp
-  $?.success?.should be_true
-end
-
-it "'routed_logs' should fail if cnfs logs are not captured", tags: ["observability"] do
-
-  LOGGING.info `./cnf-testsuite cnf_setup cnf-config=sample-cnfs/sample-coredns-cnf/cnf-testsuite.yml`
-  # resp = `./cnf-testsuite install_fluentd`
-  Log.info {"Installing FluentD daemonset "}
-  Helm.helm_repo_add("fluent","https://fluent.github.io/helm-charts")
-  #todo  #helm install --values ./override.yml fluentd ./fluentd
-  Helm.install("--values ./spec/fixtures/fluentd-values-bad.yml fluentd fluent/fluentd")
-  KubectlClient::Get.resource_wait_for_install("Daemonset", "fluentd")
-
-  response_s = `./cnf-testsuite routed_logs`
-  LOGGING.info response_s
-  (/FAILED: Your cnf's logs are not being captured/ =~ response_s).should_not be_nil
-ensure
-  LOGGING.info `./cnf-testsuite cnf_cleanup cnf-config=sample-cnfs/sample-coredns-cnf/cnf-testsuite.yml`
-  resp = `./cnf-testsuite uninstall_fluentd`
-  LOGGING.info resp
-  $?.success?.should be_true
-end
-
-it "'tracing' should fail if tracing is not used", tags: ["observability_jaeger_fail"] do
-  Log.info {"Installing Jaeger "}
-  JaegerManager.install
+  it "'routed_logs' should fail if cnfs logs are not captured", tags: ["observability"] do
   
-  LOGGING.info `./cnf-testsuite cnf_setup cnf-config=sample-cnfs/sample-coredns-cnf/cnf-testsuite.yml`
-  response_s = `./cnf-testsuite tracing`
-  LOGGING.info response_s
-  (/FAILED: Tracing not used/ =~ response_s).should_not be_nil
-ensure
-  LOGGING.info `./cnf-testsuite cnf_cleanup cnf-config=sample-cnfs/sample-coredns-cnf/cnf-testsuite.yml`
-  JaegerManager.uninstall
-  KubectlClient::Get.resource_wait_for_uninstall("Statefulset", "jaeger-cassandra")
-  KubectlClient::Get.resource_wait_for_uninstall("Deployment", "jaeger-collector")
-  KubectlClient::Get.resource_wait_for_uninstall("Deployment", "jaeger-query")
-  KubectlClient::Get.resource_wait_for_uninstall("Daemonset", "jaeger-agent")
+    LOGGING.info `./cnf-testsuite cnf_setup cnf-config=sample-cnfs/sample-coredns-cnf/cnf-testsuite.yml`
+    # resp = `./cnf-testsuite install_fluentd`
+    Log.info {"Installing FluentD daemonset "}
+    Helm.helm_repo_add("fluent","https://fluent.github.io/helm-charts")
+    #todo  #helm install --values ./override.yml fluentd ./fluentd
+    Helm.install("--values ./spec/fixtures/fluentd-values-bad.yml fluentd fluent/fluentd")
+    KubectlClient::Get.resource_wait_for_install("Daemonset", "fluentd")
+
+    response_s = `./cnf-testsuite routed_logs`
+    LOGGING.info response_s
+    (/FAILED: Your cnf's logs are not being captured/ =~ response_s).should_not be_nil
+  ensure
+    LOGGING.info `./cnf-testsuite cnf_cleanup cnf-config=sample-cnfs/sample-coredns-cnf/cnf-testsuite.yml`
+    resp = `./cnf-testsuite uninstall_fluentd`
+    LOGGING.info resp
+    $?.success?.should be_true
+  end
+
+  it "'tracing' should fail if tracing is not used", tags: ["observability_jaeger_fail"] do
+    Log.info {"Installing Jaeger "}
+    JaegerManager.install
+
+    LOGGING.info `./cnf-testsuite cnf_setup cnf-config=sample-cnfs/sample-coredns-cnf/cnf-testsuite.yml`
+    response_s = `./cnf-testsuite tracing`
+    LOGGING.info response_s
+    (/FAILED: Tracing not used/ =~ response_s).should_not be_nil
+  ensure
+    LOGGING.info `./cnf-testsuite cnf_cleanup cnf-config=sample-cnfs/sample-coredns-cnf/cnf-testsuite.yml`
+    JaegerManager.uninstall
+    KubectlClient::Get.resource_wait_for_uninstall("Statefulset", "jaeger-cassandra")
+    KubectlClient::Get.resource_wait_for_uninstall("Deployment", "jaeger-collector")
+    KubectlClient::Get.resource_wait_for_uninstall("Deployment", "jaeger-query")
+    KubectlClient::Get.resource_wait_for_uninstall("Daemonset", "jaeger-agent")
+  end
+
+  it "'tracing' should pass if tracing is used", tags: ["observability_jaeger_pass"] do
+    Log.info {"Installing Jaeger "}
+    JaegerManager.install
+
+    LOGGING.info `./cnf-testsuite cnf_setup cnf-config=sample-cnfs/sample-tracing/cnf-testsuite.yml`
+    response_s = `./cnf-testsuite tracing`
+    LOGGING.info response_s
+    (/PASSED: Tracing used/ =~ response_s).should_not be_nil
+  ensure
+    LOGGING.info `./cnf-testsuite cnf_cleanup cnf-config=sample-cnfs/sample-tracing/cnf-testsuite.yml`
+    JaegerManager.uninstall
+    KubectlClient::Get.resource_wait_for_uninstall("Statefulset", "jaeger-cassandra")
+    KubectlClient::Get.resource_wait_for_uninstall("Deployment", "jaeger-collector")
+    KubectlClient::Get.resource_wait_for_uninstall("Deployment", "jaeger-query")
+    KubectlClient::Get.resource_wait_for_uninstall("Daemonset", "jaeger-agent")
+  end
+
 end
-
-it "'tracing' should pass if tracing is used", tags: ["observability_jaeger_pass"] do
-  Log.info {"Installing Jaeger "}
-  JaegerManager.install
-
-  LOGGING.info `./cnf-testsuite cnf_setup cnf-config=sample-cnfs/sample-tracing/cnf-testsuite.yml`
-  response_s = `./cnf-testsuite tracing`
-  LOGGING.info response_s
-  (/PASSED: Tracing used/ =~ response_s).should_not be_nil
-ensure
-  LOGGING.info `./cnf-testsuite cnf_cleanup cnf-config=sample-cnfs/sample-tracing/cnf-testsuite.yml`
-  JaegerManager.uninstall
-  KubectlClient::Get.resource_wait_for_uninstall("Statefulset", "jaeger-cassandra")
-  KubectlClient::Get.resource_wait_for_uninstall("Deployment", "jaeger-collector")
-  KubectlClient::Get.resource_wait_for_uninstall("Deployment", "jaeger-query")
-  KubectlClient::Get.resource_wait_for_uninstall("Daemonset", "jaeger-agent")
-end
-

--- a/spec/workload/observability_spec.cr
+++ b/spec/workload/observability_spec.cr
@@ -45,13 +45,13 @@ describe "Observability" do
     ShellCmd.run(install_cmd, "helm_install_prometheus", force_output: true)
 
     KubectlClient::Get.wait_for_install("prometheus-server")
-    ShellCmd.run("kubectl describe deployment prometheus-server", force_output: true)
+    ShellCmd.run("kubectl describe deployment prometheus-server", "k8s_describe_prometheus", force_output: true)
 
     test_result = ShellCmd.run("./cnf-testsuite prometheus_traffic", "run_test_cmd", force_output: true)
     (/PASSED: Your cnf is sending prometheus traffic/ =~ test_result[:output]).should_not be_nil
   ensure
     ShellCmd.run("./cnf-testsuite cnf_cleanup cnf-config=sample-cnfs/sample-prom-pod-discovery/cnf-testsuite.yml", "spec_sample_cleaup")
-    result = ShellCmd.run("#{helm} delete prometheus")
+    result = ShellCmd.run("#{helm} delete prometheus", "helm_delete_prometheus")
     result[:status].success?.should be_true
   end
 

--- a/spec/workload/observability_spec.cr
+++ b/spec/workload/observability_spec.cr
@@ -34,7 +34,7 @@ describe "Observability" do
   end
 
   it "'prometheus_traffic' should pass if there is prometheus traffic", tags: ["observability"] do
-    Shell.cmd.run("./cnf-testsuite cnf_setup cnf-config=sample-cnfs/sample-prom-pod-discovery/cnf-testsuite.yml", "spec_sample_setup", force_output: true)
+    ShellCmd.run("./cnf-testsuite cnf_setup cnf-config=sample-cnfs/sample-prom-pod-discovery/cnf-testsuite.yml", "spec_sample_setup", force_output: true)
     helm = BinarySingleton.helm
 
     Log.info { "Add prometheus helm repo" }

--- a/spec/workload/registry_spec.cr
+++ b/spec/workload/registry_spec.cr
@@ -14,24 +14,24 @@ describe "Private Registry: Image" do
     KubectlClient::Get.resource_wait_for_install("Pod", "registry")
     KubectlClient::Get.resource_wait_for_install("Pod", "dockerd")
 
-    KubectlClient.exec("dockerd -t -- apk add curl", true)
-    KubectlClient.exec("dockerd -t -- curl http://example.com", true)
+    KubectlClient.exec("dockerd -t -- apk add curl", force_output: true)
+    KubectlClient.exec("dockerd -t -- curl http://example.com", force_output: true)
 
     if ENV["DOCKERHUB_USERNAME"]? && ENV["DOCKERHUB_PASSWORD"]?
-      result = KubectlClient.exec("dockerd -t -- docker login -u $DOCKERHUB_USERNAME -p $DOCKERHUB_PASSWORD", true)
+      result = KubectlClient.exec("dockerd -t -- docker login -u $DOCKERHUB_USERNAME -p $DOCKERHUB_PASSWORD", force_output: true)
       Log.info { "Docker Login output: #{result[:output]}" }
     else
       puts "DOCKERHUB_USERNAME & DOCKERHUB_PASSWORD Must be set.".colorize(:red)
       exit 1
     end
 
-    KubectlClient.exec("dockerd -t -- docker pull coredns/coredns:1.6.7", true)
-    KubectlClient.exec("dockerd -t -- docker tag coredns/coredns:1.6.7 registry:5000/coredns:1.6.7", true)
-    KubectlClient.exec("dockerd -t -- docker push registry:5000/coredns:1.6.7", true)
+    KubectlClient.exec("dockerd -t -- docker pull coredns/coredns:1.6.7", force_output: true)
+    KubectlClient.exec("dockerd -t -- docker tag coredns/coredns:1.6.7 registry:5000/coredns:1.6.7", force_output: true)
+    KubectlClient.exec("dockerd -t -- docker push registry:5000/coredns:1.6.7", force_output: true)
 
     # This is required for the test that uses the sample_local_registry_org_image CNF
-    KubectlClient.exec("dockerd -t -- docker tag coredns/coredns:1.6.7 registry:5000/coredns-sample-org/coredns:1.6.7", true)
-    KubectlClient.exec("dockerd -t -- docker push registry:5000/coredns-sample-org/coredns:1.6.7", true)
+    KubectlClient.exec("dockerd -t -- docker tag coredns/coredns:1.6.7 registry:5000/coredns-sample-org/coredns:1.6.7", force_output: true)
+    KubectlClient.exec("dockerd -t -- docker push registry:5000/coredns-sample-org/coredns:1.6.7", force_output: true)
   end
 
   it "'reasonable_image_size' should pass if using local registry and a port", tags: ["private_registry_image"]  do
@@ -75,16 +75,16 @@ describe "Private Registry: Rolling" do
     KubectlClient::Get.resource_wait_for_install("Pod", "registry")
     KubectlClient::Get.resource_wait_for_install("Pod", "dockerd")
 
-    KubectlClient.exec("dockerd -t -- apk add curl", true)
-    KubectlClient.exec("dockerd -t -- curl http://example.com", true)
+    KubectlClient.exec("dockerd -t -- apk add curl", force_output: true)
+    KubectlClient.exec("dockerd -t -- curl http://example.com", force_output: true)
 
-    KubectlClient.exec("dockerd -t -- docker pull coredns/coredns:1.6.7", true)
-    KubectlClient.exec("dockerd -t -- docker tag coredns/coredns:1.6.7 registry:5000/coredns:1.6.7", true)
-    KubectlClient.exec("dockerd -t -- docker push registry:5000/coredns:1.6.7", true)
+    KubectlClient.exec("dockerd -t -- docker pull coredns/coredns:1.6.7", force_output: true)
+    KubectlClient.exec("dockerd -t -- docker tag coredns/coredns:1.6.7 registry:5000/coredns:1.6.7", force_output: true)
+    KubectlClient.exec("dockerd -t -- docker push registry:5000/coredns:1.6.7", force_output: true)
 
-    KubectlClient.exec("dockerd -t -- docker pull coredns/coredns:1.8.0", true)
-    KubectlClient.exec("dockerd -t -- docker tag coredns/coredns:1.8.0 registry:5000/coredns:1.8.0", true)
-    KubectlClient.exec("dockerd -t -- docker push registry:5000/coredns:1.8.0", true)
+    KubectlClient.exec("dockerd -t -- docker pull coredns/coredns:1.8.0", force_output: true)
+    KubectlClient.exec("dockerd -t -- docker tag coredns/coredns:1.8.0 registry:5000/coredns:1.8.0", force_output: true)
+    KubectlClient.exec("dockerd -t -- docker push registry:5000/coredns:1.8.0", force_output: true)
   end
 
   it "'rolling_update' should pass if using local registry and a port", tags: ["private_registry_rolling"]  do

--- a/spec/workload/state_spec.cr
+++ b/spec/workload/state_spec.cr
@@ -30,7 +30,7 @@ describe "State" do
       Log.info {"Installing Mysql "}
       # Mysql.install
       # todo make helm directories work with parameters
-      Log.info {`./cnf-testsuite cnf_setup cnf-config=./sample-cnfs/sample-mysql/cnf-testsuite.yml`}
+      ShellCmd.run("./cnf-testsuite cnf_setup cnf-config=./sample-cnfs/sample-mysql/cnf-testsuite.yml", "sample_cnf_setup")
       KubectlClient::Get.resource_wait_for_install("Pod", "mysql-0")
       # KubectlClient::Delete.file("https://raw.githubusercontent.com/mysql/mysql-operator/trunk/samples/sample-cluster.yaml  --wait=false")
       # temp_pw = Random.rand.to_s
@@ -45,8 +45,8 @@ describe "State" do
        # KubectlClient::Delete.file("https://raw.githubusercontent.com/mysql/mysql-operator/trunk/samples/sample-cluster.yaml  --wait=false")
        # KubectlClient::Delete.file("https://raw.githubusercontent.com/mysql/mysql-operator/trunk/samples/sample-cluster.yaml")
       #todo fix cleanup for helm directory with parameters
-      Log.info {`./cnf-testsuite cnf_cleanup cnf-config=./sample-cnfs/sample-mysql/cnf-testsuite.yml`}
-      Log.info {`kubectl delete pvc data-mysql-0`}
+      ShellCmd.run("./cnf-testsuite cnf_cleanup cnf-config=./sample-cnfs/sample-mysql/cnf-testsuite.yml", "sample_cnf_cleanup")
+      ShellCmd.run("kubectl delete pvc data-mysql-0", "delete_pvc")
     end
   end
 

--- a/src/tasks/cnf_setup.cr
+++ b/src/tasks/cnf_setup.cr
@@ -4,7 +4,7 @@ require "colorize"
 require "totem"
 require "./utils/utils.cr"
 
-task "cnf_setup", ["helm_local_install"] do |_, args|
+task "cnf_setup", ["helm_local_install", "create_namespace"] do |_, args|
   Log.for("verbose").info { "cnf_setup" } if check_verbose(args)
   Log.for("verbose").debug { "args = #{args.inspect}" } if check_verbose(args)
   cli_hash = CNFManager.sample_setup_cli_args(args)

--- a/src/tasks/constants.cr
+++ b/src/tasks/constants.cr
@@ -23,6 +23,8 @@ IGNORED_SECRET_TYPES = ["kubernetes.io/service-account-token", "kubernetes.io/do
 EMPTY_JSON = JSON.parse(%({}))
 EMPTY_JSON_ARRAY = JSON.parse(%([]))
 
+TESTSUITE_NAMESPACE = "cnf-testsuite"
+
 #Embedded global text variables
 EmbeddedFileManager.node_failure_values
 EmbeddedFileManager.cluster_tools

--- a/src/tasks/platform/observability.cr
+++ b/src/tasks/platform/observability.cr
@@ -89,7 +89,7 @@ namespace "platform" do
         Log.info { "container_repo_digests: #{repo_digest_list}" }
         id_sha256_list = repo_digest_list.reduce([] of String) do |acc, repo_digest|
           Log.info { "repo_digest: #{repo_digest}" }
-          resp = KubectlClient.exec("#{ClusterTools.pod_name} -- crictl inspecti #{repo_digest}")
+          resp = KubectlClient.exec("#{ClusterTools.pod_name} -- crictl inspecti #{repo_digest}", namespace: TESTSUITE_NAMESPACE)
           cricti = resp[:output].to_s
           begin
             parsed_json = JSON.parse(cricti)

--- a/src/tasks/platform/observability.cr
+++ b/src/tasks/platform/observability.cr
@@ -259,7 +259,7 @@ end
         Log.info { "container_repo_digests: #{repo_digest_list}" }
         id_sha256_list = repo_digest_list.reduce([] of String) do |acc, repo_digest|
           Log.debug { "repo_digest: #{repo_digest}" }
-          cricti = KubectlClient.exec("-ti #{cluster_tools_pod} -- crictl inspecti #{repo_digest}")
+          cricti = KubectlClient.exec("-ti #{cluster_tools_pod} -- crictl inspecti #{repo_digest}", namespace: TESTSUITE_NAMESPACE)
           begin
             parsed_json = JSON.parse(cricti[:output])
             acc << parsed_json["status"]["id"].as_s

--- a/src/tasks/setup.cr
+++ b/src/tasks/setup.cr
@@ -15,6 +15,8 @@ task "create_namespace" do |_, args|
   else
     stdout_failure "Could not create cnf-testsuite namespace on the Kubernetes cluster"
   end
+rescue e : KubectlClient::Create::AlreadyExistsError
+  stdout_success "cnf-testsuite namespace already exists on the Kubernetes cluster"
 end
 
 task "offline" do |_, args|

--- a/src/tasks/setup.cr
+++ b/src/tasks/setup.cr
@@ -5,8 +5,16 @@ require "totem"
 
 desc "Sets up the CNF test suite, the K8s cluster, and upstream projects"
 
-task "setup", ["offline", "helm_local_install", "prereqs", "configuration_file_setup", "install_apisnoop", "install_sonobuoy", "install_chart_testing", "cnf_testsuite_setup", "install_kind"] do  |_, args|
+task "setup", ["offline", "helm_local_install", "prereqs", "create_namespace", "configuration_file_setup", "install_apisnoop", "install_sonobuoy", "install_chart_testing", "cnf_testsuite_setup", "install_kind"] do  |_, args|
   stdout_success "Setup complete"
+end
+
+task "create_namespace" do |_, args|
+  if KubectlClient::Create.namespace("cnf-testsuite")
+    stdout_success "Created cnf-testsuite namespace on the Kubernetes cluster"
+  else
+    stdout_failure "Could not create cnf-testsuite namespace on the Kubernetes cluster"
+  end
 end
 
 task "offline" do |_, args|
@@ -23,7 +31,7 @@ task "offline" do |_, args|
 end
 
 task "configuration_file_setup" do |_, args|
-  VERBOSE_LOGGING.info "configuration_file_setup" if check_verbose(args)
+  Log.for("verbose").info { "configuration_file_setup" } if check_verbose(args)
   CNFManager::Points.create_points_yml
 end
 

--- a/src/tasks/setup.cr
+++ b/src/tasks/setup.cr
@@ -10,7 +10,7 @@ task "setup", ["offline", "helm_local_install", "prereqs", "create_namespace", "
 end
 
 task "create_namespace" do |_, args|
-  if KubectlClient::Create.namespace("cnf-testsuite")
+  if KubectlClient::Create.namespace(TESTSUITE_NAMESPACE)
     stdout_success "Created cnf-testsuite namespace on the Kubernetes cluster"
   else
     stdout_failure "Could not create cnf-testsuite namespace on the Kubernetes cluster"

--- a/src/tasks/setup.cr
+++ b/src/tasks/setup.cr
@@ -11,12 +11,12 @@ end
 
 task "create_namespace" do |_, args|
   if KubectlClient::Create.namespace(TESTSUITE_NAMESPACE)
-    stdout_success "Created cnf-testsuite namespace on the Kubernetes cluster"
+    stdout_success "Created #{TESTSUITE_NAMESPACE} namespace on the Kubernetes cluster"
   else
-    stdout_failure "Could not create cnf-testsuite namespace on the Kubernetes cluster"
+    stdout_failure "Could not create #{TESTSUITE_NAMESPACE} namespace on the Kubernetes cluster"
   end
 rescue e : KubectlClient::Create::AlreadyExistsError
-  stdout_success "cnf-testsuite namespace already exists on the Kubernetes cluster"
+  stdout_success "#{TESTSUITE_NAMESPACE} namespace already exists on the Kubernetes cluster"
 end
 
 task "offline" do |_, args|

--- a/src/tasks/utils/cluster_utils.cr
+++ b/src/tasks/utils/cluster_utils.cr
@@ -55,7 +55,6 @@ module ClusterTools
     Log.info { "official_content_digest_by_image_name: #{image_name}"}
 
     result = exec("skopeo inspect docker://#{image_name}")
-    Log.for("skopeo_inspect").info { result[:output] }
     response = result[:output]
     if result[:status].success? && !response.empty?
       return JSON.parse(response)

--- a/src/tasks/utils/cluster_utils.cr
+++ b/src/tasks/utils/cluster_utils.cr
@@ -63,8 +63,13 @@ module ClusterTools
     JSON.parse(%({}))
   end
 
-  def self.local_match_by_image_name(image_name, nodes=KubectlClient::Get.nodes["items"].as_a )
+  def self.local_match_by_image_name(image_name, nodes = nil)
     Log.info { "local_match_by_image_name image_name: #{image_name}" }
+
+    if nodes == nil
+      nodes = KubectlClient::Get.nodes["items"].as_a
+    end
+
     match = Hash{:found => false, :digest => "", :release_name => ""}
     #todo get name of pod and match against one pod instead of getting all pods and matching them
     tag = KubectlClient::Get.container_tag_from_image_by_nodes(image_name, nodes)

--- a/src/tasks/utils/cluster_utils.cr
+++ b/src/tasks/utils/cluster_utils.cr
@@ -88,7 +88,7 @@ module ClusterTools
   end
 
   def self.pod_name()
-    KubectlClient::Get.pod_status("cluster-tools").split(",")[0]
+    KubectlClient::Get.pod_status("cluster-tools", namespace: TESTSUITE_NAMESPACE).split(",")[0]
   end
 
   def self.pod_by_node(node)

--- a/src/tasks/utils/cluster_utils.cr
+++ b/src/tasks/utils/cluster_utils.cr
@@ -93,7 +93,7 @@ module ClusterTools
 
   def self.pod_by_node(node)
     resource = KubectlClient::Get.resource("Daemonset", "cluster-tools", namespace: TESTSUITE_NAMESPACE)
-    pods = KubectlClient::Get.pods_by_resource(resource)
+    pods = KubectlClient::Get.pods_by_resource(resource, namespace: TESTSUITE_NAMESPACE)
     cluster_pod = pods.find do |pod|
       pod.dig("spec", "nodeName") == node
     end

--- a/src/tasks/utils/cluster_utils.cr
+++ b/src/tasks/utils/cluster_utils.cr
@@ -63,12 +63,14 @@ module ClusterTools
     JSON.parse(%({}))
   end
 
-  def self.local_match_by_image_name(image_name, nodes = nil)
+  def self.local_match_by_image_name(image_name : String)
     Log.info { "local_match_by_image_name image_name: #{image_name}" }
+    nodes = KubectlClient::Get.nodes["items"].as_a
+    local_match_by_image_name(image_name, nodes)
+  end
 
-    if nodes == nil
-      nodes = KubectlClient::Get.nodes["items"].as_a
-    end
+  def self.local_match_by_image_name(image_name, nodes : Array(JSON::Any))
+    Log.info { "local_match_by_image_name image_name: #{image_name}" }
 
     match = Hash{:found => false, :digest => "", :release_name => ""}
     #todo get name of pod and match against one pod instead of getting all pods and matching them

--- a/src/tasks/utils/cluster_utils.cr
+++ b/src/tasks/utils/cluster_utils.cr
@@ -55,6 +55,7 @@ module ClusterTools
     Log.info { "official_content_digest_by_image_name: #{image_name}"}
 
     result = exec("skopeo inspect docker://#{image_name}")
+    Log.for("skopeo_inspect").info { result[:output] }
     response = result[:output]
     if result[:status].success? && !response.empty?
       return JSON.parse(response)

--- a/src/tasks/utils/cluster_utils.cr
+++ b/src/tasks/utils/cluster_utils.cr
@@ -9,7 +9,7 @@ module ClusterTools
     Log.info { "ClusterTools uninstall" }
     File.write("cluster_tools.yml", CLUSTER_TOOLS)
     KubectlClient::Delete.file("cluster_tools.yml", namespace: TESTSUITE_NAMESPACE)
-    KubectlClient::Get.resource_wait_for_uninstall("Daemonset", "cluster-tools")
+    KubectlClient::Get.resource_wait_for_uninstall("Daemonset", "cluster-tools", namespace: TESTSUITE_NAMESPACE)
   end
 
   def self.exec(cli : String)

--- a/src/tasks/utils/cnf_manager.cr
+++ b/src/tasks/utils/cnf_manager.cr
@@ -949,7 +949,7 @@ module CNFManager
     destination_cnf_dir = config.cnf_config[:destination_cnf_dir]
     case install_method[0]
     when Helm::InstallMethod::ManifestDirectory
-      KubectlClient::Apply.file("#{destination_cnf_dir}/#{manifest_directory}", "--kubeconfig #{kubeconfig}")
+      KubectlClient::Apply.file("#{destination_cnf_dir}/#{manifest_directory}", kubeconfig: kubeconfig)
     when Helm::InstallMethod::HelmChart
       begin
         if offline

--- a/src/tasks/utils/cnf_manager.cr
+++ b/src/tasks/utils/cnf_manager.cr
@@ -691,7 +691,7 @@ module CNFManager
     Log.info { "tgz_name: #{tgz_name}" }
 
     unless input_file && !input_file.empty?
-      `rm #{tgz_name}`
+      FileUtils.rm_rf(tgz_name)
       helm_info = Helm.pull(helm_chart) 
       unless helm_info[:status].success?
         puts "Helm pull error".colorize(:red)

--- a/src/tasks/utils/k8s_instrumentation.cr
+++ b/src/tasks/utils/k8s_instrumentation.cr
@@ -6,7 +6,10 @@ require "halite"
 
 module K8sInstrumentation
   def self.disk_speed
-    cluster_tools = KubectlClient::Get.pod_status("cluster-tools").split(",")[0]
+    pod_status = KubectlClient::Get.pod_status("cluster-tools")
+    cluster_tools = pod_status.split(",")[0]
+    Log.info { "k8s_instrumentation_debug Pod status: #{pod_status.inspect}" }
+    result = ShellCmd.run("kubectl get all -A", "k8s_instrumentation_debug", force_output: true)
     resp = KubectlClient.exec("#{cluster_tools} -ti -- /bin/bash -c 'sysbench fileio prepare && sysbench fileio --file-test-mode=rndrw run'", namespace: TESTSUITE_NAMESPACE)
     parse_sysbench(resp[:output].to_s)
   end

--- a/src/tasks/utils/k8s_instrumentation.cr
+++ b/src/tasks/utils/k8s_instrumentation.cr
@@ -6,7 +6,7 @@ require "halite"
 
 module K8sInstrumentation
   def self.disk_speed
-    pod_status = KubectlClient::Get.pod_status("cluster-tools")
+    pod_status = KubectlClient::Get.pod_status("cluster-tools", namespace: TESTSUITE_NAMESPACE)
     cluster_tools = pod_status.split(",")[0]
     Log.info { "k8s_instrumentation_debug Pod status: #{pod_status.inspect}" }
     result = ShellCmd.run("kubectl get all -A", "k8s_instrumentation_debug", force_output: true)

--- a/src/tasks/utils/k8s_instrumentation.cr
+++ b/src/tasks/utils/k8s_instrumentation.cr
@@ -7,7 +7,7 @@ require "halite"
 module K8sInstrumentation
   def self.disk_speed
     cluster_tools = KubectlClient::Get.pod_status("cluster-tools").split(",")[0]
-    resp = KubectlClient.exec("#{cluster_tools} -ti -- /bin/bash -c 'sysbench fileio prepare && sysbench fileio --file-test-mode=rndrw run'")
+    resp = KubectlClient.exec("#{cluster_tools} -ti -- /bin/bash -c 'sysbench fileio prepare && sysbench fileio --file-test-mode=rndrw run'", namespace: TESTSUITE_NAMESPACE)
     parse_sysbench(resp[:output].to_s)
   end
 
@@ -19,7 +19,7 @@ module K8sInstrumentation
         acc
       end
     end
-    LOGGING.debug "parsed_output: #{parsed_output}"
+    Log.debug { "parsed_output: #{parsed_output}" }
     parsed_output
   end
 end

--- a/src/tasks/utils/kubescape.cr
+++ b/src/tasks/utils/kubescape.cr
@@ -4,7 +4,7 @@ require "log"
 module Kubescape
 
   #kubescape scan framework nsa --exclude-namespaces kube-system,kube-public
-  def self.scan(cmd="framework nsa --use-from ./tools/kubescape/nsa.json --exclude-namespaces kube-system,kube-public --format json --output kubescape_results.json")
+  def self.scan(cmd="framework nsa --use-from ./tools/kubescape/nsa.json --exclude-namespaces kube-system,kube-public,#{TESTSUITE_NAMESPACE} --format json --output kubescape_results.json")
     alt_cmd = "./tools/kubescape/kubescape scan " + cmd
     Log.info { "scan command: #{cmd}" }
     status = Process.run(

--- a/src/tasks/utils/mysql.cr
+++ b/src/tasks/utils/mysql.cr
@@ -2,7 +2,7 @@ require "./cluster_utils.cr"
 module Mysql
   MYSQL_PORT = "3306" 
   def self.match()
-    ClusterTools.local_match_by_image_name("mysql/mysql-server")
+    ClusterTools.local_match_by_image_name("bitnami/mysql")
   end
   def self.uninstall
     Log.for("verbose").info { "uninstall_mysql" } 

--- a/src/tasks/workload/microservice.cr
+++ b/src/tasks/workload/microservice.cr
@@ -109,7 +109,7 @@ task "shared_database", ["install_cluster_tools"] do |_, args|
         # get multiple call for a larger sample
         parsed_netstat = (1..10).map {
           sleep 10
-          netstat = KubectlClient.exec("#{cluster_tools} -ti -- nsenter -t #{pid} -n netstat")
+          netstat = KubectlClient.exec("#{cluster_tools} -ti -- nsenter -t #{pid} -n netstat", namespace: TESTSUITE_NAMESPACE)
           Log.info { "Container Netstat: #{netstat}"}
           Netstat.parse(netstat[:output])
         }.flatten.compact

--- a/src/tasks/workload/microservice.cr
+++ b/src/tasks/workload/microservice.cr
@@ -17,7 +17,7 @@ end
 REASONABLE_STARTUP_BUFFER = 10.0
 
 desc "Does the CNF have a reasonable startup time (< 30 seconds)?"
-task "shared_database" do |_, args|
+task "shared_database", ["install_cluster_tools"] do |_, args|
   LOGGING.info "Running shared_database test"
   CNFManager::Task.task_runner(args) do |args, config|
     # todo loop through local resources and see if db match found
@@ -103,7 +103,7 @@ task "shared_database" do |_, args|
       cluster_tools = ClusterTools.pod_by_node("#{status["nodeName"]}")
       Log.info { "Container Tools Pod: #{cluster_tools}"}
       pids = status["ids"].map do |id| 
-        inspect = KubectlClient.exec("#{cluster_tools} -ti -- crictl inspect #{id}")
+        inspect = KubectlClient.exec("#{cluster_tools} -ti -- crictl inspect #{id}", namespace: TESTSUITE_NAMESPACE)
         pid = JSON.parse(inspect[:output]).dig("info", "pid")
         Log.info { "Container PID: #{pid}"}
         # get multiple call for a larger sample

--- a/src/tasks/workload/observability.cr
+++ b/src/tasks/workload/observability.cr
@@ -66,6 +66,7 @@ task "prometheus_traffic" do |_, args|
 
         Log.info { "service_url: #{service_url}"}
         ClusterTools.install
+        ShellCmd.run("kubectl get all -A", "view_all_services", force_output: true)
         prom_api_resp = ClusterTools.exec_k8s("curl http://#{service_url}.default.svc.local/api/v1/targets?state=active")
 
         Log.debug { "prom_api_resp: #{prom_api_resp}"}

--- a/src/tasks/workload/observability.cr
+++ b/src/tasks/workload/observability.cr
@@ -66,7 +66,6 @@ task "prometheus_traffic" do |_, args|
 
         Log.info { "service_url: #{service_url}"}
         ClusterTools.install
-        ShellCmd.run("kubectl get all -A", "view_all_services", force_output: true)
         prom_api_resp = ClusterTools.exec_k8s("curl http://#{service_url}.default.svc.cluster.local/api/v1/targets?state=active")
 
         Log.debug { "prom_api_resp: #{prom_api_resp}"}

--- a/src/tasks/workload/observability.cr
+++ b/src/tasks/workload/observability.cr
@@ -67,7 +67,7 @@ task "prometheus_traffic" do |_, args|
         Log.info { "service_url: #{service_url}"}
         ClusterTools.install
         ShellCmd.run("kubectl get all -A", "view_all_services", force_output: true)
-        prom_api_resp = ClusterTools.exec_k8s("curl http://#{service_url}.default.svc.local/api/v1/targets?state=active")
+        prom_api_resp = ClusterTools.exec_k8s("curl http://#{service_url}.default.svc.cluster.local/api/v1/targets?state=active")
 
         Log.debug { "prom_api_resp: #{prom_api_resp}"}
         prom_json = JSON.parse(prom_api_resp[:output])

--- a/src/tasks/workload/observability.cr
+++ b/src/tasks/workload/observability.cr
@@ -66,7 +66,7 @@ task "prometheus_traffic" do |_, args|
 
         Log.info { "service_url: #{service_url}"}
         ClusterTools.install
-        prom_api_resp = ClusterTools.exec_k8s("curl http://#{service_url}/api/v1/targets?state=active")
+        prom_api_resp = ClusterTools.exec_k8s("curl http://#{service_url}.default.svc.local/api/v1/targets?state=active")
 
         Log.debug { "prom_api_resp: #{prom_api_resp}"}
         prom_json = JSON.parse(prom_api_resp[:output])

--- a/src/tasks/workload/state.cr
+++ b/src/tasks/workload/state.cr
@@ -367,7 +367,6 @@ task "database_persistence" do |_, args|
     statefulset_exists = false
     match = Mysql.match
     # VERBOSE_LOGGING.info "hithere" if check_verbose(args)
-    Log.info {"hithere info"}
     Log.info {"database_persistence mysql: #{match}"}
     if match && match[:found]
       statefulset_exists = Helm.kind_exists?(args, config, "statefulset")

--- a/utils/kubectl_client/kubectl_client.cr
+++ b/utils/kubectl_client/kubectl_client.cr
@@ -131,7 +131,7 @@ module KubectlClient
       cmd = "kubectl create namespace #{name}"
       result = ShellCmd.run(cmd, "KubectlClient::Create.namespace")
       return true if result[:status].success?
-      return true if result[:stderr].includes?("AlreadyExists")
+      return true if result[:error].includes?("AlreadyExists")
       return false
     end
   end

--- a/utils/kubectl_client/kubectl_client.cr
+++ b/utils/kubectl_client/kubectl_client.cr
@@ -621,7 +621,7 @@ module KubectlClient
       JSON.parse(%({}))
     end
 
-    def self.wait_for_install(deployment_name, wait_count : Int32 = 180, namespace="default")
+    def self.wait_for_install(deployment_name, wait_count : Int32 = 180, namespace : String = "default")
       resource_wait_for_install("deployment", deployment_name, wait_count, namespace)
     end
 
@@ -712,7 +712,13 @@ module KubectlClient
       result[:output].to_i
     end
 
-    def self.resource_wait_for_install(kind : String, resource_name : String, wait_count : Int32 = 180, namespace="default", kubeconfig=nil)
+    def self.resource_wait_for_install(
+      kind : String,
+      resource_name : String,
+      wait_count : Int32 = 180,
+      namespace : String = "default",
+      kubeconfig : String | Nil = nil
+    )
       # Not all cnfs have #{kind}.  some have only a pod.  need to check if the
       # passed in pod has a deployment, if so, watch the deployment.  Otherwise watch the pod
       Log.info { "resource_wait_for_install kind: #{kind} resource_name: #{resource_name} namespace: #{namespace} kubeconfig: #{kubeconfig}" }
@@ -733,7 +739,7 @@ module KubectlClient
     end
 
     #TODO add parameter and functionality that checks for individual pods to be successfully terminated
-    def self.resource_wait_for_uninstall(kind : String, resource_name : String, wait_count : Int32 = 180, namespace="default")
+    def self.resource_wait_for_uninstall(kind : String, resource_name : String, wait_count : Int32 = 180, namespace : String | Nil = "default")
       # Not all cnfs have #{kind}.  some have only a pod.  need to check if the
       # passed in pod has a deployment, if so, watch the deployment.  Otherwise watch the pod
       Log.info { "resource_wait_for_uninstall kind: #{kind} resource_name: #{resource_name} namespace: #{namespace}" }
@@ -755,7 +761,7 @@ module KubectlClient
         second_count = second_count + 1
       end
 
-        Log.info { "final resource_uninstalled #{resource_uninstalled}" }
+      Log.info { "final resource_uninstalled #{resource_uninstalled}" }
       if (resource_uninstalled && resource_uninstalled.as_h == empty_hash)
         Log.info { "kind/resource #{kind}, #{resource_name} uninstalled." }
         true

--- a/utils/kubectl_client/kubectl_client.cr
+++ b/utils/kubectl_client/kubectl_client.cr
@@ -137,8 +137,12 @@ module KubectlClient
   end
 
   module Apply
-    def self.file(file_name, options="")
-      cmd = "kubectl apply -f #{file_name} #{options}"
+    def self.file(file_name, kubeconfig : String | Nil = nil, namespace: String | Nil = nil)
+      cmd = ["kubectl apply"]
+      cmd << "--kubeconfig #{kubeconfig}" if kubeconfig
+      cmd << "-n #{namespace}" if namespace
+      cmd << "-f #{file_name}"
+      cmd = cmd.join(" ")
       ShellCmd.run(cmd, "KubectlClient::Apply.file")
     end
 
@@ -174,8 +178,8 @@ module KubectlClient
       ShellCmd.run(cmd, "KubectlClient::Delete.command")
     end
 
-    def self.file(file_name)
-      cmd = "kubectl delete -f #{file_name}"
+    def self.file(file_name, namespace : String | Nil = nil)
+      cmd = "kubectl delete #{namespace ? "-n #{namespace}" : ""} -f #{file_name}"
       ShellCmd.run(cmd, "KubectlClient::Delete.file")
     end
   end

--- a/utils/kubectl_client/kubectl_client.cr
+++ b/utils/kubectl_client/kubectl_client.cr
@@ -137,7 +137,7 @@ module KubectlClient
   end
 
   module Apply
-    def self.file(file_name, kubeconfig : String | Nil = nil, namespace: String | Nil = nil)
+    def self.file(file_name, kubeconfig : String | Nil = nil, namespace : String | Nil = nil)
       cmd = ["kubectl apply"]
       cmd << "--kubeconfig #{kubeconfig}" if kubeconfig
       cmd << "-n #{namespace}" if namespace

--- a/utils/kubectl_client/kubectl_client.cr
+++ b/utils/kubectl_client/kubectl_client.cr
@@ -121,6 +121,9 @@ module KubectlClient
   end
 
   module Create
+    class AlreadyExistsError < Exception
+    end
+
     def self.command(cli : String)
       cmd = "kubectl create #{cli}"
       result = ShellCmd.run(cmd, "KubectlClient::Create.command")
@@ -131,7 +134,7 @@ module KubectlClient
       cmd = "kubectl create namespace #{name}"
       result = ShellCmd.run(cmd, "KubectlClient::Create.namespace")
       return true if result[:status].success?
-      return true if result[:error].includes?("AlreadyExists")
+      raise AlreadyExistsError.new if result[:error].includes?("AlreadyExists")
       return false
     end
   end

--- a/utils/kubectl_client/kubectl_client.cr
+++ b/utils/kubectl_client/kubectl_client.cr
@@ -67,9 +67,14 @@ module KubectlClient
     {status: status, output: output, error: stderr}
   end
 
-  def self.exec(command, force_output=false)
-    cmd = "kubectl exec #{command}"
-    ShellCmd.run(cmd, "KubectlClient.exec", force_output)
+  def self.exec(command, namespace : String | Nil = nil, force_output : Bool = false)
+    full_cmd = ["kubectl", "exec"]
+    if namespace
+      full_cmd << "-n #{namespace}"
+    end
+    full_cmd << command
+    full_cmd = full_cmd.join(" ")
+    ShellCmd.run(full_cmd, "KubectlClient.exec", force_output)
   end
 
   def self.cp(command)

--- a/utils/kubectl_client/kubectl_client.cr
+++ b/utils/kubectl_client/kubectl_client.cr
@@ -126,6 +126,14 @@ module KubectlClient
       result = ShellCmd.run(cmd, "KubectlClient::Create.command")
       result[:status].success?
     end
+
+    def self.namespace(name : String)
+      cmd = "kubectl create namespace #{name}"
+      result = ShellCmd.run(cmd, "KubectlClient::Create.namespace")
+      return true if result[:status].success?
+      return true if result[:stderr].includes?("AlreadyExists")
+      return false
+    end
   end
 
   module Apply


### PR DESCRIPTION
# Description

This PR moves cluster tools to different namespace to avoid residue cluster resources and third-party tools from affecting other tests. This PR also sets up the ground work for #1219

### New namespace for third-party tools

Create new testsuite namespace (`cnf-testsuite`) in the k8s cluster
* Defines a new constant `TESTSUITE_NAMESPACE`
* Adds `create_namespace` task as a dependency for `setup` and `cnf-setup` (fail-safe)

### Runs setup before running tests

* Runs `setup` task in before_all for the following spec test groups.
  * Observability platform spec tests
  * Observability workload spec tests
  * Microservice workload spec tests
  * K8s Instrumentation spec tests
  * Utils spec tests
* Also had to move Observability Workload tests into the describe block to ensure that they respect the `before_all` block.

### Updates KubectlClient helper functions to support `namespace` argument

Add namespace optional argument to the following and update any impact areas where these are used.
* `KubectlClient::Apply.file` (also makes kubeconfig a named argument and removes unused `options` argument)
* `KubectlClient::Delete.file`
* `KubectlClient::Get.resource`
* `KubectlClient::Get.resource_wait_for_uninstall`
* `KubectlClient::Get.pods_by_resource`
* `KubectlClient::Get.resource_spec_labels`
* `KubectlClient::Get.pod_status`
* `KubectlClient.exec`

### Updates to ClusterTools

* Update all helper methods to respect the `cnf-testsuite` namespace when installing, uninstalling and executing commands.
* Use `ClusterTools.install` in place of any code that uses direct `kubectl apply` to instal cluster-tools.

### Update `Kubescape.scan` to exclude `cnf-testsuite` namespace

This ensures that all tools installed in the `cnf-testsuite` k8s namespace are excluded from the scan.

### Minor refactoring additions

* Adds argument types to function signature for following functions
  * `KubectlClient::Get.wait_for_install`
  * `KubectlClient::Get.resource_wait_for_uninstall`
* Remove commented code from `ClusterTools.wait_for_cluster_tools`
* Replace backticks with `FileUtils.rm_rf` in `CNFManager`
* Update the  `'prometheus_traffic' should pass if there is prometheus traffic` test to use `ShelCmd.run` and helm from `BinarySingleton.helm`.

### Changes to resolve #1220

Add overloads for `ClusterTools.local_match_by_image_name` to resolve the issue.

### Changes to resolve #1221

Update image name in the `Mysql` module to `bitnami/mysql` to resolve the issue.

## Issues:
Refs: #1199, #1120, #1121

## Validation

Validating this PR requires a comparison with the output of the workload tests in the main branch.

#### In the main branch
* When workload tests are run, the test output for some kubescape tests will include `cluster-tools` in the failures.
* The output will look like screenshot in #1199 (notice that failures do not include cluster-tools)

#### After the changes in the PR are applied
* When workload tests are run, the output for some kubescape tests will not include `cluster-tools` in the failures.
* The output will look like screenshot in #1219 (notice that failures do not include cluster-tools). The screenshot in the ticket 1219 was taken after applying the changes in this PR.

## How has this been tested:
 - [x] Covered by existing integration testing
 - [ ] Added integration testing to cover
 - [ ] Verified all A/C passes
     * [ ] develop
     * [ ] master
     * [ ] tag/other branch
 - [ ] Test environment
    * [ ] Shared Packet K8s cluster
    * [ ] New Packet K8s cluster
    * [ ] Kind cluster
 - [ ] Have not tested

## Types of changes:
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [ ] Documentation update

## Checklist:
**Documentation**
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] No updates required.

**Code Review**
- [x] Does the test handle fatal exceptions, ie. rescue block

**Issue**
- [x] Tasks in issue are checked off
