### PR TITLE
[1272,1273,1274,1292] Add default_namespace, latest_tag and selinux_options tests based on Kyverno

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -705,6 +705,25 @@ For example, running `kubectl get logs` returns useful information for diagnosin
 ./cnf-testsuite container_sock_mounts
 ```
 
+##### :heavy_check_mark: To check if namespaces have a default network
+
+```
+./cnf-testsuite default_network_policy
+```
+
+<details>
+<summary>Details for `default_network_policy`</summary>
+
+<p>
+By default, Kubernetes allows communications across all Pods within a cluster. The NetworkPolicy resource and a CNI plug-in that supports NetworkPolicy must be used to restrict communications.
+</p>
+
+<p>
+<b>Remediation steps:</b> A default NetworkPolicy should be configured for each Namespace to default deny all ingress and egress traffic to the Pods in the Namespace. Application teams can then configure additional NetworkPolicy resources to allow desired traffic to application Pods from select sources. This policy will create a new NetworkPolicy resource named `default-deny` which will deny all traffic anytime a new Namespace is created.
+</p>
+
+</details>
+
 ##### :heavy_check_mark: To check if containers are using any tiller images
 <details> <summary>Details for tiller images</summary>
 <p>
@@ -948,6 +967,34 @@ Read more at [ARMO-C0038](https://bit.ly/3nGvpIQ)
 ./cnf-testsuite host_pid_ipc_privileges
 ```
 
+##### :heavy_check_mark: To check if CNF resources use custom SELinux options that allow privilege escalation
+
+```
+./cnf-testsuite selinux_options
+```
+
+<details>
+<summary>Details for `selinux_options`</summary>
+
+<p>
+SELinux options can be used to escalate privileges and should not be allowed.
+</p>
+
+<p>
+<b>Remediation steps:</b>
+Ensure the following guidelines are followed for any cluster resource that allow SELinux options.
+  <ul>
+    <li>
+    If the SELinux option `type` is set, it should only be one of the allowed values: `container_t`, `container_init_t`, or `container_kvm_t`.
+    </li>
+    <li>
+    SELinux options `user` or `role` should not be set.
+    </li>
+  </ul>
+</p>
+
+</details>
+
 ##### :heavy_check_mark: To check if security services are being used to harden containers
 <details> <summary>Details for Linux Hardening</summary>
 
@@ -1043,6 +1090,44 @@ crystal src/cnf-testsuite.cr protected_access
 ```
 ./cnf-testsuite configuration_lifecycle
 ```
+
+##### :heavy_check_mark: To check if resources of the CNF are not in the default namespace
+
+```
+./cnf-testsuite default_namespace
+```
+
+<details>
+<summary>Details for `default_namespace`</summary>
+
+<p>
+Kubernetes Namespaces provide a way to segment and isolate cluster resources across multiple applications and users. As a best practice, workloads should be isolated with Namespaces.
+</p>
+
+<p>
+<b>Remediation steps:</b> Namespaces should be required and the default (empty) Namespace should not be used. This policy validates that Pods specify a Namespace name other than `default`.
+</p>
+
+</details>
+
+##### :heavy_check_mark: To check if Pods in the CNF use container images with the latest tag
+
+```
+./cnf-testsuite latest_tag
+```
+
+<details>
+<summary>Details for `latest_tag`</summary>
+
+<p>
+The `:latest` tag is mutable and can lead to unexpected errors if the image changes. Even when a tag is not specified, the `:latest` tag is used by default.
+</p>
+
+<p>
+<b>Remediation steps:</b> When specifying container images, always specify a tag and ensure to use an immutable tag that maps to a specific version of an application Pod. Avoid using the `latest` tag, as it is not guaranteed to be always point to the same version of the image.
+</p>
+
+</details>
 
 ##### :heavy_check_mark: To check if pods are using the `app.kubernetes.io/name` label
 <details> <summary>Details for labels test</summary>

