### PR TITLE
[bug/1445] Remove requirement of destructive option for `helm_deploy` test

### DIFF
--- a/spec/utils/utils_spec.cr
+++ b/spec/utils/utils_spec.cr
@@ -253,11 +253,11 @@ describe "Utils" do
   end
 
   it "'logger' or verbose output should be shown when verbose flag is set", tags: ["logger"] do
-    response_s = `./cnf-testsuite helm_deploy destructive verbose`
+    response_s = `./cnf-testsuite helm_deploy verbose`
     LOGGING.info response_s
     puts response_s
     $?.success?.should be_true
-    (/INFO -- cnf-testsuite-verbose: helm_deploy/ =~ response_s).should_not be_nil
+    (/helm_deploy args/ =~ response_s).should_not be_nil
   end
 
   it "'#update_yml' should update the value for a key in a yml file", tags: ["logger"]  do

--- a/spec/utils/utils_spec.cr
+++ b/spec/utils/utils_spec.cr
@@ -253,7 +253,7 @@ describe "Utils" do
   end
 
   it "'logger' or verbose output should be shown when verbose flag is set", tags: ["logger"] do
-    response_s = `./cnf-testsuite helm_deploy verbose`
+    response_s = `./cnf-testsuite -l info helm_deploy verbose`
     LOGGING.info response_s
     puts response_s
     $?.success?.should be_true

--- a/spec/workload/installability_spec.cr
+++ b/spec/workload/installability_spec.cr
@@ -10,7 +10,7 @@ describe CnfTestSuite do
 
 	it "'helm_deploy' should fail on a bad helm chart", tags: ["helm"] do
     LOGGING.info `./cnf-testsuite cnf_setup cnf-path=./sample-cnfs/sample-bad-helm-deploy-repo verbose`
-    response_s = `./cnf-testsuite helm_deploy destructive verbose`
+    response_s = `./cnf-testsuite helm_deploy verbose`
     LOGGING.info response_s
     $?.success?.should be_true
     (/FAILED: Helm deploy failed/ =~ response_s).should_not be_nil
@@ -19,7 +19,7 @@ describe CnfTestSuite do
   end
 
   it "'helm_deploy' should fail if command is not supplied cnf-config argument", tags: ["helm"] do
-    response_s = `./cnf-testsuite helm_deploy destructive`
+    response_s = `./cnf-testsuite helm_deploy`
     LOGGING.info response_s
     $?.success?.should be_true
     (/No cnf_testsuite.yml found! Did you run the setup task/ =~ response_s).should_not be_nil

--- a/src/tasks/workload/compatibility.cr
+++ b/src/tasks/workload/compatibility.cr
@@ -396,17 +396,10 @@ end
 
 desc "Will the CNF install using helm with helm_deploy?"
 task "helm_deploy" do |_, args|
-  unless check_destructive(args)
-    Log.info { "skipping helm_deploy: not in destructive mode" }
-    puts "⏭️  SKIPPED: Helm Deploy".colorize(:yellow)
-    next
-  end
-  Log.info { "Running helm_deploy in destructive mode!" }
-  Log.for("verbose").info { "helm_deploy" } if check_verbose(args)
+  Log.for("helm_deploy").info { "Starting test" } if check_verbose(args)
   Log.info { "helm_deploy args: #{args.inspect}" }
   if check_cnf_config(args) || CNFManager.destination_cnfs_exist?
     CNFManager::Task.task_runner(args) do |args, config|
-      
       emoji_helm_deploy="⎈🚀"
       helm_chart = config.cnf_config[:helm_chart]
       helm_directory = config.cnf_config[:helm_directory]

--- a/src/tasks/workload/compatibility.cr
+++ b/src/tasks/workload/compatibility.cr
@@ -396,8 +396,8 @@ end
 
 desc "Will the CNF install using helm with helm_deploy?"
 task "helm_deploy" do |_, args|
-  Log.for("helm_deploy").info { "Starting test" } if check_verbose(args)
-  Log.info { "helm_deploy args: #{args.inspect}" }
+  Log.for("helm_deploy").info { "Starting test" }
+  Log.info { "helm_deploy args: #{args.inspect}" } if check_verbose(args)
   if check_cnf_config(args) || CNFManager.destination_cnfs_exist?
     CNFManager::Task.task_runner(args) do |args, config|
       emoji_helm_deploy="⎈🚀"


### PR DESCRIPTION
## Description

This PR has the following changes:
* Removes requirement of destructive option for `helm_deploy` test.
* Update spec test for verbose logger because it uses the `helm_deploy` test.

### Validation

Tested the changes with the following scenarios
* With no CNF installed.
* With the `sample_coredns` CNF installed.

```
./cnf-testsuite cnf_setup cnf-path=sample-cnfs/sample_coredns
./cnf-testsuite helm_deploy
```

<img width="955" alt="CleanShot 2022-05-06 at 23 05 15@2x" src="https://user-images.githubusercontent.com/84005/167184147-25aa56b5-e211-4abc-8738-44941e61684f.png">


## Issues:
Refs: #1445

## How has this been tested:
 - [x] Covered by existing integration testing
 - [ ] Added integration testing to cover
 - [ ] Verified all A/C passes
     * [ ] develop
     * [ ] master
     * [ ] tag/other branch
 - [ ] Test environment
    * [ ] Shared Packet K8s cluster
    * [ ] New Packet K8s cluster
    * [ ] Kind cluster
 - [ ] Have not tested

## Types of changes:
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [ ] Documentation update

## Checklist:
**Documentation**
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] No updates required.

**Code Review**
- [ ] Does the test handle fatal exceptions, ie. rescue block

**Issue**
- [ ] Tasks in issue are checked off
