### PR TITLE
[#1301] Add points and max points when category task is run

### DIFF
--- a/src/tasks/utils/utils.cr
+++ b/src/tasks/utils/utils.cr
@@ -340,14 +340,18 @@ def stdout_score(test_name)
 end
 def stdout_score(test_name, full_name)
   total = CNFManager::Points.total_points(test_name)
+  max_points = CNFManager::Points.total_max_points(test_name)
   # pretty_test_name = test_name.split(/:|_/).map(&.capitalize).join(" ")
   pretty_test_name = full_name.split(/:|_/).map(&.capitalize).join(" ")
   # test_log_msg = "#{pretty_test_name} final score: #{total} of #{CNFManager::Points.total_max_points(test_name)}"
   test_log_msg = 
 <<-STRING
-#{pretty_test_name} final score: #{total} of #{CNFManager::Points.total_max_points(test_name)}
+#{pretty_test_name} final score: #{total} of #{max_points}
 
 STRING
+
+  update_yml("#{CNFManager::Points::Results.file}", "points", total)
+  update_yml("#{CNFManager::Points::Results.file}", "maximum_points", max_points)
 
   if total > 0
     stdout_success test_log_msg


### PR DESCRIPTION
## Issue refs: #1301

## Description

Add points and max points when category task is run.

### Screenshot of results file when category task is run

> Please ignore the bad formatting in the output. I resized my window and the output screen went bad. But the `maximum_points` and `points` fields are visible on the cat output in the right tmux pane.

<img width="1920" alt="CleanShot 2022-04-08 at 16 23 39@2x" src="https://user-images.githubusercontent.com/84005/162421967-58acc5fa-1909-4488-8705-e4d418b7fee0.png">

### Screenshot of results file when workload task is run

> Test output is on the left pane. The right pane is the grep output for the `points` and `maximum_points` in the results file.

<img width="1920" alt="CleanShot 2022-04-08 at 16 46 01@2x" src="https://user-images.githubusercontent.com/84005/162425286-936cbb7d-bfe2-459b-b6bf-acc0cea508b4.png">


## How has this been tested:
 - [ ] Covered by existing integration testing
 - [ ] Added integration testing to cover
 - [ ] Verified all A/C passes
     * [ ] develop
     * [ ] master
     * [ ] tag/other branch
 - [ ] Test environment
    * [ ] Shared Packet K8s cluster
    * [ ] New Packet K8s cluster
    * [ ] Kind cluster
 - [ ] Have not tested

## Types of changes:
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [x] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [ ] Documentation update

## Checklist:
**Documentation**
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] No updates required.

**Code Review**
- [ ] Does the test handle fatal exceptions, ie. rescue block

**Issue**
- [ ] Tasks in issue are checked off
