### PR TITLE
[bug/1336] The `elastic_volumes` test should be skipped if the cnf does not use any volumes

### DIFF
--- a/spec/workload/state_spec.cr
+++ b/spec/workload/state_spec.cr
@@ -25,6 +25,19 @@ describe "State" do
     end
   end
 
+  it "'elastic_volume' should be skipped if the cnf does not use any volumes", tags: ["elastic_volume"]  do
+    begin
+      LOGGING.info `./cnf-testsuite -l info cnf_setup cnf-config=./sample-cnfs/sample_nonroot`
+      $?.success?.should be_true
+      response_s = `./cnf-testsuite -l info elastic_volumes verbose`
+      LOGGING.info "Status:  #{response_s}"
+      (/SKIPPED: No volumes used/ =~ response_s).should_not be_nil
+    ensure
+      LOGGING.info `./cnf-testsuite cnf_cleanup cnf-config=./sample-cnfs/sample_nonroot`
+      $?.success?.should be_true
+    end
+  end
+
   it "'database_persistence' should pass if the cnf uses a database that uses an elastic volume with a stateful set", tags: ["elastic_volume"]  do
     begin
       Log.info {"Installing Mysql "}

--- a/spec/workload/state_spec.cr
+++ b/spec/workload/state_spec.cr
@@ -56,7 +56,7 @@ describe "State" do
       $?.success?.should be_true
       response_s = `./cnf-testsuite -l info elastic_volumes verbose`
       LOGGING.info "Status:  #{response_s}"
-      (/FAILED: Elastic Volumes Not Used/ =~ response_s).should_not be_nil
+      (/FAILED: Volumes used are not elastic volumes/ =~ response_s).should_not be_nil
     ensure
       LOGGING.info `./cnf-testsuite cnf_cleanup cnf-config=./sample-cnfs/sample-coredns-cnf/cnf-testsuite.yml`
       $?.success?.should be_true

--- a/src/tasks/workload/state.cr
+++ b/src/tasks/workload/state.cr
@@ -348,7 +348,7 @@ task "elastic_volumes" do |_, args|
     if elastic
       resp = upsert_passed_task("elastic_volumes","✔️  PASSED: Elastic Volumes Used #{emoji_probe}")
     else
-      resp = upsert_failed_task("elastic_volumes","✔️  FAILED: Elastic Volumes Not Used #{emoji_probe}")
+      resp = upsert_failed_task("elastic_volumes","✔️  FAILED: Volumes used are not elastic volumes #{emoji_probe}")
     end
     resp
   end

--- a/src/tasks/workload/state.cr
+++ b/src/tasks/workload/state.cr
@@ -345,7 +345,7 @@ task "elastic_volumes" do |_, args|
 
     if volumes_used == false
       resp = upsert_skipped_task("elastic_volumes","✔️  SKIPPED: No volumes used #{emoji_probe}")
-    if elastic
+    elsif elastic
       resp = upsert_passed_task("elastic_volumes","✔️  PASSED: Elastic Volumes Used #{emoji_probe}")
     else
       resp = upsert_failed_task("elastic_volumes","✔️  FAILED: Volumes used are not elastic volumes #{emoji_probe}")

--- a/src/tasks/workload/state.cr
+++ b/src/tasks/workload/state.cr
@@ -325,9 +325,14 @@ task "elastic_volumes" do |_, args|
     VERBOSE_LOGGING.info "elastic_volumes" if check_verbose(args)
     emoji_probe="🧫"
     elastic = false
+    volumes_used = false
     task_response = CNFManager.workload_resource_test(args, config, check_containers=false) do |resource, containers, volumes, initialized|
       Log.info {"resource: #{resource}"}
       Log.info {"volumes: #{volumes}"}
+
+      next if volumes.size == 0
+      volumes_used = true
+
       # todo use workload resource
       # elastic = WorkloadResource.elastic?(volumes)
       namespace = CNFManager.namespace_from_parameters(CNFManager.install_parameters(config))
@@ -337,6 +342,9 @@ task "elastic_volumes" do |_, args|
         elastic = true
       end
     end
+
+    if volumes_used == false
+      resp = upsert_skipped_task("elastic_volumes","✔️  SKIPPED: No volumes used #{emoji_probe}")
     if elastic
       resp = upsert_passed_task("elastic_volumes","✔️  PASSED: Elastic Volumes Used #{emoji_probe}")
     else


### PR DESCRIPTION
## Issues
Refs: #1336

## Description
* The `elastic_volumes` will be skipped if the cnf does not used any volumes.
* Updated the message for test failure to be a bit more clear.
* Add spec test for skipped scenario.

#### Sample CNFs for different scenarios
* Skipped result: `sample-cnfs/sample_nonroot`
* Pass result: `sample-cnfs/sample-elastic-volume`
* Fail result: `sample-cnfs/sample-coredns-cnf`

<img width="1205" alt="CleanShot 2022-04-20 at 11 16 39@2x" src="https://user-images.githubusercontent.com/84005/164159013-d24a29f3-c77f-473a-9d5e-0cbde4782322.png">

## How has this been tested:
 - [x] Covered by existing integration testing
 - [x] Added integration testing to cover
 - [ ] Verified all A/C passes
     * [ ] develop
     * [ ] master
     * [ ] tag/other branch
 - [ ] Test environment
    * [ ] Shared Packet K8s cluster
    * [ ] New Packet K8s cluster
    * [ ] Kind cluster
 - [ ] Have not tested

## Types of changes:
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [ ] Documentation update

## Checklist:
**Documentation**
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] No updates required.

**Code Review**
- [ ] Does the test handle fatal exceptions, ie. rescue block

**Issue**
- [ ] Tasks in issue are checked off
