### PR TITLE
[bug/1290] Replace puts with log statements in LitmusManager

### DIFF
--- a/src/tasks/litmus_setup.cr
+++ b/src/tasks/litmus_setup.cr
@@ -95,16 +95,16 @@ module LitmusManager
     experimentStatus = ""
     
     experimentStatus_cmd = "kubectl get chaosengine.litmuschaos.io #{test_name} -o jsonpath='{.status.engineStatus}'"
-    puts "Checking experiment status  #{experimentStatus_cmd}" if check_verbose(args)
+    Log.for("wait_for_test").info { "Checking experiment status #{experimentStatus_cmd}" } if check_verbose(args)
 
     ## Wait for completion of chaosengine which indicates the completion of chaos
     until (status_code == 0 && experimentStatus == "Completed") || wait_count >= retry
       sleep delay
       experimentStatus_cmd = "kubectl get chaosengine.litmuschaos.io #{test_name} -o jsonpath='{.status.experiments[0].status}'"
-      puts "Checking experiment status  #{experimentStatus_cmd}" if check_verbose(args)
+      Log.for("wait_for_test").info { "Checking experiment status  #{experimentStatus_cmd}" } if check_verbose(args)
       status_code = Process.run("#{experimentStatus_cmd}", shell: true, output: experimentStatus_response = IO::Memory.new, error: stderr = IO::Memory.new).exit_status
-      puts "status_code: #{status_code}" if check_verbose(args)
-      puts "Checking experiment status  #{experimentStatus_cmd}" if check_verbose(args)
+      Log.for("wait_for_test").info { "status_code: #{status_code}" } if check_verbose(args)
+      Log.for("wait_for_test").info { "Checking experiment status  #{experimentStatus_cmd}" } if check_verbose(args)
       experimentStatus = experimentStatus_response.to_s
       Log.info {"#{chaos_experiment_name} experiment status: "+experimentStatus}
 
@@ -119,13 +119,13 @@ module LitmusManager
     verdict = ""
     wait_count = 0
     verdict_cmd = "kubectl get chaosresults.litmuschaos.io #{chaos_result_name} -o jsonpath='{.status.experimentStatus.verdict}'"
-    puts "Checking experiment verdict  #{verdict_cmd}" if check_verbose(args)
+    Log.for("wait_for_test").info { "Checking experiment verdict  #{verdict_cmd}" } if check_verbose(args)
     ## Check the chaosresult verdict
     until (status_code == 0 && verdict != "Awaited") || wait_count >= 30
       sleep delay
       status_code = Process.run("#{verdict_cmd}", shell: true, output: verdict_response = IO::Memory.new, error: stderr = IO::Memory.new).exit_status
-      puts "status_code: #{status_code}" if check_verbose(args)
-      puts "verdict: #{verdict_response.to_s}"  if check_verbose(args)
+      Log.for("wait_for_test").info { "status_code: #{status_code}" } if check_verbose(args)
+      Log.for("wait_for_test").info { "verdict: #{verdict_response.to_s}" } if check_verbose(args)
       verdict = verdict_response.to_s
       wait_count = wait_count + 1
     end
@@ -134,10 +134,10 @@ module LitmusManager
   ## check_chaos_verdict will check the verdict of chaosexperiment
   def self.check_chaos_verdict(chaos_result_name,chaos_experiment_name,args): Bool
     verdict_cmd = "kubectl get chaosresults.litmuschaos.io #{chaos_result_name} -o jsonpath='{.status.experimentStatus.verdict}'"
-    puts "Checking experiment verdict  #{verdict_cmd}" if check_verbose(args)
+    Log.for("check_chaos_verdict").info { "Checking experiment verdict #{verdict_cmd}" } if check_verbose(args)
     status_code = Process.run("#{verdict_cmd}", shell: true, output: verdict_response = IO::Memory.new, error: stderr = IO::Memory.new).exit_status
-    puts "status_code: #{status_code}" if check_verbose(args)
-    puts "verdict: #{verdict_response.to_s}"  if check_verbose(args)
+    Log.for("check_chaos_verdict").info { "status_code: #{status_code}" } if check_verbose(args)
+    Log.for("check_chaos_verdict").info { "verdict: #{verdict_response.to_s}" } if check_verbose(args)
     verdict = verdict_response.to_s
 
     emoji_test_failed= "🗡️💀♻️"
@@ -145,7 +145,6 @@ module LitmusManager
       return true
     else
       Log.info {"#{chaos_experiment_name} chaos test failed: #{chaos_result_name}, verdict: #{verdict}"}
-      puts "#{chaos_experiment_name} chaos test failed #{emoji_test_failed}"
       return false
     end
   end


### PR DESCRIPTION
## Description

The `puts` statements in LitmusManager causes unformatted white-colored output to be displayed.

* This PR removes the puts statement that was displaying unformatted output.
* Also replaces any other `puts` statements with calls to the `Log` module.

## Issues:
Refs: #1290

## How has this been tested:
 - [x] Covered by existing integration testing
 - [ ] Added integration testing to cover
 - [ ] Verified all A/C passes
     * [ ] develop
     * [ ] master
     * [ ] tag/other branch
 - [ ] Test environment
    * [ ] Shared Packet K8s cluster
    * [ ] New Packet K8s cluster
    * [ ] Kind cluster
 - [ ] Have not tested

## Types of changes:
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [ ] Documentation update

## Checklist:
**Documentation**
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] No updates required.

**Code Review**
- [ ] Does the test handle fatal exceptions, ie. rescue block

**Issue**
- [ ] Tasks in issue are checked off
