### PR TITLE
[Fix points-related issues] Runs tests that were missed earlier

### DIFF
--- a/embedded_files/points.yml
+++ b/embedded_files/points.yml
@@ -83,7 +83,7 @@
 - name: disk_fill
   tags: resilience, dynamic, workload  
 - name: pod_dns_error
-  tags: pod_dns_error, dynamic, workload  
+  tags: resilience, dynamic, workload  
 #- name: external_retry 
 #  tags: scalability, dynamic, workload
 

--- a/spec/workload/microservice_spec.cr
+++ b/spec/workload/microservice_spec.cr
@@ -13,6 +13,19 @@ describe "Microservice" do
     $?.success?.should be_true
   end
 
+  it "'shared_database' should be skipped no MariaDB containers are found", tags: ["shared_database"]  do
+    begin
+      LOGGING.info `./cnf-testsuite cnf_setup cnf-path=sample-cnfs/sample_coredns/cnf-testsuite.yml`
+      response_s = `./cnf-testsuite shared_database`
+      LOGGING.info response_s
+      $?.success?.should be_true
+      (/SKIPPED: \[shared_database\] No MariaDB containers were found/ =~ response_s).should_not be_nil
+    ensure
+      LOGGING.info `./cnf-testsuite cnf_cleanup cnf-path=sample-cnfs/sample_coredns/cnf-testsuite.yml`
+      $?.success?.should be_true
+    end
+  end
+
   it "'shared_database' should pass if no database is used by two microservices", tags: ["shared_database"]  do
     begin
       LOGGING.info `./cnf-testsuite cnf_setup cnf-path=sample-cnfs/sample-statefulset-cnf/cnf-testsuite.yml`

--- a/src/tasks/workload/configuration.cr
+++ b/src/tasks/workload/configuration.cr
@@ -20,7 +20,8 @@ task "configuration", [
     "alpha_k8s_apis",
     "require_labels",
     "latest_tag",
-    "default_namespace"
+    "default_namespace",
+    "versioned_tag"
   ] do |_, args|
   stdout_score("configuration", "configuration")
 end

--- a/src/tasks/workload/configuration.cr
+++ b/src/tasks/workload/configuration.cr
@@ -29,18 +29,20 @@ desc "Check if the CNF is running containers with labels configured?"
 task "require_labels" do |_, args|
   Log.for("verbose").info { "require-labels" }
   Kyverno.install
-  emoji_passed = "🏷️✔️"
-  emoji_failed = "🏷️❌"
-  policy_path = Kyverno.best_practice_policy("require_labels/require_labels.yaml")
-  failures = Kyverno::PolicyAudit.run(policy_path, EXCLUDE_NAMESPACES)
+  CNFManager::Task.task_runner(args) do |args, config|
+    emoji_passed = "🏷️✔️"
+    emoji_failed = "🏷️❌"
+    policy_path = Kyverno.best_practice_policy("require_labels/require_labels.yaml")
+    failures = Kyverno::PolicyAudit.run(policy_path, EXCLUDE_NAMESPACES)
 
-  if failures.size == 0
-    resp = upsert_passed_task("require_labels", "✔️  PASSED: Pods have the app.kubernetes.io/name label #{emoji_passed}")
-  else
-    resp = upsert_failed_task("require_labels", "✖️  FAILED: Pods should have the app.kubernetes.io/name label. #{emoji_failed}")
-    failures.each do |failure|
-      failure.resources.each do |resource|
-        puts "#{resource.kind} #{resource.name} in #{resource.namespace} namespace failed. #{failure.message}".colorize(:red)
+    if failures.size == 0
+      resp = upsert_passed_task("require_labels", "✔️  PASSED: Pods have the app.kubernetes.io/name label #{emoji_passed}")
+    else
+      resp = upsert_failed_task("require_labels", "✖️  FAILED: Pods should have the app.kubernetes.io/name label. #{emoji_failed}")
+      failures.each do |failure|
+        failure.resources.each do |resource|
+          puts "#{resource.kind} #{resource.name} in #{resource.namespace} namespace failed. #{failure.message}".colorize(:red)
+        end
       end
     end
   end
@@ -50,18 +52,20 @@ desc "Check if the CNF installs resources in the default namespace"
 task "default_namespace" do |_, args|
   Log.for("verbose").info { "default_namespace" }
   Kyverno.install
-  emoji_passed = "🏷️✔️"
-  emoji_failed = "🏷️❌"
-  policy_path = Kyverno.best_practice_policy("disallow_default_namespace/disallow_default_namespace.yaml")
-  failures = Kyverno::PolicyAudit.run(policy_path, EXCLUDE_NAMESPACES)
+  CNFManager::Task.task_runner(args) do |args, config|
+    emoji_passed = "🏷️✔️"
+    emoji_failed = "🏷️❌"
+    policy_path = Kyverno.best_practice_policy("disallow_default_namespace/disallow_default_namespace.yaml")
+    failures = Kyverno::PolicyAudit.run(policy_path, EXCLUDE_NAMESPACES)
 
