### PR TITLE
[BUG] 1243 1244 usage doc URL and description fixes

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -261,14 +261,15 @@ Now run the test:
 
 ##### :heavy_check_mark: To check if the CNF is compatible with different CNIs
 <details> <summary>Details for CNI Compatibility Tests</summary>
+<p>
 
-<p><b>CNI Compatible Tests:</b> Best practice states a good CNF should be compatible with multiple and different CNIs (Container Network Interface). The CNI handles the container network for the container network namespace, along with management of IP Addresses through IPAM plug-in among other networking needs and requirements. You can read more about CNIs for kubernetes with their list of [compatible CNIs](https://bit.ly/cni-compatible-k8s-doc). 
+<b>CNI Compatible Tests:</b> Best practice states a good CNF should be compatible with multiple and different CNIs (Container Network Interface). The CNI handles the container network for the container network namespace, along with management of IP Addresses through IPAM plug-in among other networking needs and requirements. You can read more about CNIs for kubernetes with their list of [compatible CNIs](https://bit.ly/cni-compatible-k8s-doc). 
 
 <b>What's Tested:</b> This test will install temporary kind clusters to test your CNF using Calico and Cilium CNIs.
 
 <b>Remediation:</b> To mitigate this issue, make sure your CNF is compatible with Calico, Cilium and other available CNIs.
-
 </p>
+
 </details>
 
 ```

--- a/USAGE.md
+++ b/USAGE.md
@@ -262,7 +262,7 @@ Now run the test:
 ##### :heavy_check_mark: To check if the CNF is compatible with different CNIs
 <details> <summary>Details for CNI Compatibility Tests</summary>
 
-<p><b>CNI Compatible Tests:</b> Best practice states a good CNF should be compatible with multiple and different CNIs (Container Network Interface). The CNI handles the container network for the container network namespace, along with management of IP Addresses through IPAM plug-in among other networking needs and requirements. You can read more about CNIs for kubernetes with their list of [compatible CNIs](https://bit.ly/cni-compatible-k8s-doc)
+<p><b>CNI Compatible Tests:</b> Best practice states a good CNF should be compatible with multiple and different CNIs (Container Network Interface). The CNI handles the container network for the container network namespace, along with management of IP Addresses through IPAM plug-in among other networking needs and requirements. You can read more about CNIs for kubernetes with their list of [compatible CNIs](https://bit.ly/cni-compatible-k8s-doc). 
 
 <b>What's Tested:</b> This test will install temporary kind clusters to test your CNF using Calico and Cilium CNIs.
 

--- a/USAGE.md
+++ b/USAGE.md
@@ -234,7 +234,7 @@ Now run the test:
 ./cnf-testsuite install_script_helm
 ```
 
-##### :heavy_check_mark: To test if the CNF can perform a [rolling update](https://kubernetes.io/docs/tasks/run-application/rolling-update-replication-controller/)
+##### :heavy_check_mark: To test if the CNF can perform a [rolling update](https://kubernetes.io/docs/tutorials/kubernetes-basics/update/update-intro/)
 
 ```
 ./cnf-testsuite rolling_update
@@ -262,7 +262,7 @@ Now run the test:
 ##### :heavy_check_mark: To check if the CNF is compatible with different CNIs
 <details> <summary>Details for CNI Compatibility Tests</summary>
 
-<p><b>CNI Compatible Tests:</b> Best practice states a good CNF should be compatible with multiple and different CNIs (Cloud Container Interface). The CNI handles the container network for the container network namespace, along with management of IP Addresses through IPAM plug-in among other networking needs and requirements. You can read more about CNIs for kubernetes with a list of CNIs for use [here](https://bit.ly/cni-compatible-k8s-doc)
+<p><b>CNI Compatible Tests:</b> Best practice states a good CNF should be compatible with multiple and different CNIs (Container Network Interface). The CNI handles the container network for the container network namespace, along with management of IP Addresses through IPAM plug-in among other networking needs and requirements. You can read more about CNIs for kubernetes with their list of [compatible CNIs](https://bit.ly/cni-compatible-k8s-doc)
 
 <b>What's Tested:</b> This test will install temporary kind clusters to test your CNF using Calico and Cilium CNIs.
 


### PR DESCRIPTION
## Description
Fixed URLs and small updates of CNI description.

## Issues:
Refs: #1243 #1244

## How has this been tested:
 - [ ] Covered by existing integration testing
 - [ ] Added integration testing to cover
 - [ ] Verified all A/C passes
     * [ ] develop
     * [ ] master
     * [ ] tag/other branch
 - [ ] Test environment
    * [ ] Shared Packet K8s cluster
    * [ ] New Packet K8s cluster
    * [ ] Kind cluster
 - [ ] Have not tested

## Types of changes:
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [x] Documentation update

## Checklist:
**Documentation**
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] No updates required.

**Code Review**
- [ ] Does the test handle fatal exceptions, ie. rescue block

**Issue**
- [ ] Tasks in issue are checked off
