### PR TITLE
[1375, 1387, 1386] Add non-default namespace support for workload security tests

### DIFF
--- a/sample-cnfs/ndn-non-root-user/cnf-testsuite.yml
+++ b/sample-cnfs/ndn-non-root-user/cnf-testsuite.yml
@@ -1,0 +1,16 @@
+---
+git_clone_url: 
+install_script: 
+manifest_directory: manifests
+release_name: nginx
+docker_repository: 
+helm_repository:
+  name: 
+  repo_url:
+container_names: 
+  - name: nginx
+    rolling_update_test_tag: "latest"
+    rolling_downgrade_test_tag: latest
+    rolling_version_change_test_tag: latest
+    rollback_from_tag: latest
+allowlist_helm_chart_container_names: []

--- a/sample-cnfs/ndn-non-root-user/manifests/pod.yml
+++ b/sample-cnfs/ndn-non-root-user/manifests/pod.yml
@@ -33,8 +33,5 @@ spec:
     args: ["-c", "while true; do echo echo $(date -u) 'Hi I am from Sidecar container' >> /var/log/index.html; sleep 5;done"]
     name: sidecar-container
     resources: {}
-    volumeMounts:
-    - name: var-logs
-      mountPath: /var/log
 
   dnsPolicy: Default

--- a/sample-cnfs/ndn-non-root-user/manifests/pod.yml
+++ b/sample-cnfs/ndn-non-root-user/manifests/pod.yml
@@ -1,0 +1,32 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: nginx
+spec:
+  containers:
+  - image: bitnami/nginx:1.20
+    name: main-container
+    command:
+      - /opt/bitnami/scripts/nginx/entrypoint.sh
+      - /opt/bitnami/scripts/nginx/run.sh
+    livenessProbe:
+      tcpSocket:
+        port: 8080
+    readinessProbe:
+      tcpSocket:
+        port: 8080
+    resources: {}
+    ports:
+      - containerPort: 8080
+      - containerPort: 8443
+
+  - image: busybox:1.33.1
+    command: ["/bin/sh"]
+    args: ["-c", "while true; do echo echo $(date -u) 'Hi I am from Sidecar container' >> /var/log/index.html; sleep 5;done"]
+    name: sidecar-container
+    resources: {}
+    volumeMounts:
+    - name: var-logs
+      mountPath: /var/log
+
+  dnsPolicy: Default

--- a/sample-cnfs/ndn-non-root-user/manifests/pod.yml
+++ b/sample-cnfs/ndn-non-root-user/manifests/pod.yml
@@ -1,7 +1,15 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: nginx-stuff
+
+---
 apiVersion: v1
 kind: Pod
 metadata:
   name: nginx
+  namespace: nginx-stuff
 spec:
   containers:
   - image: bitnami/nginx:1.20

--- a/sample-cnfs/sample-ndn-privileged/cnf-testsuite.yml
+++ b/sample-cnfs/sample-ndn-privileged/cnf-testsuite.yml
@@ -1,0 +1,16 @@
+---
+git_clone_url: 
+install_script: 
+manifest_directory: manifests
+release_name: nginx
+docker_repository: 
+helm_repository:
+  name: 
+  repo_url:
+container_names: 
+  - name: nginx
+    rolling_update_test_tag: "latest"
+    rolling_downgrade_test_tag: latest
+    rolling_version_change_test_tag: latest
+    rollback_from_tag: latest
+allowlist_helm_chart_container_names: []

--- a/sample-cnfs/sample-ndn-privileged/manifests/pod.yml
+++ b/sample-cnfs/sample-ndn-privileged/manifests/pod.yml
@@ -1,0 +1,24 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: nginx
+spec:
+  containers:
+  - image: bitnami/nginx:1.20
+    name: nginx
+    command:
+      - /opt/bitnami/scripts/nginx/entrypoint.sh
+      - /opt/bitnami/scripts/nginx/run.sh
+    securityContext:
+      privileged: true
+    livenessProbe:
+      tcpSocket:
+        port: 8080
+    readinessProbe:
+      tcpSocket:
+        port: 8080
+    resources: {}
+    ports:
+      - containerPort: 8080
+      - containerPort: 8443
+  dnsPolicy: Default