-  if failures.size == 0
-    resp = upsert_passed_task("default_namespace", "✔️  PASSED: default namespace is not being used #{emoji_passed}")
-  else
-    resp = upsert_failed_task("default_namespace", "✖️  FAILED: Resources are created in the default namespace #{emoji_failed}")
-    failures.each do |failure|
-      failure.resources.each do |resource|
-        puts "#{resource.kind} #{resource.name} in #{resource.namespace} namespace failed. #{failure.message}".colorize(:red)
+    if failures.size == 0
+      resp = upsert_passed_task("default_namespace", "✔️  PASSED: default namespace is not being used #{emoji_passed}")
+    else
+      resp = upsert_failed_task("default_namespace", "✖️  FAILED: Resources are created in the default namespace #{emoji_failed}")
+      failures.each do |failure|
+        failure.resources.each do |resource|
+          puts "#{resource.kind} #{resource.name} in #{resource.namespace} namespace failed. #{failure.message}".colorize(:red)
+        end
       end
     end
   end

--- a/src/tasks/workload/microservice.cr
+++ b/src/tasks/workload/microservice.cr
@@ -10,7 +10,7 @@ require "halite"
 require "totem"
 
 desc "The CNF test suite checks to see if CNFs follows microservice principles"
-task "microservice", ["reasonable_image_size", "reasonable_startup_time", "single_process_type", "service_discovery"] do |_, args|
+task "microservice", ["reasonable_image_size", "reasonable_startup_time", "single_process_type", "service_discovery", "shared_database"] do |_, args|
   stdout_score("microservice")
 end
 

--- a/src/tasks/workload/microservice.cr
+++ b/src/tasks/workload/microservice.cr
@@ -22,7 +22,13 @@ task "shared_database", ["install_cluster_tools"] do |_, args|
   CNFManager::Task.task_runner(args) do |args, config|
     # todo loop through local resources and see if db match found
     db_match = Mariadb.match
+    if db_match[:found] == false
+      upsert_skipped_task("shared_database", "⏭️  SKIPPED: [shared_database] No MariaDB containers were found")
+      next
+    end
+
     Log.info { "DB Digest: #{db_match[:digest]}" }
+
     #todo find offical database ip
     db_pods = KubectlClient::Get.pods_by_digest(db_match[:digest])
     Log.info { "DB Pods: #{db_pods}" }

--- a/src/tasks/workload/reliability.cr
+++ b/src/tasks/workload/reliability.cr
@@ -13,7 +13,9 @@ desc "The CNF test suite checks to see if the CNFs are resilient to failures."
    "pod_memory_hog",
    "pod_io_stress",
    "pod_dns_error",
-   "pod_network_duplication"
+   "pod_network_duplication",
+   "liveness",
+   "readiness"
   ] do |t, args|
   Log.for("verbose").info {  "resilience" } if check_verbose(args)
   VERBOSE_LOGGING.debug "resilience args.raw: #{args.raw}" if check_verbose(args)

--- a/src/tasks/workload/reliability.cr
+++ b/src/tasks/workload/reliability.cr
@@ -5,7 +5,16 @@ require "colorize"
 require "../utils/utils.cr"
 
 desc "The CNF test suite checks to see if the CNFs are resilient to failures."
- task "resilience", ["pod_network_latency", "pod_network_corruption", "disk_fill", "pod_delete", "pod_memory_hog", "pod_io_stress", "pod_dns_error"] do |t, args|
+ task "resilience", [
+   "pod_network_latency",
+   "pod_network_corruption",
+   "disk_fill",
+   "pod_delete",
+   "pod_memory_hog",
+   "pod_io_stress",
+   "pod_dns_error",
+   "pod_network_duplication"
+  ] do |t, args|
   Log.for("verbose").info {  "resilience" } if check_verbose(args)
   VERBOSE_LOGGING.debug "resilience args.raw: #{args.raw}" if check_verbose(args)
   VERBOSE_LOGGING.debug "resilience args.named: #{args.named}" if check_verbose(args)

--- a/src/tasks/workload/security.cr
+++ b/src/tasks/workload/security.cr
@@ -26,7 +26,8 @@ task "security", [
     "external_ips",
     "selinux_options",
     "sysctls",
-    "host_network"
+    "host_network",
+    "service_account_mapping",
   ] do |_, args|
   stdout_score("security")
 end

--- a/src/tasks/workload/security.cr
+++ b/src/tasks/workload/security.cr
@@ -34,17 +34,20 @@ desc "Check if pods in the CNF use sysctls with restricted values"
 task "sysctls" do |_, args|
   Log.for("verbose").info { "sysctls" }
   Kyverno.install
