### PR TITLE
Add points and maximum_points to the results file

### DIFF
--- a/src/cnf-testsuite.cr
+++ b/src/cnf-testsuite.cr
@@ -11,11 +11,16 @@ task "all", ["workload", "platform"] do  |_, args|
   VERBOSE_LOGGING.info "all" if check_verbose(args)
 
   total = CNFManager::Points.total_points
+  max_points = CNFManager::Points.total_max_points
+
   if total > 0
-    stdout_success "Final score: #{total} of #{CNFManager::Points.total_max_points}"
+    stdout_success "Final score: #{total} of #{max_points}"
   else
-    stdout_failure "Final score: #{total} of #{CNFManager::Points.total_max_points}"
+    stdout_failure "Final score: #{total} of #{max_points}"
   end
+
+  update_yml("#{CNFManager::Points::Results.file}", "points", total)
+  update_yml("#{CNFManager::Points::Results.file}", "maximum_points", max_points)
 
   if CNFManager::Points.failed_required_tasks.size > 0
     stdout_failure "Test Suite failed!"
@@ -23,6 +28,7 @@ task "all", ["workload", "platform"] do  |_, args|
     yaml = File.open("#{CNFManager::Points::Results.file}") do |file|
       YAML.parse(file)
     end
+
     Log.debug { "results yaml: #{yaml}" }
     if (yaml["exit_code"]) != 2
       update_yml("#{CNFManager::Points::Results.file}", "exit_code", "1")
@@ -36,11 +42,15 @@ task "workload", ["automatic_cnf_install", "ensure_cnf_installed", "configuratio
   VERBOSE_LOGGING.info "workload" if check_verbose(args)
 
   total = CNFManager::Points.total_points("workload")
+  max_points = CNFManager::Points.total_max_points("workload")
   if total > 0
-    stdout_success "Final workload score: #{total} of #{CNFManager::Points.total_max_points("workload")}"
+    stdout_success "Final workload score: #{total} of #{max_points}"
   else
-    stdout_failure "Final workload score: #{total} of #{CNFManager::Points.total_max_points("workload")}"
+    stdout_failure "Final workload score: #{total} of #{max_points}"
   end
+
+  update_yml("#{CNFManager::Points::Results.file}", "points", total)
+  update_yml("#{CNFManager::Points::Results.file}", "maximum_points", max_points)
 
   if CNFManager::Points.failed_required_tasks.size > 0
     stdout_failure "Test Suite failed!"


### PR DESCRIPTION
## Description

This PR adds `points` and `maximum_points` to the results file when `all` or `workload` tasks are run.

## Issues:
Refs: #1301

## How has this been tested:
 - [ ] Covered by existing integration testing
 - [ ] Added integration testing to cover
 - [ ] Verified all A/C passes
     * [ ] develop
     * [ ] master
     * [ ] tag/other branch
 - [ ] Test environment
    * [ ] Shared Packet K8s cluster
    * [ ] New Packet K8s cluster
    * [ ] Kind cluster
 - [ ] Have not tested

## Types of changes:
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [x] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [ ] Documentation update

## Checklist:
**Documentation**
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] No updates required.

**Code Review**
- [ ] Does the test handle fatal exceptions, ie. rescue block

**Issue**
- [ ] Tasks in issue are checked off