--- a/sample-cnfs/sample-ndn-privileged/manifests/pod.yml
+++ b/sample-cnfs/sample-ndn-privileged/manifests/pod.yml
@@ -1,7 +1,15 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: nginx-stuff
+
+---
 apiVersion: v1
 kind: Pod
 metadata:
   name: nginx
+  namespace: nginx-stuff
 spec:
   containers:
   - image: bitnami/nginx:1.20

--- a/spec/cnf_testsuite_all/cnf_testsuite_spec.cr
+++ b/spec/cnf_testsuite_all/cnf_testsuite_spec.cr
@@ -38,7 +38,8 @@ describe CnfTestSuite do
       response_s = `./cnf-testsuite workload ~automatic_cnf_install ~ensure_cnf_installed ~configuration_file_setup ~compatibility ~state ~scalability ~configuration_lifecycle ~observability ~installability ~hardware_and_scheduling ~microservice ~resilience ~non_root_user`
       LOGGING.info response_s
       $?.success?.should be_false
-      (/Found.*privileged containers.*coredns/ =~ response_s).should_not be_nil
+      (/Found.*privileged containers.*/ =~ response_s).should_not be_nil
+      (/Privileged container (privileged-coredns) in.*/ =~ response_s).should_not be_nil
       response_s = `./cnf-testsuite privileged strict`
       $?.success?.should be_false
     ensure

--- a/spec/utils/utils_spec.cr
+++ b/spec/utils/utils_spec.cr
@@ -174,7 +174,7 @@ describe "Utils" do
 
     resp = `./cnf-testsuite privileged`
     Log.info { resp }
-    (resp).includes?("✖️  FAILED: Found 1 privileged containers: [\"privileged-coredns\"]").should be_true
+    (resp).includes?("✖️  FAILED: Found 1 privileged containers").should be_true
   ensure
     response_s = `./cnf-testsuite cnf_cleanup cnf-config=sample-cnfs/sample-generic-cnf/cnf-testsuite.yml`
     Log.info { response_s }
@@ -182,7 +182,7 @@ describe "Utils" do
     response_s = `./cnf-testsuite cnf_cleanup cnf-config=sample-cnfs/sample_privileged_cnf/cnf-testsuite.yml`
     Log.info { response_s }
     $?.success?.should be_true
-end
+  end
 
   it "'logger' command line logger level setting via config.yml", tags: ["logger"]  do
     # NOTE: the config.yml file is in the root of the repo directory. 

--- a/spec/workload/security_spec.cr
+++ b/spec/workload/security_spec.cr
@@ -50,7 +50,8 @@ describe "Security" do
       response_s = `./cnf-testsuite privileged verbose`
       LOGGING.info response_s
       $?.success?.should be_true
-      (/Found.*privileged containers.*coredns/ =~ response_s).should_not be_nil
+      (/Found.*privileged containers.*/ =~ response_s).should_not be_nil
+      (/Privileged container (privileged-coredns) in.*/ =~ response_s).should_not be_nil
     ensure
       `./cnf-testsuite sample_privileged_cnf_non_whitelisted_cleanup`
     end
@@ -62,7 +63,7 @@ describe "Security" do
       response_s = `./cnf-testsuite privileged cnf-config=sample-cnfs/sample_whitelisted_privileged_cnf verbose`
       LOGGING.info response_s
       $?.success?.should be_true
-      (/Found.*privileged containers.*coredns/ =~ response_s).should be_nil
+      (/Found.*privileged containers.*/ =~ response_s).should be_nil
     ensure
       `./cnf-testsuite sample_privileged_cnf_whitelisted_cleanup`
     end

--- a/spec/workload/security_spec.cr
+++ b/spec/workload/security_spec.cr
@@ -32,6 +32,20 @@ describe "Security" do
     end
   end
 
+  it "'non_root_user' should fail with a root cnf using a non-default namespace", tags: ["security"]  do
+    begin
+      LOGGING.info `./cnf-testsuite cnf_setup cnf-config=sample-cnfs/ndn-non-root-user/cnf-testsuite.yml`
+      response_s = `./cnf-testsuite non_root_user verbose`
+      LOGGING.info response_s
+      $?.success?.should be_true
+      (/Root user found/ =~ response_s).should_not be_nil
+    ensure
+      LOGGING.info `./cnf-testsuite cnf_cleanup cnf-config=sample-cnfs/ndn-non-root-user/cnf-testsuite.yml`
+      LOGGING.debug `./cnf-testsuite uninstall_falco`
+      KubectlClient::Get.resource_wait_for_uninstall("DaemonSet", "falco")
+    end
+  end
+
   it "'privileged' should pass with a non-privileged cnf", tags: ["privileged"]  do
     begin
       LOGGING.debug `./cnf-testsuite cnf_setup cnf-config=sample-cnfs/sample-statefulset-cnf/cnf-testsuite.yml`