-  emoji_security = "🔓🔑"
-  policy_path = Kyverno.policy_path("pod-security/baseline/restrict-sysctls/restrict-sysctls.yaml")
-  failures = Kyverno::PolicyAudit.run(policy_path, EXCLUDE_NAMESPACES)
 
-  if failures.size == 0
-    resp = upsert_passed_task("sysctls", "✔️  PASSED: No restricted values found for sysctls #{emoji_security}")
-  else
-    resp = upsert_failed_task("sysctls", "✖️  FAILED: Restricted values for are being used for sysctls #{emoji_security}")
-    failures.each do |failure|
-      failure.resources.each do |resource|
-        puts "#{resource.kind} #{resource.name} in #{resource.namespace} namespace failed. #{failure.message}".colorize(:red)
+  CNFManager::Task.task_runner(args) do |args, config|
+    emoji_security = "🔓🔑"
+    policy_path = Kyverno.policy_path("pod-security/baseline/restrict-sysctls/restrict-sysctls.yaml")
+    failures = Kyverno::PolicyAudit.run(policy_path, EXCLUDE_NAMESPACES)
+
+    if failures.size == 0
+      resp = upsert_passed_task("sysctls", "✔️  PASSED: No restricted values found for sysctls #{emoji_security}")
+    else
+      resp = upsert_failed_task("sysctls", "✖️  FAILED: Restricted values for are being used for sysctls #{emoji_security}")
+      failures.each do |failure|
+        failure.resources.each do |resource|
+          puts "#{resource.kind} #{resource.name} in #{resource.namespace} namespace failed. #{failure.message}".colorize(:red)
+        end
       end
     end
   end
@@ -54,17 +57,19 @@ desc "Check if the CNF has services with external IPs configured"
 task "external_ips" do |_, args|
   Log.for("verbose").info { "external_ips" }
   Kyverno.install
-  emoji_security = "🔓🔑"
-  policy_path = Kyverno.best_practice_policy("restrict-service-external-ips/restrict-service-external-ips.yaml")
-  failures = Kyverno::PolicyAudit.run(policy_path, EXCLUDE_NAMESPACES)
+  CNFManager::Task.task_runner(args) do |args, config|
+    emoji_security = "🔓🔑"
+    policy_path = Kyverno.best_practice_policy("restrict-service-external-ips/restrict-service-external-ips.yaml")
+    failures = Kyverno::PolicyAudit.run(policy_path, EXCLUDE_NAMESPACES)
 
-  if failures.size == 0
-    resp = upsert_passed_task("external_ips", "✔️  PASSED: Services are not using external IPs #{emoji_security}")
-  else
-    resp = upsert_failed_task("external_ips", "✖️  FAILED: Services are using external IPs #{emoji_security}")
-    failures.each do |failure|
-      failure.resources.each do |resource|
-        puts "#{resource.kind} #{resource.name} in #{resource.namespace} namespace failed. #{failure.message}".colorize(:red)
+    if failures.size == 0
+      resp = upsert_passed_task("external_ips", "✔️  PASSED: Services are not using external IPs #{emoji_security}")
+    else
+      resp = upsert_failed_task("external_ips", "✖️  FAILED: Services are using external IPs #{emoji_security}")
+      failures.each do |failure|
+        failure.resources.each do |resource|
+          puts "#{resource.kind} #{resource.name} in #{resource.namespace} namespace failed. #{failure.message}".colorize(:red)
+        end
       end
     end
   end
@@ -74,17 +79,19 @@ desc "Check if the CNF or the cluster resources have custom SELinux options"
 task "selinux_options" do |_, args|
   Log.for("verbose").info { "selinux_options" }
   Kyverno.install
-  emoji_security = "🔓🔑"
-  policy_path = Kyverno.policy_path("pod-security/baseline/disallow-selinux/disallow-selinux.yaml")
-  failures = Kyverno::PolicyAudit.run(policy_path, EXCLUDE_NAMESPACES)
+  CNFManager::Task.task_runner(args) do |args, config|
+    emoji_security = "🔓🔑"
+    policy_path = Kyverno.policy_path("pod-security/baseline/disallow-selinux/disallow-selinux.yaml")
+    failures = Kyverno::PolicyAudit.run(policy_path, EXCLUDE_NAMESPACES)
 
