### PR TITLE
[#1477] Update pod_network_duplication test to support CNFs in non-default namespaces

### DIFF
--- a/src/tasks/utils/chaos_templates.cr
+++ b/src/tasks/utils/chaos_templates.cr
@@ -53,6 +53,7 @@ class ChaosTemplates
     def initialize(
       @test_name : String,
       @chaos_experiment_name : String,
+      @app_namespace : String,
       @deployment_label : String,
       @deployment_label_value : String,
       @total_chaos_duration : String

--- a/src/tasks/workload/reliability.cr
+++ b/src/tasks/workload/reliability.cr
@@ -210,16 +210,19 @@ end
 desc "Does the CNF crash when network duplication occurs"
 task "pod_network_duplication", ["install_litmus"] do |_, args|
   CNFManager::Task.task_runner(args) do |args, config|
-    Log.for("verbose").info {"pod_network_duplication"} if check_verbose(args)
-    LOGGING.debug "cnf_config: #{config}"
+    test_name = "pod_network_duplication"
+    Log.for(test_name).info { "Starting test" } if check_verbose(args)
+    Log.debug { "cnf_config: #{config}" }
     #TODO tests should fail if cnf not installed
     destination_cnf_dir = config.cnf_config[:destination_cnf_dir]
     task_response = CNFManager.workload_resource_test(args, config) do |resource, container, initialized|
-      Log.info{ "Current Resource Name: #{resource["name"]} Type: #{resource["kind"]}"}
-      if KubectlClient::Get.resource_spec_labels(resource["kind"], resource["name"]).as_h? && KubectlClient::Get.resource_spec_labels(resource["kind"], resource["name"]).as_h.size > 0 && resource["kind"] == "Deployment"
+      app_namespace = resource[:namespace] || config.cnf_config[:helm_install_namespace]
+      Log.info{ "Current Resource Name: #{resource["name"]} Type: #{resource["kind"]} Namespace: #{resource["namespace"]}"}
+      spec_labels = KubectlClient::Get.resource_spec_labels(resource["kind"], resource["name"], resource["namespace"])
+      if spec_labels.as_h? && spec_labels.as_h.size > 0 && resource["kind"] == "Deployment"
         test_passed = true
       else
-        puts "Resource is not a Deployment or no resource label was found for resource: #{resource["name"]}".colorize(:red)
+        stdout_failure("Resource is not a Deployment or no resource label was found for resource: #{resource["kind"]}/#{resource["name"]} in #{resource["namespace"]} namespace")
         test_passed = false
       end
       if test_passed
@@ -229,27 +232,38 @@ task "pod_network_duplication", ["install_litmus"] do |_, args|
           KubectlClient::Apply.file("#{OFFLINE_MANIFESTS_PATH}/dup-experiment.yaml")
           KubectlClient::Apply.file("#{OFFLINE_MANIFESTS_PATH}/dup-rbac.yaml")
         else
-          KubectlClient::Apply.file("https://hub.litmuschaos.io/api/chaos/#{LitmusManager::Version}?file=charts/generic/pod-network-duplication/experiment.yaml")
-          KubectlClient::Apply.file("https://hub.litmuschaos.io/api/chaos/#{LitmusManager::Version}?file=charts/generic/pod-network-duplication/rbac.yaml")
+          experiment_url = "https://hub.litmuschaos.io/api/chaos/#{LitmusManager::Version}?file=charts/generic/pod-network-duplication/experiment.yaml"
+          rbac_url = "https://hub.litmuschaos.io/api/chaos/#{LitmusManager::Version}?file=charts/generic/pod-network-duplication/rbac.yaml"
+
+          experiment_path = LitmusManager.download_template(experiment_url, "#{test_name}_experiment.yaml")
+          KubectlClient::Apply.file(experiment_path, namespace: app_namespace)
+
+          rbac_path = LitmusManager.download_template(rbac_url, "#{test_name}_rbac.yaml")
+          rbac_yaml = File.read(rbac_path)
+          rbac_yaml = rbac_yaml.gsub("namespace: default", "namespace: #{app_namespace}")
+          File.write(rbac_path, rbac_yaml)
+          KubectlClient::Apply.file(rbac_path)
         end
-        KubectlClient::Annotate.run("--overwrite deploy/#{resource["name"]} litmuschaos.io/chaos=\"true\"")
+        KubectlClient::Annotate.run("--overwrite -n #{app_namespace} deploy/#{resource["name"]} litmuschaos.io/chaos=\"true\"")
 
         chaos_experiment_name = "pod-network-duplication"
         total_chaos_duration = "60"
         test_name = "#{resource["name"]}-#{Random.rand(99)}"
         chaos_result_name = "#{test_name}-#{chaos_experiment_name}"
 
+        spec_labels = KubectlClient::Get.resource_spec_labels(resource["kind"], resource["name"], resource["namespace"]).as_h
         template = ChaosTemplates::PodNetworkDuplication.new(
           test_name,
           "#{chaos_experiment_name}",
-          "#{KubectlClient::Get.resource_spec_labels(resource["kind"], resource["name"]).as_h.first_key}",
-          "#{KubectlClient::Get.resource_spec_labels(resource["kind"], resource["name"]).as_h.first_value}",
+          app_namespace,
+          "#{spec_labels.first_key}",
+          "#{spec_labels.first_value}",
           total_chaos_duration
         ).to_s
         File.write("#{destination_cnf_dir}/#{chaos_experiment_name}-chaosengine.yml", template)
         KubectlClient::Apply.file("#{destination_cnf_dir}/#{chaos_experiment_name}-chaosengine.yml")
-        LitmusManager.wait_for_test(test_name,chaos_experiment_name,total_chaos_duration,args)
-        test_passed = LitmusManager.check_chaos_verdict(chaos_result_name,chaos_experiment_name,args)
+        LitmusManager.wait_for_test(test_name,chaos_experiment_name,total_chaos_duration,args, namespace: app_namespace)
+        test_passed = LitmusManager.check_chaos_verdict(chaos_result_name,chaos_experiment_name,args, namespace: app_namespace)
       end
     end
     if task_response

--- a/src/templates/chaos_templates/pod_network_duplication.yml.ecr
+++ b/src/templates/chaos_templates/pod_network_duplication.yml.ecr
@@ -2,13 +2,13 @@ apiVersion: litmuschaos.io/v1alpha1
 kind: ChaosEngine
 metadata:
   name: <%= @test_name %>
-  namespace: default
+  namespace: <%= @app_namespace %>
 spec:
   jobCleanUpPolicy: 'delete'
   annotationCheck: 'true'
   engineState: 'active'
   appinfo:
-    appns: 'default'
+    appns: '<%= @app_namespace %>'
     applabel: '<%= @deployment_label %>=<%= @deployment_label_value %>'
     appkind: 'deployment'
   chaosServiceAccount: <%= @chaos_experiment_name %>-sa


### PR DESCRIPTION
> *This PR resolves #1477*

## Description
Add support for running the `pod_network_duplication` test against CNFs that use non-default namespaces.

Sample CNF to test: `sample-cnfs/sample-coredns-cnf`

### Screenshot from [latest main branch build](https://github.com/cncf/cnf-testsuite/runs/6627902847?check_suite_focus=true)

<img width="1080" alt="CleanShot 2022-05-30 at 19 57 24@2x" src="https://user-images.githubusercontent.com/84005/171012691-ccb49ac3-083f-4c1f-948c-3ab74d9cfbfb.png">

### Screenshot from [build for PR](https://github.com/cncf/cnf-testsuite/runs/6655186253?check_suite_focus=true)

<img width="963" alt="CleanShot 2022-05-30 at 19 56 19@2x" src="https://user-images.githubusercontent.com/84005/171012502-5f41b78b-2da9-4072-a2c9-6653f8ad10cb.png">


## How has this been tested:
 - [x] Covered by existing integration testing
 - [ ] Added integration testing to cover
 - [ ] Verified all A/C passes
     * [ ] develop
     * [ ] master
     * [ ] tag/other branch
 - [ ] Test environment
    * [ ] Shared Packet K8s cluster
    * [ ] New Packet K8s cluster
    * [ ] Kind cluster
 - [ ] Have not tested

## Types of changes:
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [x] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [ ] Documentation update

## Checklist:
**Documentation**
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] No updates required.

**Code Review**
- [ ] Does the test handle fatal exceptions, ie. rescue block

**Issue**
- [ ] Tasks in issue are checked off