--- a/src/tasks/cleanup.cr
+++ b/src/tasks/cleanup.cr
@@ -43,7 +43,7 @@ task "samples_cleanup" do  |_, args|
 end
 
 desc "Cleans up the CNF Test Suite helper tools and containers"
-task "tools_cleanup", ["helm_local_cleanup", "sonobuoy_cleanup", "uninstall_chaosmesh","uninstall_litmus", "uninstall_dockerd", "uninstall_kubescape","uninstall_cluster_tools"] do  |_, args|
+task "tools_cleanup", ["helm_local_cleanup", "sonobuoy_cleanup", "uninstall_chaosmesh","uninstall_litmus", "uninstall_dockerd", "uninstall_kubescape","uninstall_cluster_tools", "uninstall_opa"] do  |_, args|
 end
 
 desc "Cleans up the CNF Test Suite sample projects, helper tools, and containers"

--- a/src/tasks/utils/cnf_manager.cr
+++ b/src/tasks/utils/cnf_manager.cr
@@ -165,8 +165,7 @@ module CNFManager
     # todo check to see if following 'resource' variable is conflicting with above resource variable
 		resource_names.each do | resource |
 			Log.for("verbose").debug { resource.inspect } if check_verbose(args)
-      #todo accept namespace
-			volumes = KubectlClient::Get.resource_volumes(resource[:kind], resource[:name], namespace)
+      volumes = KubectlClient::Get.resource_volumes(kind: resource[:kind], resource_name: resource[:name], namespace: resource[:namespace])
       Log.for("verbose").debug { "check_service: #{check_service}" } if check_verbose(args)
       Log.for("verbose").debug { "check_containers: #{check_containers}" } if check_verbose(args)
       case resource[:kind].downcase
@@ -179,7 +178,7 @@ module CNFManager
           test_passed = false if resp == false
         end
       else
-				containers = KubectlClient::Get.resource_containers(resource[:kind], resource[:name], namespace)
+        containers = KubectlClient::Get.resource_containers(resource[:kind], resource[:name], resource[:namespace])
 				if check_containers
 					containers.as_a.each do |container|
 						resp = yield resource, container, volumes, initialized

--- a/src/tasks/workload/configuration.cr
+++ b/src/tasks/workload/configuration.cr
@@ -158,7 +158,7 @@ task "versioned_tag", ["install_opa"] do |_, args|
        kind = resource["kind"].downcase
        case kind 
        when  "deployment","statefulset","pod","replicaset", "daemonset"
-         resource_yaml = KubectlClient::Get.resource(resource[:kind], resource[:name])
+         resource_yaml = KubectlClient::Get.resource(resource[:kind], resource[:name], resource[:namespace])
          pods = KubectlClient::Get.pods_by_resource(resource_yaml)
          pods.map do |pod|
            pod_name = pod.dig("metadata", "name")

--- a/src/tasks/workload/security.cr
+++ b/src/tasks/workload/security.cr
@@ -159,7 +159,7 @@ task "non_root_user", ["install_falco"] do |_, args|
        kind = resource["kind"].downcase
        case kind 
        when  "deployment","statefulset","pod","replicaset", "daemonset"
-         resource_yaml = KubectlClient::Get.resource(resource[:kind], resource[:name])
+         resource_yaml = KubectlClient::Get.resource(resource[:kind], resource[:name], resource[:namespace])
          pods = KubectlClient::Get.pods_by_resource(resource_yaml)
          # containers = KubectlClient::Get.resource_containers(kind, resource[:name]) 
          pods.map do |pod|

--- a/utils/helm/helm.cr
+++ b/utils/helm/helm.cr
@@ -26,9 +26,15 @@ class BinaryReference
     helm_v3 && helm_v3.not_nil![1]
   end
 