-  if failures.size == 0
-    resp = upsert_passed_task("selinux_options", "✔️  PASSED: Resources are not using custom SELinux options #{emoji_security}")
-  else
-    resp = upsert_failed_task("selinux_options", "✖️  FAILED: Resources are using custom SELinux options #{emoji_security}")
-    failures.each do |failure|
-      failure.resources.each do |resource|
-        puts "#{resource.kind} #{resource.name} in #{resource.namespace} namespace failed. #{failure.message}".colorize(:red)
+    if failures.size == 0
+      resp = upsert_passed_task("selinux_options", "✔️  PASSED: Resources are not using custom SELinux options #{emoji_security}")
+    else
+      resp = upsert_failed_task("selinux_options", "✖️  FAILED: Resources are using custom SELinux options #{emoji_security}")
+      failures.each do |failure|
+        failure.resources.each do |resource|
+          puts "#{resource.kind} #{resource.name} in #{resource.namespace} namespace failed. #{failure.message}".colorize(:red)
+        end
       end
     end
   end
@@ -94,17 +101,19 @@ desc "Check if the CNF is running containers with container sock mounts"
 task "container_sock_mounts" do |_, args|
   Log.for("verbose").info { "container_sock_mounts" }
   Kyverno.install
-  emoji_security = "🔓🔑"
-  policy_path = Kyverno.best_practice_policy("disallow_cri_sock_mount/disallow_cri_sock_mount.yaml")
-  failures = Kyverno::PolicyAudit.run(policy_path, EXCLUDE_NAMESPACES)
+  CNFManager::Task.task_runner(args) do |args, config|
+    emoji_security = "🔓🔑"
+    policy_path = Kyverno.best_practice_policy("disallow_cri_sock_mount/disallow_cri_sock_mount.yaml")
+    failures = Kyverno::PolicyAudit.run(policy_path, EXCLUDE_NAMESPACES)
 
-  if failures.size == 0
-    resp = upsert_passed_task("container_sock_mounts", "✔️  PASSED: Container engine daemon sockets are not mounted as volumes #{emoji_security}")
-  else
-    resp = upsert_failed_task("container_sock_mounts", "✖️  FAILED: Container engine daemon sockets are mounted as volumes #{emoji_security}")
-    failures.each do |failure|
-      failure.resources.each do |resource|
-        puts "#{resource.kind} #{resource.name} in #{resource.namespace} namespace failed. #{failure.message}".colorize(:red)
+    if failures.size == 0
+      resp = upsert_passed_task("container_sock_mounts", "✔️  PASSED: Container engine daemon sockets are not mounted as volumes #{emoji_security}")
+    else
+      resp = upsert_failed_task("container_sock_mounts", "✖️  FAILED: Container engine daemon sockets are mounted as volumes #{emoji_security}")
+      failures.each do |failure|
+        failure.resources.each do |resource|
+          puts "#{resource.kind} #{resource.name} in #{resource.namespace} namespace failed. #{failure.message}".colorize(:red)
+        end
       end
     end
   end

--- a/src/tasks/workload/security.cr
+++ b/src/tasks/workload/security.cr
@@ -25,7 +25,8 @@ task "security", [
     "container_sock_mounts",
     "external_ips",
     "selinux_options",
-    "sysctls"
+    "sysctls",
+    "host_network"
   ] do |_, args|
   stdout_score("security")
 end

--- a/src/tasks/workload/security.cr
+++ b/src/tasks/workload/security.cr
@@ -28,6 +28,7 @@ task "security", [
     "sysctls",
     "host_network",
     "service_account_mapping",
+    "application_credentials"
   ] do |_, args|
   stdout_score("security")
 end


### PR DESCRIPTION
## Description

* `shared_database` should be run when microservice test category is run (#1323)
* `versioned_tag` test should be run when configuration category is run (#1324)
* `host_network` sholud be run when workload security is run (#1325)
* `service_account_mapping` should be run as a part of workload security (#1326)
* `pod_network_duplication` should be run as a part of resilience (#1330)
* `liveness` and `readiness` should be run as a part of resilience (#1331)
* Ship shared_database test if not MariaDB containers are found (#1342)
* Mark `pod_dns_error` under the `resilience` category in `points.yml` (#1343)
* Surround all Kyverno tests with `CNFManager::Task.task_runner` block (No ticket for this. Just added it for sanity)

## Issues:
Refs: #1323, #1324, #1325, #1326, #1330, #1331, #1342, #1343

## How has this been tested:
 - [ ] Covered by existing integration testing
 - [ ] Added integration testing to cover
 - [ ] Verified all A/C passes
     * [ ] develop
     * [ ] master
     * [ ] tag/other branch
 - [ ] Test environment
    * [ ] Shared Packet K8s cluster
    * [ ] New Packet K8s cluster
    * [ ] Kind cluster
 - [ ] Have not tested

## Types of changes:
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [ ] Documentation update

## Checklist:
**Documentation**
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] No updates required.

**Code Review**
- [ ] Does the test handle fatal exceptions, ie. rescue block

**Issue**
- [ ] Tasks in issue are checked off
