### PR TITLE
add POC and expectation to K8s alpha API test

### DIFF
--- a/docs/LIST_OF_TESTS.md
+++ b/docs/LIST_OF_TESTS.md
@@ -105,7 +105,7 @@ You can read more about horizonal pod autoscaling to create replicas [here](http
 ## [Kubernetes Alpha APIs - Proof of Concept](https://github.com/cncf/cnf-testsuite/blob/v0.27.0/src/tasks/workload/configuration.cr#L499)
 - Expectation: CNF should not use Kubernetes alpha APIs
 
-**What's tested:** This checks if a CNF uses Kubernetes alpha or unstable APIs
+**What's tested:** This checks if a CNF uses alpha or unstable versions of Kubernetes APIs
 
 
 # Microservice Category

--- a/docs/LIST_OF_TESTS.md
+++ b/docs/LIST_OF_TESTS.md
@@ -102,10 +102,10 @@ You can read more about horizonal pod autoscaling to create replicas [here](http
 **What's tested:** This installs temporary kind clusters and will test the CNF against both Calico and Cilium CNIs. 
 
 
-## [Kubernetes Alpha APIs](https://github.com/cncf/cnf-testsuite/blob/v0.27.0/src/tasks/workload/configuration.cr#L552)
-- Expectation: (PoC) To check if a CNF uses Kubernetes alpha APIs
+## [Kubernetes Alpha APIs - Proof of Concept](https://github.com/cncf/cnf-testsuite/blob/v0.27.0/src/tasks/workload/configuration.cr#L499)
+- Expectation: CNF should not use Kubernetes alpha APIs
 
-**What's tested:** TBD
+**What's tested:** This checks if a CNF uses Kubernetes alpha or unstable APIs
 
 
 # Microservice Category


### PR DESCRIPTION
## Description
- add POC and expectation to K8s alpha API test
- ## [Kubernetes Alpha APIs - Proof of Concept](https://github.com/cncf/cnf-testsuite/blob/v0.27.0/src/tasks/workload/configuration.cr#L499)
- Expectation: CNF should not use Kubernetes alpha APIs

**What's tested:** This checks if a CNF uses Kubernetes alpha or unstable APIs

## Issues:
Refs: #1306 

## How has this been tested:
 - [ ] Covered by existing integration testing
 - [ ] Added integration testing to cover
 - [ ] Verified all A/C passes
     * [ ] develop
     * [ ] master
     * [ ] tag/other branch
 - [ ] Test environment
    * [ ] Shared Packet K8s cluster
    * [ ] New Packet K8s cluster
    * [ ] Kind cluster
 - [x] Have not tested

## Types of changes:
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [x] Documentation update

## Checklist:
**Documentation**
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] No updates required.

**Code Review**
- [ ] Does the test handle fatal exceptions, ie. rescue block

**Issue**
- [ ] Tasks in issue are checked off