+
+  def local_helm_path
+    current_dir = FileUtils.pwd
+    helm = "#{current_dir}/#{TOOLS_DIR}/helm/linux-amd64/helm"
+  end
+
   # Get helm directory
   def helm
-    @helm ||= global_helm_installed? ? "helm" : raise "Global install of Helm not found"
+    @helm ||= global_helm_installed? ? "helm" : local_helm_path
   end
 end
 
@@ -263,11 +269,6 @@ module Helm
       stdout_failure("Please use newer version of helm")
       true
     end
-  end
-
-  def self.local_helm_path
-    current_dir = FileUtils.pwd
-    helm = "#{current_dir}/#{TOOLS_DIR}/helm/linux-amd64/helm"
   end
 
   def self.chart_name(helm_chart_repo)

--- a/utils/kubectl_client/kubectl_client.cr
+++ b/utils/kubectl_client/kubectl_client.cr
@@ -631,7 +631,7 @@ module KubectlClient
 
     #todo pass in namespace
     def self.resource_volumes(kind, resource_name, namespace="default") : JSON::Any
-      Log.info { "kubectl get resource volumes kind: #{kind} resource_name: #{resource_name} namespace: #{namespace}" }
+      Log.for("KubectlClient::Get.resource_volumes").info { "#{kind} resource_name: #{resource_name} namespace: #{namespace}" }
       unless kind.downcase == "service" ## services have no volumes
         resp = resource(kind, resource_name, namespace).dig?("spec", "template", "spec", "volumes")
       end


### PR DESCRIPTION
> *Resolves #1387, #1386, #1375*

Adds support for security tests to test CNFs using non-default namespaces.

## [#1387] Update `CNFManager.workload_resource_test` to return resources along with namespace

* Return the namespace for every resource as a part of the resource hash.
* The namespace returned must be the namespace as in the spec and not the default namespace assumed by the helper function.
* Update calls to `KubectlClient` helpers to pass a namespace arg.

> No A/C steps would be required for this. Any validation done for the `privileged` test would verify these CNFManager changes too.

## [#1387] Updates to `privileged` test

* Added new sample CNF to test non-default namespaces `sample-ndn-privileged`
* Updated the test failure output to display the container's resource/pod name and namespace. This helps clarity.
* Commands added below to setup and test sample CNF that does not use default namespace.
* Update calls to `KubectlClient` helpers to pass a namespace arg.

```
./cnf-testsuite cnf_setup cnf-config=./sample-cnfs/sample-ndn-privileged
./cnf-testsuite privileged
```

#### Test failure output before formatting changes
<img width="1459" alt="CleanShot 2022-04-25 at 08 27 09@2x" src="https://user-images.githubusercontent.com/84005/165046965-b3c01bf7-f5da-4bf3-9788-ef8ec9f2e673.png">

#### Test failure output after formatting changes
<img width="1022" alt="CleanShot 2022-04-25 at 08 34 54@2x" src="https://user-images.githubusercontent.com/84005/165047094-507dfb22-e1eb-4473-96a6-534078200f18.png">

## Updates to `non_root_user` test

* Added sample CNF that does not use default namespace: `ndn-non-root-user`.
* Added a spec test to validate this scenario.

## [#1386] Uninstall OPA when `cleanup_all` task is run

OPA is uninstalled for the `versioned_tag` test. This ensures that when the cluster resources are cleaned up, OPA is removed too.

## [#1375] Use local helm if global helm is not found

* Removed the rescue and returned the local helm path instead.
* We can assume that local helm is always there because we download it as a part of our setup.

## Other changes

There is a stray change in `configuration.cr` that passes the resource namespace to KubectlClient helper. Builds pass and wouldn't hurt to have this change - coming soon in another PR anyway. So leaving it as is.

## How has this been tested:
 - [x] Covered by existing integration testing
 - [x] Added integration testing to cover
 - [ ] Verified all A/C passes
     * [ ] develop
     * [ ] master
     * [ ] tag/other branch
 - [ ] Test environment
    * [ ] Shared Packet K8s cluster
    * [ ] New Packet K8s cluster
    * [ ] Kind cluster
 - [ ] Have not tested

## Types of changes:
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [x] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [ ] Documentation update

## Checklist:
**Documentation**
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] No updates required.

**Code Review**
- [ ] Does the test handle fatal exceptions, ie. rescue block

**Issue**
- [ ] Tasks in issue are checked off