--- a/USAGE.md
+++ b/USAGE.md
@@ -705,25 +705,6 @@ For example, running `kubectl get logs` returns useful information for diagnosin
 ./cnf-testsuite container_sock_mounts
 ```
 
-##### :heavy_check_mark: To check if namespaces have a default network
-
-```
-./cnf-testsuite default_network_policy
-```
-
-<details>
-<summary>Details for `default_network_policy`</summary>
-
-<p>
-By default, Kubernetes allows communications across all Pods within a cluster. The NetworkPolicy resource and a CNI plug-in that supports NetworkPolicy must be used to restrict communications.
-</p>
-
-<p>
-<b>Remediation steps:</b> A default NetworkPolicy should be configured for each Namespace to default deny all ingress and egress traffic to the Pods in the Namespace. Application teams can then configure additional NetworkPolicy resources to allow desired traffic to application Pods from select sources. This policy will create a new NetworkPolicy resource named `default-deny` which will deny all traffic anytime a new Namespace is created.
-</p>
-
-</details>
-
 ##### :heavy_check_mark: To check if containers are using any tiller images
 <details> <summary>Details for tiller images</summary>
 <p>

--- a/embedded_files/points.yml
+++ b/embedded_files/points.yml
@@ -259,3 +259,12 @@
 
 - name: external_ips
   tags: security, dynamic, workload
+
+- name: selinux_options
+  tags: security, dynamic, workload
+
+- name: default_namespace
+  tags: configuration, dynamic, workload
+
+- name: latest_tag
+  tags: configuration, dynamic, workload

--- a/sample-cnfs/sample_latest_tag/cnf-testsuite.yml
+++ b/sample-cnfs/sample_latest_tag/cnf-testsuite.yml
@@ -1,0 +1,16 @@
+---
+git_clone_url: 
+install_script: 
+manifest_directory: manifests
+release_name: nginx
+docker_repository: 
+helm_repository:
+  name: 
+  repo_url:
+container_names: 
+  - name: nginx
+    rolling_update_test_tag: "latest"
+    rolling_downgrade_test_tag: latest
+    rolling_version_change_test_tag: latest
+    rollback_from_tag: latest
+allowlist_helm_chart_container_names: []

--- a/sample-cnfs/sample_latest_tag/manifests/pod.yml
+++ b/sample-cnfs/sample_latest_tag/manifests/pod.yml
@@ -27,4 +27,7 @@ spec:
     ports:
       - containerPort: 8080
       - containerPort: 8443
+    securityContext:
+      seLinuxOptions:
+        type: spc_t
   dnsPolicy: Default

--- a/sample-cnfs/sample_latest_tag/manifests/pod.yml
+++ b/sample-cnfs/sample_latest_tag/manifests/pod.yml
@@ -1,0 +1,30 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: nginx-stuff
+
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: nginx
+  namespace: nginx-stuff
+spec:
+  containers:
+  - image: bitnami/nginx:latest
+    name: nginx
+    command:
+      - /opt/bitnami/scripts/nginx/entrypoint.sh
+      - /opt/bitnami/scripts/nginx/run.sh
+    livenessProbe:
+      tcpSocket:
+        port: 8080
+    readinessProbe:
+      tcpSocket:
+        port: 8080
+    resources: {}
+    ports:
+      - containerPort: 8080
+      - containerPort: 8443
+  dnsPolicy: Default

--- a/spec/utils/cnf_manager_spec.cr
+++ b/spec/utils/cnf_manager_spec.cr
@@ -155,7 +155,7 @@ describe "SampleUtils" do
             "prometheus_traffic", "open_metrics",
             "ingress_egress_blocked", "dangerous_capabilities", "insecure_capabilities",
             "routed_logs", "tracing", "elastic_volumes", "alpha_k8s_apis", "service_discovery", "shared_database", "pod_dns_error",
-            "external_ips", "container_sock_mounts", "require_labels"]
+            "external_ips", "container_sock_mounts", "require_labels", "default_namespace"]
     (CNFManager::Points.all_task_test_names()).sort.should eq(tags.sort)
   end
 

--- a/spec/utils/cnf_manager_spec.cr
+++ b/spec/utils/cnf_manager_spec.cr
@@ -155,7 +155,7 @@ describe "SampleUtils" do
             "prometheus_traffic", "open_metrics",
             "ingress_egress_blocked", "dangerous_capabilities", "insecure_capabilities",
             "routed_logs", "tracing", "elastic_volumes", "alpha_k8s_apis", "service_discovery", "shared_database", "pod_dns_error",
-            "external_ips", "container_sock_mounts", "require_labels", "default_namespace"]
+            "external_ips", "container_sock_mounts", "require_labels", "default_namespace", "selinux_options"]
     (CNFManager::Points.all_task_test_names()).sort.should eq(tags.sort)
   end
 

--- a/spec/utils/cnf_manager_spec.cr
+++ b/spec/utils/cnf_manager_spec.cr
@@ -118,7 +118,11 @@ describe "SampleUtils" do
 
   it "'CNFManager::Points.tasks_by_tag' should return the tasks assigned to a tag", tags: ["points"] do
     CNFManager::Points.clean_results_yml
-    tags = ["alpha_k8s_apis", "hardcoded_ip_addresses_in_k8s_runtime_configuration", "hostport_not_used", "immutable_configmap", "ip_addresses", "nodeport_not_used", "secrets_used", "versioned_tag", "require_labels"]
+    tags = [
+      "alpha_k8s_apis", "hardcoded_ip_addresses_in_k8s_runtime_configuration", "hostport_not_used",
+      "immutable_configmap", "ip_addresses", "nodeport_not_used", "secrets_used", "versioned_tag",
+      "require_labels", "default_namespace", "latest_tag"
+    ]
     (CNFManager::Points.tasks_by_tag("configuration")).sort.should eq(tags.sort)
     (CNFManager::Points.tasks_by_tag("does-not-exist")).should eq([] of YAML::Any) 
   end
@@ -155,7 +159,7 @@ describe "SampleUtils" do
             "prometheus_traffic", "open_metrics",
             "ingress_egress_blocked", "dangerous_capabilities", "insecure_capabilities",
             "routed_logs", "tracing", "elastic_volumes", "alpha_k8s_apis", "service_discovery", "shared_database", "pod_dns_error",
-            "external_ips", "container_sock_mounts", "require_labels", "default_namespace", "selinux_options"]
+            "external_ips", "container_sock_mounts", "require_labels", "default_namespace", "selinux_options", "latest_tag"]
     (CNFManager::Points.all_task_test_names()).sort.should eq(tags.sort)
   end
 

--- a/spec/workload/configuration_spec.cr
+++ b/spec/workload/configuration_spec.cr
@@ -477,7 +477,7 @@ describe CnfTestSuite do
     begin
       LOGGING.info `./cnf-testsuite cnf_setup cnf-config=./sample-cnfs/sample_latest_tag`
       $?.success?.should be_true
-      response_s = `./cnf-testsuite default_namespace verbose`
+      response_s = `./cnf-testsuite latest_tag verbose`
       LOGGING.info response_s
       $?.success?.should be_true
       (/FAILED: Container images are using the latest tag/ =~ response_s).should_not be_nil
@@ -490,7 +490,7 @@ describe CnfTestSuite do
     begin
       LOGGING.info `./cnf-testsuite cnf_setup cnf-config=./sample-cnfs/sample_nonroot`
       $?.success?.should be_true
-      response_s = `./cnf-testsuite default_namespace verbose`
+      response_s = `./cnf-testsuite latest_tag verbose`
       LOGGING.info response_s
       $?.success?.should be_true
       (/PASSED: Container images are not using the latest tag/ =~ response_s).should_not be_nil

--- a/spec/workload/configuration_spec.cr
+++ b/spec/workload/configuration_spec.cr
@@ -447,6 +447,32 @@ describe CnfTestSuite do
     end
   end
 
+  it "'default_namespace' should fail if a cnf creates resources in the default namespace", tags: ["default_namespace"] do
+    begin
+      LOGGING.info `./cnf-testsuite cnf_setup cnf-config=./sample-cnfs/sample_coredns`
+      $?.success?.should be_true
+      response_s = `./cnf-testsuite default_namespace verbose`
+      LOGGING.info response_s
+      $?.success?.should be_true
+      (/FAILED: Resources are created in the default namespace/ =~ response_s).should_not be_nil
+    ensure
+      LOGGING.info `./cnf-testsuite cnf_cleanup cnf-config=./sample-cnfs/sample_coredns`
+    end
+  end
+
+  it "'default_namespace' should pass if a cnf does not create resources in the default namespace", tags: ["default_namespace"] do
+    begin
+      LOGGING.info `./cnf-testsuite cnf_setup cnf-config=./sample-cnfs/sample_latest_tag`
+      $?.success?.should be_true
+      response_s = `./cnf-testsuite default_namespace verbose`
+      LOGGING.info response_s
+      $?.success?.should be_true
+      (/PASSED: default namespace is not being used/ =~ response_s).should_not be_nil
+    ensure
+      LOGGING.info `./cnf-testsuite cnf_cleanup cnf-config=./sample-cnfs/sample_latest_tag`
+    end
+  end
+
   # Commenting because the test has now been marked as a POC
   #
   # it "'alpha_k8s_apis' should pass with a CNF that does not make use of alpha k8s APIs", tags: ["apisnoop"] do

--- a/spec/workload/configuration_spec.cr
+++ b/spec/workload/configuration_spec.cr
@@ -457,10 +457,12 @@ describe CnfTestSuite do
       (/FAILED: Resources are created in the default namespace/ =~ response_s).should_not be_nil
     ensure
       LOGGING.info `./cnf-testsuite cnf_cleanup cnf-config=./sample-cnfs/sample_coredns`
+      ShellCmd.run("kubectl get all -A", "test_cleanup_check", force_output=true)
     end
   end
 
   it "'default_namespace' should pass if a cnf does not create resources in the default namespace", tags: ["default_namespace"] do
+    ShellCmd.run("kubectl get all -A", "test_startup_check", force_output=true)
     begin
       LOGGING.info `./cnf-testsuite cnf_setup cnf-config=./sample-cnfs/sample_latest_tag`
       $?.success?.should be_true

--- a/spec/workload/configuration_spec.cr
+++ b/spec/workload/configuration_spec.cr
@@ -457,12 +457,25 @@ describe CnfTestSuite do
       (/FAILED: Resources are created in the default namespace/ =~ response_s).should_not be_nil
     ensure
       LOGGING.info `./cnf-testsuite cnf_cleanup cnf-config=./sample-cnfs/sample_coredns`
-      ShellCmd.run("kubectl get all -A", "test_cleanup_check", force_output=true)
+
+      # Using sleep() to wait for terminating resources to be fully deleted before running the next test.
+      #
+      # 1. Resources still in terminating state are not detected by Kyverno
+      #    and result in failures of the next default_namespace test.
+      #
+      # 2. Helm uninstall wait option and kubectl delete wait options,
+      #    do not wait for child resources to be fully deleted.
+      #
+      # 3. The output from kubectl json does not clearly indicate when a resource is in a terminating state.
+      #    Solution to this is a really solid wait_for_unintsall helper that checks for child resources also.
+      #    Can be possible by using the app.kubernetes.io/name label to lookup other resources of the CNF,
+      #    and using that selector to look for terminating resources.
+      #
+      sleep(3)
     end
   end
 
   it "'default_namespace' should pass if a cnf does not create resources in the default namespace", tags: ["default_namespace"] do
-    ShellCmd.run("kubectl get all -A", "test_startup_check", force_output=true)
     begin
       LOGGING.info `./cnf-testsuite cnf_setup cnf-config=./sample-cnfs/sample_latest_tag`
       $?.success?.should be_true

--- a/spec/workload/configuration_spec.cr
+++ b/spec/workload/configuration_spec.cr
@@ -463,7 +463,6 @@ describe CnfTestSuite do
 
   it "'default_namespace' should pass if a cnf does not create resources in the default namespace", tags: ["default_namespace"] do
     begin
-      KubectlClient::Utils.wait_for_terminations()
       LOGGING.info `./cnf-testsuite cnf_setup cnf-config=./sample-cnfs/sample_latest_tag`
       $?.success?.should be_true
       response_s = `./cnf-testsuite default_namespace verbose`

--- a/spec/workload/configuration_spec.cr
+++ b/spec/workload/configuration_spec.cr
@@ -473,6 +473,32 @@ describe CnfTestSuite do
     end
   end
 
+  it "'latest_tag' should fail if a cnf has containers that use images with the latest tag", tags: ["latest_tag"] do
+    begin
+      LOGGING.info `./cnf-testsuite cnf_setup cnf-config=./sample-cnfs/sample_latest_tag`
+      $?.success?.should be_true
+      response_s = `./cnf-testsuite default_namespace verbose`
+      LOGGING.info response_s
+      $?.success?.should be_true
+      (/FAILED: Container images are using the latest tag/ =~ response_s).should_not be_nil
+    ensure
+      LOGGING.info `./cnf-testsuite cnf_cleanup cnf-config=./sample-cnfs/sample_latest_tag`
+    end
+  end
+
+  it "'latest_tag' should pass if a cnf does not have containers that use images with the latest tag", tags: ["latest_tag"] do
+    begin
+      LOGGING.info `./cnf-testsuite cnf_setup cnf-config=./sample-cnfs/sample_nonroot`
+      $?.success?.should be_true
+      response_s = `./cnf-testsuite default_namespace verbose`
+      LOGGING.info response_s
+      $?.success?.should be_true
+      (/PASSED: Container images are not using the latest tag/ =~ response_s).should_not be_nil
+    ensure
+      LOGGING.info `./cnf-testsuite cnf_cleanup cnf-config=./sample-cnfs/sample_nonroot`
+    end
+  end
+
   # Commenting because the test has now been marked as a POC
   #
   # it "'alpha_k8s_apis' should pass with a CNF that does not make use of alpha k8s APIs", tags: ["apisnoop"] do

--- a/spec/workload/configuration_spec.cr
+++ b/spec/workload/configuration_spec.cr
@@ -104,7 +104,7 @@ describe CnfTestSuite do
       $?.success?.should be_true
       (/Passed/ =~ response_s).should_not be_nil
     ensure
-      `./cnf-testsuite cleanup_sample_coredns`
+      `./cnf-testsuite cnf_cleanup cnf-config=./sample-cnfs/sample_coredns/cnf-testsuite.yml`
     end
   end
 
@@ -138,7 +138,7 @@ describe CnfTestSuite do
       $?.success?.should be_true
       (/Passed/ =~ response_s).should_not be_nil
     ensure
-      `./cnf-testsuite cleanup_sample_coredns`
+      `./cnf-testsuite cnf_cleanup cnf-config=./sample-cnfs/sample_coredns/cnf-testsuite.yml`
     end
   end
 
@@ -164,7 +164,7 @@ describe CnfTestSuite do
       $?.success?.should be_true
       (/Passed/ =~ response_s).should_not be_nil
     ensure
-      `./cnf-testsuite cleanup_sample_coredns`
+      `./cnf-testsuite cnf_cleanup cnf-config=./sample-cnfs/sample_coredns/cnf-testsuite.yml`
     end
   end
 
@@ -190,7 +190,7 @@ describe CnfTestSuite do
       $?.success?.should be_true
       (/Passed/ =~ response_s).should_not be_nil
     ensure
-      `./cnf-testsuite cleanup_sample_coredns`
+      `./cnf-testsuite cnf_cleanup cnf-config=./sample-cnfs/sample_coredns/cnf-testsuite.yml`
     end
   end
 
@@ -218,7 +218,7 @@ describe CnfTestSuite do
       $?.success?.should be_true
       (/PASSED: NodePort is not used/ =~ response_s).should_not be_nil
     ensure
-      `./cnf-testsuite cleanup_sample_coredns`
+      `./cnf-testsuite cnf_cleanup cnf-config=./sample-cnfs/sample_coredns/cnf-testsuite.yml`
     end
   end
 
@@ -244,7 +244,7 @@ describe CnfTestSuite do
       $?.success?.should be_true
       (/PASSED: HostPort is not used/ =~ response_s).should_not be_nil
     ensure
-      `./cnf-testsuite cleanup_sample_coredns`
+      `./cnf-testsuite cnf_cleanup cnf-config=./sample-cnfs/sample_coredns/cnf-testsuite.yml`
     end
   end
 
@@ -283,7 +283,7 @@ describe CnfTestSuite do
       $?.success?.should be_true
       (/PASSED: No hard-coded IP addresses found in the runtime K8s configuration/ =~ response_s).should_not be_nil
     ensure
-      `./cnf-testsuite cleanup_sample_coredns`
+      `./cnf-testsuite cnf_cleanup cnf-config=./sample-cnfs/sample_coredns/cnf-testsuite.yml`
     end
   end
 

--- a/spec/workload/installability_spec.cr
+++ b/spec/workload/installability_spec.cr
@@ -51,8 +51,8 @@ describe CnfTestSuite do
     # LOGGING.debug `pwd` 
     # LOGGING.debug `echo $KUBECONFIG`
     begin
-      `./cnf-testsuite sample_coredns_cleanup force=true`
-      $?.success?.should be_true
+      # `./cnf-testsuite cnf_cleanup cnf-config=./sample-cnfs/sample-coredns-cnf/cnf-testsuite.yml verbose`
+      # $?.success?.should be_true
       LOGGING.info `./cnf-testsuite cnf_setup cnf-config=./sample-cnfs/sample-bad_helm_coredns-cnf/cnf-testsuite.yml verbose wait_count=0`
       $?.success?.should be_true
       response_s = `./cnf-testsuite helm_chart_valid`

--- a/spec/workload/installability_spec.cr
+++ b/spec/workload/installability_spec.cr
@@ -51,8 +51,6 @@ describe CnfTestSuite do
     # LOGGING.debug `pwd` 
     # LOGGING.debug `echo $KUBECONFIG`
     begin
-      # `./cnf-testsuite cnf_cleanup cnf-config=./sample-cnfs/sample-coredns-cnf/cnf-testsuite.yml verbose`
-      # $?.success?.should be_true
       LOGGING.info `./cnf-testsuite cnf_setup cnf-config=./sample-cnfs/sample-bad_helm_coredns-cnf/cnf-testsuite.yml verbose wait_count=0`
       $?.success?.should be_true
       response_s = `./cnf-testsuite helm_chart_valid`

--- a/spec/workload/security_spec.cr
+++ b/spec/workload/security_spec.cr
@@ -355,4 +355,30 @@ describe "Security" do
       LOGGING.info `./cnf-testsuite cnf_cleanup cnf-config=./sample-cnfs/sample_external_ips/cnf-testsuite.yml`
     end
   end
+
+  it "'selinux_options' should fail if containers have custom selinux options that can be used for privilege escalations", tags: ["selinux_options"] do
+    begin
+      LOGGING.info `./cnf-testsuite cnf_setup cnf-config=./sample-cnfs/sample_latest_tag`
+      $?.success?.should be_true
+      response_s = `./cnf-testsuite selinux_options verbose`
+      LOGGING.info response_s
+      $?.success?.should be_true
+      (/FAILED: Resources are using custom SELinux options/ =~ response_s).should_not be_nil
+    ensure
+      LOGGING.info `./cnf-testsuite cnf_cleanup cnf-config=./sample-cnfs/sample_latest_tag`
+    end
+  end
+
+  it "'selinux_options' should pass if containers do not have custom selinux options that can be used for privilege escalations", tags: ["selinux_options"] do
+    begin
+      LOGGING.info `./cnf-testsuite cnf_setup cnf-config=./sample-cnfs/sample_nonroot`
+      $?.success?.should be_true
+      response_s = `./cnf-testsuite selinux_options verbose`
+      LOGGING.info response_s
+      $?.success?.should be_true
+      (/PASSED: Resources are not using custom SELinux options/ =~ response_s).should_not be_nil
+    ensure
+      LOGGING.info `./cnf-testsuite cnf_cleanup cnf-config=./sample-cnfs/sample_nonroot`
+    end
+  end
 end

--- a/src/tasks/cnf_setup.cr
+++ b/src/tasks/cnf_setup.cr
@@ -97,14 +97,6 @@ task "generate_config" do |_, args|
 end
 
 #TODO force all cleanups to use generic cleanup
-task "sample_coredns_cleanup" do |_, args|
-  CNFManager.sample_cleanup(config_file: "sample-cnfs/sample-coredns-cnf", verbose: true)
-end
-
-task "cleanup_sample_coredns" do |_, args|
-  CNFManager.sample_cleanup(config_file: "sample-cnfs/sample_coredns", verbose: true)
-end
-
 task "bad_helm_cnf_cleanup" do |_, args|
   CNFManager.sample_cleanup(config_file: "sample-cnfs/sample-bad_helm_coredns-cnf", verbose: true)
 end

--- a/src/tasks/utils/cnf_manager.cr
+++ b/src/tasks/utils/cnf_manager.cr
@@ -1113,6 +1113,7 @@ module CNFManager
       end
     end
 
+    Log.for("cnf_cleanup_resources").info { resources.inspect }
     resources.each do | resource |
       case resource[:kind].downcase
       when "replicaset", "deployment", "statefulset", "pod", "daemonset"

--- a/src/tasks/utils/cnf_manager.cr
+++ b/src/tasks/utils/cnf_manager.cr
@@ -1113,14 +1113,6 @@ module CNFManager
       end
     end
 
-    Log.for("cnf_cleanup_resources").info { resources.inspect }
-    resources.each do | resource |
-      case resource[:kind].downcase
-      when "replicaset", "deployment", "statefulset", "pod", "daemonset"
-        KubectlClient::Get.resource_wait_for_uninstall(kind: resource[:kind], resource_name: resource[:name], namespace: resource[:namespace])
-      end
-    end
-
     ret
   end
 

--- a/src/tasks/utils/cnf_manager.cr
+++ b/src/tasks/utils/cnf_manager.cr
@@ -1052,7 +1052,7 @@ module CNFManager
       case resource[:kind].downcase
       when "replicaset", "deployment", "statefulset", "pod", "daemonset"
         Log.info { "waiting on resource of kind: #{resource[:kind].downcase}" }
-        KubectlClient::Get.resource_wait_for_install(resource[:kind], resource[:name], 180, namespace="default", kubeconfig)
+        KubectlClient::Get.resource_wait_for_install(resource[:kind], resource[:name], 180, namespace: resource[:namespace], kubeconfig: kubeconfig)
       else 
         true
       end

--- a/src/tasks/utils/cnf_manager.cr
+++ b/src/tasks/utils/cnf_manager.cr
@@ -902,8 +902,8 @@ module CNFManager
           containers = resource.dig("spec", "containers")
         when  "deployment","statefulset","replicaset","daemonset"
           Log.info { "resource: #{resource}" }
-
           containers = resource.dig("spec", "template", "spec", "containers")
+          Log.for("RESOURCE_CONTAINERS").info { containers }
         end
         containers && containers.as_a.map do |container|
           initialDelaySeconds = container.dig?("livenessProbe", "initialDelaySeconds")
@@ -950,6 +950,7 @@ module CNFManager
       resource_names.each do | resource |
         case resource[:kind].as_s.downcase
         when "replicaset", "deployment", "statefulset", "pod", "daemonset"
+          Log.for("INSTALL_RESOURCE_WAIT").info { "Waiting for #{resource[:kind].as_s}, #{resource[:name].as_s}" }
           KubectlClient::Get.resource_wait_for_install(resource[:kind].as_s, resource[:name].as_s, wait_count)
         end
       end

--- a/src/tasks/utils/cnf_manager.cr
+++ b/src/tasks/utils/cnf_manager.cr
@@ -903,7 +903,6 @@ module CNFManager
         when  "deployment","statefulset","replicaset","daemonset"
           Log.info { "resource: #{resource}" }
           containers = resource.dig("spec", "template", "spec", "containers")
-          Log.for("RESOURCE_CONTAINERS").info { containers }
         end
         containers && containers.as_a.map do |container|
           initialDelaySeconds = container.dig?("livenessProbe", "initialDelaySeconds")
@@ -950,7 +949,6 @@ module CNFManager
       resource_names.each do | resource |
         case resource[:kind].downcase
         when "replicaset", "deployment", "statefulset", "pod", "daemonset"
-          Log.for("INSTALL_RESOURCE_WAIT").info { "Waiting for #{resource[:kind]}, #{resource[:name]}" }
           KubectlClient::Get.resource_wait_for_install(resource[:kind], resource[:name], wait_count: wait_count, namespace: resource[:namespace])
         end
       end

--- a/src/tasks/utils/cnf_manager.cr
+++ b/src/tasks/utils/cnf_manager.cr
@@ -1094,7 +1094,7 @@ module CNFManager
     # todo use install_from_config_src to determine installation method
     if dir_exists || force == true
       if installed_from_manifest
-        ret = KubectlClient::Delete.file("#{manifest_directory}")
+        ret = KubectlClient::Delete.file("#{manifest_directory}", wait: true)
         # Log.for("verbose").info { kubectl_delete } if verbose
         # TODO put more safety around this
         FileUtils.rm_rf(destination_cnf_dir)
@@ -1102,7 +1102,7 @@ module CNFManager
           stdout_success "Successfully cleaned up #{manifest_directory} directory"
         end
       else
-        helm_uninstall = Helm.uninstall(release_name.split(" ")[0] + " #{namespace}")
+        helm_uninstall = Helm.uninstall(release_name.split(" ")[0] + " #{namespace} --wait")
         # helm_uninstall = Helm.uninstall(release_name + " #{namespace}")
         ret = helm_uninstall[:status].success?
         Log.for("verbose").info { helm_uninstall[:output].to_s } if verbose

--- a/src/tasks/utils/kyverno.cr
+++ b/src/tasks/utils/kyverno.cr
@@ -55,6 +55,10 @@ module Kyverno
     "#{policies_repo_path}/best-practices/#{policy_path}"
   end
 
+  def self.policy_path(policy_path : String) : String
+    "#{policies_repo_path}/#{policy_path}"
+  end
+
   def self.policies_repo_path
     "#{tools_path}/kyverno-policies"
   end

--- a/src/tasks/workload/configuration.cr
+++ b/src/tasks/workload/configuration.cr
@@ -10,7 +10,18 @@ rolling_version_change_test_names = ["rolling_update", "rolling_downgrade", "rol
 
 desc "Configuration should be managed in a declarative manner, using ConfigMaps, Operators, or other declarative interfaces."
 
-task "configuration", ["ip_addresses", "nodeport_not_used", "hostport_not_used", "hardcoded_ip_addresses_in_k8s_runtime_configuration", "secrets_used", "immutable_configmap", "alpha_k8s_apis", "require_labels"] do |_, args|
+task "configuration", [
+    "ip_addresses",
+    "nodeport_not_used",
+    "hostport_not_used",
+    "hardcoded_ip_addresses_in_k8s_runtime_configuration",
+    "secrets_used",
+    "immutable_configmap",
+    "alpha_k8s_apis",
+    "require_labels",
+    "latest_tag",
+    "default_namespace"
+  ] do |_, args|
   stdout_score("configuration", "configuration")
 end
 

--- a/src/tasks/workload/configuration.cr
+++ b/src/tasks/workload/configuration.cr
@@ -150,7 +150,7 @@ task "versioned_tag", ["install_opa"] do |_, args|
      fail_msgs = [] of String
      task_response = CNFManager.workload_resource_test(args, config) do |resource, container, initialized|
        test_passed = true
-       kind = resource["kind"].as_s.downcase
+       kind = resource["kind"].downcase
        case kind 
        when  "deployment","statefulset","pod","replicaset", "daemonset"
          resource_yaml = KubectlClient::Get.resource(resource[:kind], resource[:name])
@@ -191,7 +191,7 @@ task "nodeport_not_used" do |_, args|
     destination_cnf_dir = config.cnf_config[:destination_cnf_dir]
     task_response = CNFManager.workload_resource_test(args, config, check_containers:false, check_service: true) do |resource, container, initialized|
       LOGGING.info "nodeport_not_used resource: #{resource}"
-      if resource["kind"].as_s.downcase == "service"
+      if resource["kind"].downcase == "service"
         LOGGING.info "resource kind: #{resource}"
         service = KubectlClient::Get.resource(resource[:kind], resource[:name])
         LOGGING.debug "service: #{service}"

--- a/src/tasks/workload/configuration.cr
+++ b/src/tasks/workload/configuration.cr
@@ -56,6 +56,27 @@ task "default_namespace" do |_, args|
   end
 end
 
+desc "Check if the CNF uses container images with the latest tag"
+task "latest_tag" do |_, args|
+  Log.for("verbose").info { "latest_tag" }
+  Kyverno.install
+  emoji_passed = "🏷️✔️"
+  emoji_failed = "🏷️❌"
+  policy_path = Kyverno.best_practice_policy("disallow_latest_tag/disallow_latest_tag.yaml")
+  failures = Kyverno::PolicyAudit.run(policy_path, EXCLUDE_NAMESPACES)
+
+  if failures.size == 0
+    resp = upsert_passed_task("latest_tag", "✔️  PASSED: Container images are not using the latest tag #{emoji_passed}")
+  else
+    resp = upsert_failed_task("latest_tag", "✖️  FAILED: Container images are using the latest tag #{emoji_failed}")
+    failures.each do |failure|
+      failure.resources.each do |resource|
+        puts "#{resource.kind} #{resource.name} in #{resource.namespace} namespace failed. #{failure.message}".colorize(:red)
+      end
+    end
+  end
+end
+
 desc "Does a search for IP addresses or subnets come back as negative?"
 task "ip_addresses" do |_, args|
   CNFManager::Task.task_runner(args) do |args, config|

--- a/src/tasks/workload/microservice.cr
+++ b/src/tasks/workload/microservice.cr
@@ -278,10 +278,10 @@ task "reasonable_image_size" do |_, args|
 
       yml_file_path = config.cnf_config[:yml_file_path]
 
-      if resource["kind"].as_s.downcase == "deployment" ||
-          resource["kind"].as_s.downcase == "statefulset" ||
-          resource["kind"].as_s.downcase == "pod" ||
-          resource["kind"].as_s.downcase == "replicaset"
+      if resource["kind"].downcase == "deployment" ||
+          resource["kind"].downcase == "statefulset" ||
+          resource["kind"].downcase == "pod" ||
+          resource["kind"].downcase == "replicaset"
 				test_passed = true
 
 				fqdn_image = container.as_h["image"].as_s
@@ -364,7 +364,7 @@ task "single_process_type" do |_, args|
     fail_msgs = [] of String
     task_response = CNFManager.workload_resource_test(args, config) do |resource, container, initialized|
       test_passed = true
-      kind = resource["kind"].as_s.downcase
+      kind = resource["kind"].downcase
       case kind 
       when  "deployment","statefulset","pod","replicaset", "daemonset"
         resource_yaml = KubectlClient::Get.resource(resource[:kind], resource[:name])
@@ -423,9 +423,9 @@ task "service_discovery" do |_, args|
     # Collect service names from the CNF resource list
     cnf_service_names = [] of String
     resources.each do |resource|
-      case resource[:kind].as_s.downcase
+      case resource[:kind].downcase
       when "service"
-        cnf_service_names.push(resource[:name].as_s)
+        cnf_service_names.push(resource[:name])
       end
     end
 

--- a/src/tasks/workload/observability.cr
+++ b/src/tasks/workload/observability.cr
@@ -17,7 +17,7 @@ task "log_output" do |_, args|
 
     task_response = CNFManager.workload_resource_test(args, config) do |resource, container, initialized|
       test_passed = false
-      case resource["kind"].as_s.downcase
+      case resource["kind"].downcase
       when "replicaset", "deployment", "statefulset", "pod", "daemonset"
         result = KubectlClient.logs("#{resource["kind"]}/#{resource["name"]}", options: "--all-containers --tail=5 --prefix=true")
         Log.for("Log lines").info { result[:output] }

--- a/src/tasks/workload/security.cr
+++ b/src/tasks/workload/security.cr
@@ -109,7 +109,7 @@ task "non_root_user", ["install_falco"] do |_, args|
      task_response = CNFManager.workload_resource_test(args, config) do |resource, container, initialized|
        test_passed = true
        Log.info { "Falco is Running" }
-       kind = resource["kind"].as_s.downcase
+       kind = resource["kind"].downcase
        case kind 
        when  "deployment","statefulset","pod","replicaset", "daemonset"
          resource_yaml = KubectlClient::Get.resource(resource[:kind], resource[:name])

--- a/src/tasks/workload/security.cr
+++ b/src/tasks/workload/security.cr
@@ -23,7 +23,8 @@ task "security", [
     "immutable_file_systems",
     "hostpath_mounts",
     "container_sock_mounts",
-    "external_ips"
+    "external_ips",
+    "selinux_options"
   ] do |_, args|
   stdout_score("security")
 end

--- a/src/tasks/workload/security.cr
+++ b/src/tasks/workload/security.cr
@@ -48,6 +48,26 @@ task "external_ips" do |_, args|
   end
 end
 
+desc "Check if the CNF or the cluster resources have custom SELinux options"
+task "selinux_options" do |_, args|
+  Log.for("verbose").info { "selinux_options" }
+  Kyverno.install
+  emoji_security = "🔓🔑"
+  policy_path = Kyverno.policy_path("pod-security/baseline/disallow-selinux/disallow-selinux.yaml")
+  failures = Kyverno::PolicyAudit.run(policy_path, EXCLUDE_NAMESPACES)
+
+  if failures.size == 0
+    resp = upsert_passed_task("selinux_options", "✔️  PASSED: Resources are not using custom SELinux options #{emoji_security}")
+  else
+    resp = upsert_failed_task("selinux_options", "✖️  FAILED: Resources are using custom SELinux options #{emoji_security}")
+    failures.each do |failure|
+      failure.resources.each do |resource|
+        puts "#{resource.kind} #{resource.name} in #{resource.namespace} namespace failed. #{failure.message}".colorize(:red)
+      end
+    end
+  end
+end
+
 desc "Check if the CNF is running containers with container sock mounts"
 task "container_sock_mounts" do |_, args|
   Log.for("verbose").info { "container_sock_mounts" }

--- a/utils/helm/helm.cr
+++ b/utils/helm/helm.cr
@@ -188,9 +188,14 @@ module Helm
     resource_names
   end
 
-  def self.workload_resource_kind_names(resources : Array(YAML::Any) )
+  def self.workload_resource_kind_names(resources : Array(YAML::Any) ) : Array(NamedTuple(kind: String, name: String, namespace: String))
     resource_names = resources.map do |x|
-      {kind: x["kind"], name: x["metadata"]["name"]}
+      namespace = (x.dig?("metadata", "namespace") || "default").to_s
+      {
+        kind: x["kind"].as_s,
+        name: x["metadata"]["name"].as_s,
+        namespace: namespace
+      }
     end
     Log.debug { "resource names: #{resource_names}" }
     resource_names
@@ -204,7 +209,7 @@ module Helm
     resource_names = Helm.workload_resource_kind_names(resource_ymls)
     found = false
 		resource_names.each do | resource |
-      if resource[:kind].as_s.downcase == kind.downcase
+      if resource[:kind].downcase == kind.downcase
         found = true
       end
     end

--- a/utils/kubectl_client/kubectl_client.cr
+++ b/utils/kubectl_client/kubectl_client.cr
@@ -224,17 +224,17 @@ module KubectlClient
       end
 
       # By default assume there is a resource still terminating.
-      found_terminated = true
+      found_terminating = true
       second_count = 0
-      until found_terminated = false || second_count > wait_count
-        result = ShellCmd.run(cmd, "kubectl_get_resources")
+      until found_terminating = false || second_count == wait_count
+        result = ShellCmd.run(cmd, "kubectl_get_resources", force_output: true)
         if result[:output].match(/([\s+]Terminating)/)
-          found_terminated = true
+          found_terminating = true
         else
           sleep(1)
           second_count = second_count + 1
         end
-        Log.info { "found_terminated = #{found_terminated}; second_count = #{second_count}" }
+        Log.info { "found_terminating = #{found_terminating}; second_count = #{second_count}" }
       end
     end
   end

--- a/utils/kubectl_client/kubectl_client.cr
+++ b/utils/kubectl_client/kubectl_client.cr
@@ -226,13 +226,14 @@ module KubectlClient
       # By default assume there is a resource still terminating.
       found_terminating = true
       second_count = 0
-      until found_terminating = false || second_count == wait_count
+      while (found_terminating == true && second_count < wait_count)
         result = ShellCmd.run(cmd, "kubectl_get_resources", force_output: true)
         if result[:output].match(/([\s+]Terminating)/)
           found_terminating = true
-        else
-          sleep(1)
           second_count = second_count + 1
+          sleep(1)
+        else
+          found_terminating = false
         end
         Log.info { "found_terminating = #{found_terminating}; second_count = #{second_count}" }
       end

--- a/utils/kubectl_client/kubectl_client.cr
+++ b/utils/kubectl_client/kubectl_client.cr
@@ -399,7 +399,7 @@ module KubectlClient
       if name
         #todo deployment labels may not match template metadata labels.
         # -- may need to match on selector matchlabels instead
-        labels = KubectlClient::Get.resource_spec_labels(resource_yml["kind"], name, namespace: namespace).as_h
+        labels = KubectlClient::Get.resource_spec_labels(resource_yml["kind"].as_s, name.as_s, namespace: namespace).as_h
         Log.info { "pods_by_resource labels: #{labels}" }
         KubectlClient::Get.pods_by_labels(pods, labels)
       else
@@ -454,7 +454,7 @@ module KubectlClient
       end
     end
 
-    def self.resource(kind, resource_name, namespace : String | Nil = nil) : JSON::Any
+    def self.resource(kind : String, resource_name : String, namespace : String | Nil = nil) : JSON::Any
       namespace_opt = ""
       if namespace != nil
         namespace_opt = "-n #{namespace.gsub("--namespace ", "").gsub("-n ", "") if namespace}"
@@ -955,9 +955,9 @@ module KubectlClient
     def self.deployment_spec_labels(deployment_name) : JSON::Any
       resource_spec_labels("deployment", deployment_name)
     end
-    def self.resource_spec_labels(kind, resource_name, namespace : String | Nil = nil) : JSON::Any
+    def self.resource_spec_labels(kind : String, resource_name : String, namespace : String | Nil = nil) : JSON::Any
       Log.debug { "resource_labels kind: #{kind} resource_name: #{resource_name}" }
-      if kind.as_s.downcase == "service"
+      if kind.downcase == "service"
         resp = resource(kind, resource_name, namespace: namespace).dig?("spec", "selector")
       else
         resp = resource(kind, resource_name, namespace: namespace).dig?("spec", "template", "metadata", "labels")

--- a/utils/kubectl_client/kubectl_client.cr
+++ b/utils/kubectl_client/kubectl_client.cr
@@ -189,8 +189,14 @@ module KubectlClient
       ShellCmd.run(cmd, "KubectlClient::Delete.command")
     end
 
-    def self.file(file_name, namespace : String | Nil = nil)
-      cmd = "kubectl delete #{namespace ? "-n #{namespace}" : ""} -f #{file_name}"
+    def self.file(file_name, namespace : String | Nil = nil, wait : Bool = false)
+      cmd = "kubectl delete -f #{file_name}"
+      if namespace
+        cmd = "#{cmd} -n #{namespace}"
+      end
+      if wait == true
+        cmd = "#{cmd} --wait=true"
+      end
       ShellCmd.run(cmd, "KubectlClient::Delete.file")
     end
   end


### PR DESCRIPTION
## Description

* Add the following tests based on Kyverno:
  * `default_namespace`
  * `latest_tag`
  * `selinux_options`
* Add spec tests for the above tests
* Add docs for the above tests
* Add the tests to points.yml

### Additional changes for #1292
These changes prevent residue of CNFs installed for different spec tests from affecting subsequent tests.

* Add new `KubectlClient::Utils.wait_for_terminations` with reasoning in comments
* Add wait option for `KubectlClient::Delete.file`
* Update CNFManager.sample_cleanup to wait for resources to be deleted on cleanup.

### Additional changes to help CNFs in non-default namespace (#1286)
* Add return types for `Helm.workload_resource_kind_names` and fix rabbit hole of type issues.
* `Helm.workload_resource_kind_names` should return namespace of the resource.
* `KubectClient::Get.resource_wait_for_install` should be passed the namespace name when called from `cnf_setup`.

### Unrelated changes
Replace the below cleanup tasks for specific CNFs with direct calls to `cnf_setup` command.
* `sample_coredns_cleanup`
* `cleanup_sample_coredns`

## Issues:
Refs: #1272, #1273, #1274, #1292

## How has this been tested:
 - [x] Covered by existing integration testing
 - [x] Added integration testing to cover
 - [ ] Verified all A/C passes
     * [ ] develop
     * [ ] master
     * [ ] tag/other branch
 - [ ] Test environment
    * [ ] Shared Packet K8s cluster
    * [ ] New Packet K8s cluster
    * [ ] Kind cluster
 - [ ] Have not tested

## Types of changes:
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [x] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [x] Documentation update

## Checklist:
**Documentation**
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] No updates required.

**Code Review**
- [ ] Does the test handle fatal exceptions, ie. rescue block

**Issue**
- [ ] Tasks in issue are checked off
