### PR TITLE
[bug/1390] Display accurate local helm version in the setup command output

### DIFF
--- a/spec/utils/system_information/helm_spec.cr
+++ b/spec/utils/system_information/helm_spec.cr
@@ -8,7 +8,9 @@ require "sam"
 
 describe "Helm" do
   before_all do
-    result = ShellCmd.run("./cnf-testsuite helm_local_install", "helm_local_setup", force_output: true)
+    # If the environment has a good global helm version then local install is skipped.
+    # We need the local helm to be able to run the test. So we are force installing it.
+    result = ShellCmd.run("force_install=true ./cnf-testsuite helm_local_install", "helm_local_setup", force_output: true)
     result[:status].success?.should be_true
   end
 

--- a/spec/utils/system_information/helm_spec.cr
+++ b/spec/utils/system_information/helm_spec.cr
@@ -18,10 +18,12 @@ describe "Helm" do
   end
 
   it "'helm_local_response()' should return the information about the helm installation", tags: ["helm-utils"]  do
+    ShellCmd.run("ls -R tools/helm", "helm_dir_check", force_output: true)
     (helm_local_response(true)).should contain("\"v3.")
   end
 
   it "'helm_version()' should return the information about the helm version", tags: ["helm-utils"]  do
+    ShellCmd.run("ls -R tools/helm", "helm_dir_check", force_output: true)
     (helm_version(helm_local_response)).should contain("v3.")
   end
 

--- a/spec/utils/system_information/helm_spec.cr
+++ b/spec/utils/system_information/helm_spec.cr
@@ -8,8 +8,8 @@ require "sam"
 
 describe "Helm" do
   before_all do
-    `./cnf-testsuite helm_local_install`
-    $?.success?.should be_true
+    result = ShellCmd.run("./cnf-testsuite helm_local_install", "helm_local_setup", force_output: true)
+    result[:status].success?.should be_true
   end
 
   it "'helm_global_response()' should return the information about the helm installation", tags: ["helm-utils"]  do

--- a/spec/utils/system_information/helm_spec.cr
+++ b/spec/utils/system_information/helm_spec.cr
@@ -7,6 +7,10 @@ require "file_utils"
 require "sam"
 
 describe "Helm" do
+  before_all do
+    `./cnf-testsuite helm_local_install`
+    $?.success?.should be_true
+  end
 
   it "'helm_global_response()' should return the information about the helm installation", tags: ["helm-utils"]  do
     # TODO make global response be a regex of v. or nil?

--- a/src/tasks/helmenv_setup.cr
+++ b/src/tasks/helmenv_setup.cr
@@ -10,12 +10,15 @@ task "helm_local_install", ["cnf_directory_setup"] do |_, args|
   Log.for("verbose").info { "helm_local_install" } if check_verbose(args)
   # check if helm is installed
   # if proper version of helm installed, don't install
-  if SystemInfo::Helm.global_helm_installed? || ENV["force_install"] != nil
-    Log.for("verbose").info { "Globally installed helm satisfies required version. Skipping local helm install." }
+  if SystemInfo::Helm.global_helm_installed? && ENV["force_install"] == nil
+    Log.info { "Globally installed helm satisfies required version. Skipping local helm install." }
   else
-    current_dir = FileUtils.pwd 
+    current_dir = FileUtils.pwd
     Log.for("verbose").debug { current_dir } if check_verbose(args)
-    unless Dir.exists?("#{current_dir}/#{TOOLS_DIR}/helm")
+    arch = "linux-amd64"
+
+    FileUtils.mkdir_p("#{current_dir}/#{TOOLS_DIR}/helm")
+    unless File.exists?("#{current_dir}/#{TOOLS_DIR}/helm/#{arch}/helm")
       begin
         if check_verbose(args)
           Log.for("verbose").debug { "pwd? : #{current_dir}" }
@@ -23,12 +26,11 @@ task "helm_local_install", ["cnf_directory_setup"] do |_, args|
           Log.for("verbose").debug { "full path?: #{current_dir.to_s}/#{TOOLS_DIR}/helm" }
         end
 
-        FileUtils.mkdir_p("#{current_dir}/#{TOOLS_DIR}/helm") 
-        HTTP::Client.get("https://get.helm.sh/helm-v3.1.1-linux-amd64.tar.gz") do |response| 
-          File.write("#{current_dir}/#{TOOLS_DIR}/helm/helm-v3.1.1-linux-amd64.tar.gz", response.body_io)
+        HTTP::Client.get("https://get.helm.sh/helm-v3.1.1-#{arch}.tar.gz") do |response|
+          File.write("#{current_dir}/#{TOOLS_DIR}/helm/helm-v3.1.1-#{arch}.tar.gz", response.body_io)
         end
         TarClient.untar(
-          "#{current_dir}/#{TOOLS_DIR}/helm/helm-v3.1.1-linux-amd64.tar.gz",
+          "#{current_dir}/#{TOOLS_DIR}/helm/helm-v3.1.1-#{arch}.tar.gz",
           "#{current_dir}/#{TOOLS_DIR}/helm"
         )
 

--- a/src/tasks/helmenv_setup.cr
+++ b/src/tasks/helmenv_setup.cr
@@ -10,7 +10,7 @@ task "helm_local_install", ["cnf_directory_setup"] do |_, args|
   Log.for("verbose").info { "helm_local_install" } if check_verbose(args)
   # check if helm is installed
   # if proper version of helm installed, don't install
-  if SystemInfo::Helm.global_helm_installed? && ENV["force_install"] == nil
+  if SystemInfo::Helm.global_helm_installed? && !ENV.has_key?("force_install")
     Log.info { "Globally installed helm satisfies required version. Skipping local helm install." }
   else
     current_dir = FileUtils.pwd

