### PR TITLE
[#1514] sysctls should only test CNF resources

### DIFF
--- a/src/tasks/utils/cnf_manager.cr
+++ b/src/tasks/utils/cnf_manager.cr
@@ -1170,6 +1170,21 @@ module CNFManager
     Log.for("ensure_namespace_exists").info { "Kubernetes namespace #{name} already exists for the CNF install" }
   end
 
+  def self.workload_resource_keys(args, config)
+    resource_keys = CNFManager.cnf_workload_resources(args, config) do |resource|
+      namespace = resource.dig?("metadata", "namespace") || config.cnf_config[:helm_install_namespace]
+      kind = resource.dig?("kind")
+      name = resource.dig?("metadata", "name")
+      "#{namespace},#{kind}/#{name}".downcase
+    end
+    resource_keys
+  end
+
+  def self.resources_includes?(resource_keys, kind, name, namespace)
+    resource_key = "#{namespace},#{kind}/#{name}".downcase
+    resource_keys.includes?(resource_key)
+  end
+
   class HelmDirectoryMissingError < Exception
     property helm_directory : String = ""
 

--- a/src/tasks/utils/kyverno.cr
+++ b/src/tasks/utils/kyverno.cr
@@ -138,4 +138,18 @@ module Kyverno
     end
   end
 
+  def self.filter_failures_for_cnf_resources(resource_keys, failures)
+    filtered = failures.map do |failure|
+      failed_resources = failure.resources.select do |resource|
+        CNFManager.resources_includes?(resource_keys, resource.kind, resource.name, resource.namespace)
+      end
+      PolicyAudit::PolicyFailure.new(failure.message, failed_resources)
+    end
+    filtered = filtered.select do |failure|
+      failure.resources.size > 0
+    end
+
+    filtered
+  end
+
 end

--- a/src/tasks/workload/security.cr
+++ b/src/tasks/workload/security.cr
@@ -47,6 +47,9 @@ task "sysctls" do |_, args|
     policy_path = Kyverno.policy_path("pod-security/baseline/restrict-sysctls/restrict-sysctls.yaml")
     failures = Kyverno::PolicyAudit.run(policy_path, EXCLUDE_NAMESPACES)
 
+    resource_keys = CNFManager.workload_resource_keys(args, config)
+    failures = Kyverno.filter_failures_for_cnf_resources(resource_keys, failures)
+
     if failures.size == 0
       resp = upsert_passed_task("sysctls", "✔️  PASSED: No restricted values found for sysctls #{emoji_security}")
     else


### PR DESCRIPTION
> Issue: #1514

## Description

`sysctls` test will only report failures of resources that are part of the CNF

## Test scenario

* Install `sample-cnfs/sample_coredns` CNF
* Run this command to create one more resource: `kubectl apply -f sample-cnfs/sample_sysctls/manifests/pod.yml`

#### Test results with the changes in the PR

<img width="1792" alt="CleanShot 2022-06-21 at 23 06 06@2x" src="https://user-images.githubusercontent.com/84005/174862552-047e4265-cc40-4a19-bb37-8c1496d0cb78.png">

#### Test results with in the `main` branch

<img width="1789" alt="CleanShot 2022-06-21 at 23 05 17@2x" src="https://user-images.githubusercontent.com/84005/174862426-32d6a55f-5859-4822-b2d0-508237e22e4d.png">

## How has this been tested:
 - [x] Covered by existing integration testing
 - [ ] Added integration testing to cover
 - [ ] Verified all A/C passes
     * [ ] develop
     * [ ] master
     * [ ] tag/other branch
 - [ ] Test environment
    * [ ] Shared Packet K8s cluster
    * [ ] New Packet K8s cluster
    * [ ] Kind cluster
 - [ ] Have not tested

## Types of changes:
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [x] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [ ] Documentation update

## Checklist:
**Documentation**
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] No updates required.

**Code Review**
- [ ] Does the test handle fatal exceptions, ie. rescue block

**Issue**
- [ ] Tasks in issue are checked off
