### PR TITLE
Fix bug that causes cnf-setup to fail when a helm warning occurs.

### DIFF
--- a/spec/utils/cnf_manager_spec.cr
+++ b/spec/utils/cnf_manager_spec.cr
@@ -286,10 +286,12 @@ describe "SampleUtils" do
     config_file = "sample-cnfs/k8s-non-helm"
     args = Sam::Args.new(["cnf-config=./#{config_file}/cnf-testsuite.yml", "verbose", "wait_count=0"])
     cli_hash = CNFManager.sample_setup_cli_args(args)
+    Log.info {"Running Setup"}
     CNFManager.sample_setup(cli_hash)
     # args = Sam::Args.new
     # config_file = "sample-cnfs/k8s-non-helm"
     # CNFManager.sample_setup_args(sample_dir: config_file, deploy_with_chart: false, args: args, verbose: true, install_from_manifest: true, wait_count: 0 )
+    Log.info {"Parse Config"}
     config = CNFManager::Config.parse_config_yml(CNFManager.ensure_cnf_testsuite_yml_path(config_file))    
     release_name = config.cnf_config[:release_name]
     (Dir.exists? "cnfs/#{release_name}").should be_true

--- a/src/tasks/utils/cnf_manager.cr
+++ b/src/tasks/utils/cnf_manager.cr
@@ -967,8 +967,12 @@ module CNFManager
 
     Log.info { "final liveness_time: #{liveness_time}" }
     Log.info { "elapsed_time.seconds: #{elapsed_time.seconds}" }
+    Log.info { "helm_install: #{helm_install}" }
+    Log.info { "helm_error: #{helm_error}" }
+    Log.info { "helm_install[:error].to_s: #{helm_install[:error].to_s}" }
+    Log.info { "helm_install[:error].to_s.size: #{helm_install[:error].to_s.size}" }
     helm_used = false
-    if helm_install && helm_error == false && helm_install[:error].to_s.size == 0 # && helm_pull.to_s.size > 0
+    if helm_install && helm_error == false # fails on warnings ... && helm_install[:error].to_s.size == 0 # && helm_pull.to_s.size > 0
       helm_used = true
       stdout_success "Successfully setup #{release_name}"
     end

--- a/tools/cluster-tools/Dockerfile
+++ b/tools/cluster-tools/Dockerfile
@@ -7,8 +7,8 @@ RUN make openmetricsvalidator
 FROM debian:latest
 ENV CRI_VERSION="v1.17.0"
 ENV CTR_VERSION="1.5.0"
-ENV CONTAINER_RUNTIME_ENDPOINT=unix:///run/containerd/containerd.sock
-ENV IMAGE_SERVICE_ENDPOINT=unix:///run/containerd/containerd.sock
+#ENV CONTAINER_RUNTIME_ENDPOINT=unix:///run/containerd/containerd.sock
+#ENV IMAGE_SERVICE_ENDPOINT=unix:///run/containerd/containerd.sock
 
 COPY --from=validator /validator/bin/openmetricsvalidator /usr/local/bin/
 RUN echo "deb http://deb.debian.org/debian buster-backports main" >> /etc/apt/sources.list

--- a/tools/cluster-tools/manifest.yml
+++ b/tools/cluster-tools/manifest.yml
@@ -14,7 +14,7 @@ spec:
       hostNetwork: true
       containers:
         - name: cluster-tools
-          image: conformance/cluster-tools:v1.0.0
+          image: conformance/cluster-tools:v1.0.1
           imagePullPolicy: Always
           command: ["/bin/sh"]
           args: ["-c", "sleep infinity"]
@@ -23,6 +23,8 @@ spec:
             name: containerd-volume
           - mountPath: /proc
             name: proc
+          - mountPath: /run/dockershim.sock
+            name: dockerd-volume
           securityContext:
             privileged: true
       volumes:
@@ -32,6 +34,9 @@ spec:
       - name: proc
         hostPath:
           path: /proc
+      - name: dockerd-volume
+        hostPath:
+          path: /run/dockershim.sock
 ---
 apiVersion: apps/v1
 kind: DaemonSet
@@ -48,14 +53,19 @@ spec:
     spec:
       containers:
         - name: cluster-tools-k8s
-          image: conformance/cluster-tools:v1.0.0
+          image: conformance/cluster-tools:v1.0.1
           imagePullPolicy: Always
           command: ["/bin/sh"]
           args: ["-c", "sleep infinity"]
           volumeMounts:
           - mountPath: /run/containerd/containerd.sock
             name: containerd-volume
+          - mountPath: /run/dockershim.sock
+            name: dockerd-volume
       volumes:
       - name: containerd-volume
         hostPath:
           path: /var/run/containerd/containerd.sock
+      - name: dockerd-volume
+        hostPath:
+          path: /run/dockershim.sock

--- a/tools/cluster-tools/manifest.yml
+++ b/tools/cluster-tools/manifest.yml
@@ -14,7 +14,7 @@ spec:
       hostNetwork: true
       containers:
         - name: cluster-tools
-          image: conformance/cluster-tools:v1.0.1
+          image: conformance/cluster-tools:v1.0.0
           imagePullPolicy: Always
           command: ["/bin/sh"]
           args: ["-c", "sleep infinity"]
@@ -53,7 +53,7 @@ spec:
     spec:
       containers:
         - name: cluster-tools-k8s
-          image: conformance/cluster-tools:v1.0.1
+          image: conformance/cluster-tools:v1.0.0
           imagePullPolicy: Always
           command: ["/bin/sh"]
           args: ["-c", "sleep infinity"]


### PR DESCRIPTION
## Description
Fix bug that causes cnf-setup to fail when a helm warning occurs.

## Issues:
Refs: cncf/cnf-testsuite#1275

## How has this been tested:
 - [ ] Covered by existing integration testing
 - [ ] Added integration testing to cover
 - [ ] Verified all A/C passes
     * [ ] develop
     * [ ] master
     * [ ] tag/other branch
 - [ ] Test environment
    * [ ] Shared Packet K8s cluster
    * [ ] New Packet K8s cluster
    * [ ] Kind cluster
 - [ ] Have not tested

## Types of changes:
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [ ] Documentation update

## Checklist:
**Documentation**
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] No updates required.

**Code Review**
- [ ] Does the test handle fatal exceptions, ie. rescue block

**Issue**
- [ ] Tasks in issue are checked off
