### PR TITLE
[#1484] Fix version parsing for k3s clusters

### DIFF
--- a/src/tasks/utils/utils.cr
+++ b/src/tasks/utils/utils.cr
@@ -391,13 +391,21 @@ end
 
 # compare 2 SemVer strings and return true if v1 is less than v2
 def version_less_than(v1str, v2str)
-  # NOTES: This is why the below code attempts to strip the plus sign from the versions.
-  # Versions for microk8s look like this: "1.20+". As a result, the input args to this function may be "1.20+.0"
-  # This results in bad input to the semantic version parser.
-  # To allow microk8s, we strip the plus sign from the versions.
+  # k3s verisons look like this (valid semantic version): 1.23.6+k3s1
+  #
+  # microk8s verisons look like this (invalid semantic version): 1.20+.0
+  #
+  # microk8s version strings are bad input to the semantic version parser.
+  # To allow microk8s, we strip the plus sign from the minor version.
+  # The below code block performs that cleanup.
 
-  v1 = SemanticVersion.parse(v1str.gsub("+", ""))
-  v2 = SemanticVersion.parse(v2str.gsub("+", ""))
+  v1str = v1str.split(".").map {|i| i.ends_with?("+") ? i.gsub("+", "") : i}
+  v1str = v1str.join(".")
+  v2str = v2str.split(".").map {|i| i.ends_with?("+") ? i.gsub("+", "") : i}
+  v2str = v2str.join(".")
+
+  v1 = SemanticVersion.parse(v1str)
+  v2 = SemanticVersion.parse(v2str)
   less_than = (v1 <=> v2) == -1
   LOGGING.debug "version_less_than: #{v1} < #{v2}: #{less_than}"
   less_than


### PR DESCRIPTION
> *This PR resolves the issue reported on #1484*

## Description
The fix for microk8s version parsing had broken the version parsing for k3s (which has a perfectly valid semantic version).
Improved the fix to not handle good semantic versions.

`cnf_setup` now succeeds on k3s after this fix.

<img width="1123" alt="CleanShot 2022-05-31 at 09 34 13@2x" src="https://user-images.githubusercontent.com/84005/171090565-06239539-2447-4f22-94a7-b4a529ef76f3.png">


## How has this been tested:
 - [x] Covered by existing integration testing
 - [ ] Added integration testing to cover
 - [ ] Verified all A/C passes
     * [ ] develop
     * [ ] master
     * [ ] tag/other branch
 - [ ] Test environment
    * [ ] Shared Packet K8s cluster
    * [ ] New Packet K8s cluster
    * [ ] Kind cluster
 - [ ] Have not tested

## Types of changes:
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [ ] Documentation update

## Checklist:
**Documentation**
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] No updates required.

**Code Review**
- [ ] Does the test handle fatal exceptions, ie. rescue block

**Issue**
- [ ] Tasks in issue are checked off