--- a/src/tasks/helmenv_setup.cr
+++ b/src/tasks/helmenv_setup.cr
@@ -10,7 +10,7 @@ task "helm_local_install", ["cnf_directory_setup"] do |_, args|
   Log.for("verbose").info { "helm_local_install" } if check_verbose(args)
   # check if helm is installed
   # if proper version of helm installed, don't install
-  if SystemInfo::Helm.global_helm_installed?
+  if SystemInfo::Helm.global_helm_installed? || ENV["force_install"] != nil
     Log.for("verbose").info { "Globally installed helm satisfies required version. Skipping local helm install." }
   else
     current_dir = FileUtils.pwd 

--- a/src/tasks/helmenv_setup.cr
+++ b/src/tasks/helmenv_setup.cr
@@ -10,7 +10,9 @@ task "helm_local_install", ["cnf_directory_setup"] do |_, args|
   Log.for("verbose").info { "helm_local_install" } if check_verbose(args)
   # check if helm is installed
   # if proper version of helm installed, don't install
-  unless SystemInfo::Helm.global_helm_installed?
+  if SystemInfo::Helm.global_helm_installed?
+    Log.for("verbose").info { "Globally installed helm satisfies required version. Skipping local helm install." }
+  else
     current_dir = FileUtils.pwd 
     Log.for("verbose").debug { current_dir } if check_verbose(args)
     unless Dir.exists?("#{current_dir}/#{TOOLS_DIR}/helm")

--- a/src/tasks/utils/system_information/helm.cr
+++ b/src/tasks/utils/system_information/helm.cr
@@ -51,7 +51,7 @@ end
 
 def helm_local_response(verbose=false)
   helm = BinarySingleton.local_helm_path
-  result = ShellCmd.run("#{helm} version", "helm_local_version", force_output: true)
+  result = ShellCmd.run("#{helm} version", "helm_local_version", force_output: verbose)
   result[:output]
 end
 

--- a/src/tasks/utils/system_information/helm.cr
+++ b/src/tasks/utils/system_information/helm.cr
@@ -53,7 +53,7 @@ def helm_local_response(verbose=false)
   current_dir = FileUtils.pwd
   VERBOSE_LOGGING.info current_dir if verbose
   #helm = "#{current_dir}/#{TOOLS_DIR}/helm/linux-amd64/helm"
-    helm = BinarySingleton.helm
+  helm = BinarySingleton.local_helm_path
   # helm_response = `#{helm} version`
   status = Process.run("#{helm} version", shell: true, output: helm_response = IO::Memory.new, error: stderr = IO::Memory.new)
   VERBOSE_LOGGING.info helm_response.to_s if verbose

--- a/src/tasks/utils/system_information/helm.cr
+++ b/src/tasks/utils/system_information/helm.cr
@@ -50,14 +50,9 @@ def helm_global_response(verbose=false)
 end
 
 def helm_local_response(verbose=false)
-  current_dir = FileUtils.pwd
-  VERBOSE_LOGGING.info current_dir if verbose
-  #helm = "#{current_dir}/#{TOOLS_DIR}/helm/linux-amd64/helm"
   helm = BinarySingleton.local_helm_path
-  # helm_response = `#{helm} version`
-  status = Process.run("#{helm} version", shell: true, output: helm_response = IO::Memory.new, error: stderr = IO::Memory.new)
-  VERBOSE_LOGGING.info helm_response.to_s if verbose
-  helm_response.to_s
+  result = ShellCmd.run("#{helm} version", "helm_local_version", force_output: true)
+  result[:output]
 end
 
 def helm_version(helm_response, verbose=false)


### PR DESCRIPTION
> *This PR fixes #1390*

## Description
The setup command should show the local helm version accurately. It is currently using a helm that fallsback to display the global helm version - this causes the bug reported in 1390.

## Test scenarios

If global helm is not available on the machine, download and set path for global helm.

```
wget https://get.helm.sh/helm-v3.9.0-linux-amd64.tar.gz
tar zxvf helm-v3.9.0-linux-amd64.tar.gz

export PATH=$PATH:/home/pair/workspace/akash/projects/linux-amd64
```

### `setup` command output before fix

```
$ ./cnf-testsuite setup
Successfully created directories for cnf-testsuite
Global helm found. Version: v3.9.0
Local helm found. Version: v3.9.0
Global kubectl found. Version: 1.21
Global kubectl client version could not be checked for compatibility with server. (Server not configured?)
No Local kubectl version found
Global git found. Version: 2.17.1
No Local git version found
All prerequisites found.
Could not create cnf-testsuite namespace on the Kubernetes cluster
Setup complete
```

### `setup` command output after fix

```
$ ./cnf-testsuite setup
Successfully created directories for cnf-testsuite
Global helm found. Version: v3.9.0
Local helm found. Version: v3.1.1
Global kubectl found. Version: 1.21
Global kubectl client version could not be checked for compatibility with server. (Server not configured?)
No Local kubectl version found
Global git found. Version: 2.17.1
No Local git version found
All prerequisites found.
Could not create cnf-testsuite namespace on the Kubernetes cluster
Setup complete
```

## How has this been tested:
 - [x] Covered by existing integration testing
 - [ ] Added integration testing to cover
 - [ ] Verified all A/C passes
     * [ ] develop
     * [ ] master
     * [ ] tag/other branch
 - [ ] Test environment
    * [ ] Shared Packet K8s cluster
    * [ ] New Packet K8s cluster
    * [ ] Kind cluster
 - [ ] Have not tested

## Types of changes:
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [ ] Documentation update

## Checklist:
**Documentation**
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] No updates required.

**Code Review**
- [ ] Does the test handle fatal exceptions, ie. rescue block

**Issue**
- [ ] Tasks in issue are checked off
