### PR TITLE
Update default_namespace test to only check the CNF's Resources #1513

### DIFF
--- a/src/tasks/workload/configuration.cr
+++ b/src/tasks/workload/configuration.cr
@@ -57,11 +57,15 @@ desc "Check if the CNF installs resources in the default namespace"
 task "default_namespace" do |_, args|
   Log.for("verbose").info { "default_namespace" }
   Kyverno.install
+  emoji_passed = "🏷️✔️"
+  emoji_failed = "🏷️❌"
+  policy_path = Kyverno.best_practice_policy("disallow_default_namespace/disallow_default_namespace.yaml")
+  failures = Kyverno::PolicyAudit.run(policy_path, EXCLUDE_NAMESPACES)
+
   CNFManager::Task.task_runner(args) do |args, config|
-    emoji_passed = "🏷️✔️"
-    emoji_failed = "🏷️❌"
-    policy_path = Kyverno.best_practice_policy("disallow_default_namespace/disallow_default_namespace.yaml")
-    failures = Kyverno::PolicyAudit.run(policy_path, EXCLUDE_NAMESPACES)
+
+    resource_keys = CNFManager.workload_resource_keys(args, config)
+    failures = Kyverno.filter_failures_for_cnf_resources(resource_keys, failures)
 
     if failures.size == 0
       resp = upsert_passed_task("default_namespace", "✔️  PASSED: default namespace is not being used #{emoji_passed}")
@@ -70,7 +74,7 @@ task "default_namespace" do |_, args|
       failures.each do |failure|
         failure.resources.each do |resource|
           puts "#{resource.kind} #{resource.name} in #{resource.namespace} namespace failed. #{failure.message}".colorize(:red)
-        end
+      end
       end
     end
   end
@@ -85,13 +89,19 @@ task "latest_tag" do |_, args|
   policy_path = Kyverno.best_practice_policy("disallow_latest_tag/disallow_latest_tag.yaml")
   failures = Kyverno::PolicyAudit.run(policy_path, EXCLUDE_NAMESPACES)
 
-  if failures.size == 0
-    resp = upsert_passed_task("latest_tag", "✔️  🏆 PASSED: Container images are not using the latest tag #{emoji_passed}")
-  else
-    resp = upsert_failed_task("latest_tag", "✖️  🏆 FAILED: Container images are using the latest tag #{emoji_failed}")
-    failures.each do |failure|
-      failure.resources.each do |resource|
-        puts "#{resource.kind} #{resource.name} in #{resource.namespace} namespace failed. #{failure.message}".colorize(:red)
+  CNFManager::Task.task_runner(args) do |args, config|
+
+    resource_keys = CNFManager.workload_resource_keys(args, config)
+    failures = Kyverno.filter_failures_for_cnf_resources(resource_keys, failures)
+
+    if failures.size == 0
+      resp = upsert_passed_task("latest_tag", "✔️  🏆 PASSED: Container images are not using the latest tag #{emoji_passed}")
+    else
+      resp = upsert_failed_task("latest_tag", "✖️  🏆 FAILED: Container images are using the latest tag #{emoji_failed}")
+      failures.each do |failure|
+        failure.resources.each do |resource|
+          puts "#{resource.kind} #{resource.name} in #{resource.namespace} namespace failed. #{failure.message}".colorize(:red)
+        end
       end
     end
   end


### PR DESCRIPTION
Signed-off-by: denverwilliams <denver@debian.nz>

## Description
Testing:

Install a container into the default namespace(outside of the CNF being tested):
helm install --set image.tag=latest corednstag coredns/coredns

Results on default_namespace_fix#1513 branch: (Passing - Only the CNF being tested was caught in the failure logs)
`./cnf-testsuite -l info cnf_setup cnf-config=./sample-cnfs/sample_coredns`
`./cnf-testsuite -l info latest_tag`

```
 ./cnf-testsuite -l info default_namespace
I, [2022-06-21 23:10:01 +00:00 #885830]  INFO -- cnf-testsuite-verbose: default_namespace
I, [2022-06-21 23:10:01 +00:00 #885830]  INFO -- cnf-testsuite: kyverno_policy_path command: ls /home/pair/src/denver/cnf-testsuite/tools/kyverno-policies/best-practices/disallow_default_namespace/disallow_default_namespace.yaml
I, [2022-06-21 23:10:01 +00:00 #885830]  INFO -- cnf-testsuite: kyverno_policy_path output: /home/pair/src/denver/cnf-testsuite/tools/kyverno-policies/best-practices/disallow_default_namespace/disallow_default_namespace.yaml

I, [2022-06-21 23:10:01 +00:00 #885830]  INFO -- cnf-testsuite: Kyverno::PolicyAudit.run command: /home/pair/src/denver/cnf-testsuite/tools/kyverno apply /home/pair/src/denver/cnf-testsuite/tools/kyverno-policies/best-practices/disallow_default_namespace/disallow_default_namespace.yaml --cluster --policy-report
I, [2022-06-21 23:10:02 +00:00 #885830]  INFO -- cnf-testsuite: task_runner args: #<Sam::Args:0x7f59ae498a40 @arr=[], @named_args={}>
I, [2022-06-21 23:10:02 +00:00 #885830]  INFO -- cnf-testsuite: check_cnf_config args: #<Sam::Args:0x7f59ae498a40 @arr=[], @named_args={}>
I, [2022-06-21 23:10:02 +00:00 #885830]  INFO -- cnf-testsuite: check_cnf_config cnf: 
I, [2022-06-21 23:10:02 +00:00 #885830]  INFO -- cnf-testsuite: cnf_config_list
I, [2022-06-21 23:10:02 +00:00 #885830]  INFO -- cnf-testsuite: find: find cnfs/* -name "cnf-testsuite.yml"
I, [2022-06-21 23:10:02 +00:00 #885830]  INFO -- cnf-testsuite: find response: ["cnfs/coredns/cnf-testsuite.yml"]
I, [2022-06-21 23:10:02 +00:00 #885830]  INFO -- cnf-testsuite: CNF configs found: 1
I, [2022-06-21 23:10:02 +00:00 #885830]  INFO -- cnf-testsuite: airgapped: false
I, [2022-06-21 23:10:02 +00:00 #885830]  INFO -- cnf-testsuite: generate_tar_mode: false
I, [2022-06-21 23:10:02 +00:00 #885830]  INFO -- cnf-testsuite: ensure_cnf_testsuite_yml_path
I, [2022-06-21 23:10:02 +00:00 #885830]  INFO -- cnf-testsuite: generate_and_set_release_name
I, [2022-06-21 23:10:02 +00:00 #885830]  INFO -- cnf-testsuite: generate_and_set_release_name config_yml_path: cnfs/coredns/cnf-testsuite.yml
I, [2022-06-21 23:10:02 +00:00 #885830]  INFO -- cnf-testsuite: airgapped mode: false
I, [2022-06-21 23:10:02 +00:00 #885830]  INFO -- cnf-testsuite: generate_tar_mode: false
I, [2022-06-21 23:10:02 +00:00 #885830]  INFO -- cnf-testsuite: ensure_cnf_testsuite_yml_path
I, [2022-06-21 23:10:02 +00:00 #885830]  INFO -- cnf-testsuite: ensure_cnf_testsuite_yml_dir
I, [2022-06-21 23:10:02 +00:00 #885830]  INFO -- cnf-testsuite: parsed_config_file: cnfs/coredns/cnf-testsuite.yml
I, [2022-06-21 23:10:02 +00:00 #885830]  INFO -- cnf-testsuite: parsed_config_file: cnfs/coredns/cnf-testsuite.yml
I, [2022-06-21 23:10:02 +00:00 #885830]  INFO -- cnf-testsuite: cnf_installation_method
I, [2022-06-21 23:10:02 +00:00 #885830]  INFO -- cnf-testsuite: cnf_installation_method config: #<Totem::Config:0x7f59b6361be0>
I, [2022-06-21 23:10:02 +00:00 #885830]  INFO -- cnf-testsuite: cnf_installation_method config: cnfs/coredns/cnf-testsuite.yml
I, [2022-06-21 23:10:02 +00:00 #885830]  INFO -- cnf-testsuite: directory_parameter_split : chart
I, [2022-06-21 23:10:02 +00:00 #885830]  INFO -- cnf-testsuite: directory_parameter_split : chart
I, [2022-06-21 23:10:02 +00:00 #885830]  INFO -- cnf-testsuite: directory : chart parameters: 
I, [2022-06-21 23:10:02 +00:00 #885830]  INFO -- cnf-testsuite: release_name: coredns
I, [2022-06-21 23:10:02 +00:00 #885830]  INFO -- cnf-testsuite: helm_directory: chart
I, [2022-06-21 23:10:02 +00:00 #885830]  INFO -- cnf-testsuite: manifest_directory: 
I, [2022-06-21 23:10:02 +00:00 #885830]  INFO -- cnf-testsuite: Building helm_directory and manifest_directory full paths
I, [2022-06-21 23:10:02 +00:00 #885830]  INFO -- cnf-testsuite: full_helm_directory: /home/pair/src/denver/cnf-testsuite/cnfs/coredns/chart exists? true
I, [2022-06-21 23:10:02 +00:00 #885830]  INFO -- cnf-testsuite: full_manifest_directory: /home/pair/src/denver/cnf-testsuite/cnfs/coredns/ exists? true
I, [2022-06-21 23:10:02 +00:00 #885830]  INFO -- cnf-testsuite: helm_directory not empty, using: /home/pair/src/denver/cnf-testsuite/cnfs/coredns/chart
I, [2022-06-21 23:10:02 +00:00 #885830]  INFO -- cnf-testsuite: cnf_destination_dir config_file: cnfs/coredns/cnf-testsuite.yml
I, [2022-06-21 23:10:02 +00:00 #885830]  INFO -- cnf-testsuite: parsed_config_file: cnfs/coredns/cnf-testsuite.yml
I, [2022-06-21 23:10:02 +00:00 #885830]  INFO -- cnf-testsuite: release_name: coredns
I, [2022-06-21 23:10:02 +00:00 #885830]  INFO -- cnf-testsuite: cnf destination dir: /home/pair/src/denver/cnf-testsuite/cnfs/coredns
I, [2022-06-21 23:10:02 +00:00 #885830]  INFO -- cnf-testsuite: ensure_cnf_testsuite_yml_dir
I, [2022-06-21 23:10:02 +00:00 #885830]  INFO -- cnf-testsuite: NOT USING EXPORTED CHART PATH
I, [2022-06-21 23:10:02 +00:00 #885830]  INFO -- cnf-testsuite: cnf_workload_resources
I, [2022-06-21 23:10:02 +00:00 #885830]  INFO -- cnf-testsuite: cnf_installation_method config : CNFManager::Config
I, [2022-06-21 23:10:02 +00:00 #885830]  INFO -- cnf-testsuite: config_cnf_config: {destination_cnf_dir: "/home/pair/src/denver/cnf-testsuite/cnfs/coredns", source_cnf_file: "cnfs/coredns/cnf-testsuite.yml", source_cnf_dir: "cnfs/coredns/", yml_file_path: "cnfs/coredns/", install_method: {HelmDirectory, "/home/pair/src/denver/cnf-testsuite/cnfs/coredns/chart"}, manifest_directory: "", helm_directory: "chart ", source_helm_directory: "chart", helm_chart_path: "/home/pair/src/denver/cnf-testsuite/cnfs/coredns/chart ", manifest_file_path: "/home/pair/src/denver/cnf-testsuite/cnfs/coredns/temp_template.yml", release_name: "coredns", service_name: "", helm_repository: {name: "stable", repo_url: "https://cncf.gitlab.io/stable"}, helm_chart: "", helm_install_namespace: "", rolling_update_tag: "", container_names: [{"name" => "", "rolling_update_test_tag" => "", "rolling_downgrade_test_tag" => "", "rolling_version_change_test_tag" => "", "rollback_from_tag" => ""}], white_list_container_names: []}
I, [2022-06-21 23:10:02 +00:00 #885830]  INFO -- cnf-testsuite: parsed_config_file: cnfs/coredns/cnf-testsuite.yml
I, [2022-06-21 23:10:02 +00:00 #885830]  INFO -- cnf-testsuite: cnf_installation_method
I, [2022-06-21 23:10:02 +00:00 #885830]  INFO -- cnf-testsuite: cnf_installation_method config: #<Totem::Config:0x7f59b6361aa0>
I, [2022-06-21 23:10:02 +00:00 #885830]  INFO -- cnf-testsuite: cnf_installation_method config: cnfs/coredns/cnf-testsuite.yml
I, [2022-06-21 23:10:02 +00:00 #885830]  INFO -- cnf-testsuite: directory_parameter_split : chart
I, [2022-06-21 23:10:02 +00:00 #885830]  INFO -- cnf-testsuite: directory_parameter_split : chart
I, [2022-06-21 23:10:02 +00:00 #885830]  INFO -- cnf-testsuite: directory : chart parameters: 
I, [2022-06-21 23:10:02 +00:00 #885830]  INFO -- cnf-testsuite: release_name: coredns
I, [2022-06-21 23:10:02 +00:00 #885830]  INFO -- cnf-testsuite: helm_directory: chart
I, [2022-06-21 23:10:02 +00:00 #885830]  INFO -- cnf-testsuite: manifest_directory: 
I, [2022-06-21 23:10:02 +00:00 #885830]  INFO -- cnf-testsuite: Building helm_directory and manifest_directory full paths
I, [2022-06-21 23:10:02 +00:00 #885830]  INFO -- cnf-testsuite: full_helm_directory: /home/pair/src/denver/cnf-testsuite/cnfs/coredns/chart exists? true
I, [2022-06-21 23:10:02 +00:00 #885830]  INFO -- cnf-testsuite: full_manifest_directory: /home/pair/src/denver/cnf-testsuite/cnfs/coredns/ exists? true
I, [2022-06-21 23:10:02 +00:00 #885830]  INFO -- cnf-testsuite: helm_directory not empty, using: /home/pair/src/denver/cnf-testsuite/cnfs/coredns/chart
I, [2022-06-21 23:10:02 +00:00 #885830]  INFO -- cnf-testsuite: EXPORTED CHART PATH: /home/pair/src/denver/cnf-testsuite/cnfs/coredns/chart 
I, [2022-06-21 23:10:02 +00:00 #885830]  INFO -- cnf-testsuite: Helm::generate_manifest_from_templates command: helm template coredns /home/pair/src/denver/cnf-testsuite/cnfs/coredns/chart  > /home/pair/src/denver/cnf-testsuite/cnfs/coredns/temp_template.yml
I, [2022-06-21 23:10:02 +00:00 #885830]  INFO -- cnf-testsuite: before generate command: ls -alR /home/pair/src/denver/cnf-testsuite/cnfs/coredns/chart 
I, [2022-06-21 23:10:02 +00:00 #885830]  INFO -- cnf-testsuite: before generate command: ls -alR cnfs
I, [2022-06-21 23:10:02 +00:00 #885830]  INFO -- cnf-testsuite: helm command: helm template coredns /home/pair/src/denver/cnf-testsuite/cnfs/coredns/chart  > /home/pair/src/denver/cnf-testsuite/cnfs/coredns/temp_template.yml
I, [2022-06-21 23:10:02 +00:00 #885830]  INFO -- cnf-testsuite: Helm.template output: 
I, [2022-06-21 23:10:02 +00:00 #885830]  INFO -- cnf-testsuite: Helm.template stderr: 
I, [2022-06-21 23:10:02 +00:00 #885830]  INFO -- cnf-testsuite: after generate command: ls -alR /home/pair/src/denver/cnf-testsuite/cnfs/coredns/chart 
I, [2022-06-21 23:10:02 +00:00 #885830]  INFO -- cnf-testsuite: after generate command: ls -alR cnfs
✖️  FAILED: Resources are created in the default namespace 🏷️❌
Deployment coredns-coredns in default namespace failed. validation error: Using 'default' namespace is not allowed for pod controllers. Rule validate-podcontroller-namespace failed at path /metadata/namespace/
I, [2022-06-21 23:10:02 +00:00 #885830]  INFO -- cnf-testsuite: parse_manifest_as_ymls template_file_name: /home/pair/src/denver/cnf-testsuite/cnfs/coredns/temp_template.yml
I, [2022-06-21 23:10:02 +00:00 #885830]  INFO -- cnf-testsuite: workload_resource_by_kind kind: Deployment
I, [2022-06-21 23:10:02 +00:00 #885830]  INFO -- cnf-testsuite: workload_resource_by_kind kind: Service
I, [2022-06-21 23:10:02 +00:00 #885830]  INFO -- cnf-testsuite: workload_resource_by_kind kind: Pod
I, [2022-06-21 23:10:02 +00:00 #885830]  INFO -- cnf-testsuite: workload_resource_by_kind kind: ReplicaSet
I, [2022-06-21 23:10:02 +00:00 #885830]  INFO -- cnf-testsuite: workload_resource_by_kind kind: StatefulSet
I, [2022-06-21 23:10:02 +00:00 #885830]  INFO -- cnf-testsuite: workload_resource_by_kind kind: DaemonSet
I, [2022-06-21 23:10:02 +00:00 #885830]  INFO -- cnf-testsuite: cmd: /home/pair/src/denver/cnf-testsuite/cnf-testsuite default_namespace
I, [2022-06-21 23:10:02 +00:00 #885830]  INFO -- cnf-testsuite: task_type_by_task
I, [2022-06-21 23:10:02 +00:00 #885830]  INFO -- cnf-testsuite: points: {"name" => "default_namespace", "tags" => "configuration, dynamic, workload, cert, normal"}
I, [2022-06-21 23:10:02 +00:00 #885830]  INFO -- cnf-testsuite: resp: ["configuration", "dynamic", "workload", "cert", "normal"]
I, [2022-06-21 23:10:02 +00:00 #885830]  INFO -- cnf-testsuite: task_type x: configuration acc: 
I, [2022-06-21 23:10:02 +00:00 #885830]  INFO -- cnf-testsuite: task_type x: dynamic acc: 
I, [2022-06-21 23:10:02 +00:00 #885830]  INFO -- cnf-testsuite: task_type x: workload acc: 
I, [2022-06-21 23:10:02 +00:00 #885830]  INFO -- cnf-testsuite: task_type x: cert acc: 
I, [2022-06-21 23:10:02 +00:00 #885830]  INFO -- cnf-testsuite: task_type x: normal acc: cert
I, [2022-06-21 23:10:02 +00:00 #885830]  INFO -- cnf-testsuite: task_type: normal
I, [2022-06-21 23:10:02 +00:00 #885830]  INFO -- cnf-testsuite: upsert_task: task: default_namespace has status: failed and is awarded: 0 points
I, [2022-06-21 23:10:02 +00:00 #885830]  INFO -- cnf-testsuite: results yaml: {"name" => "cnf testsuite", "status" => nil, "command" => "/home/pair/src/denver/cnf-testsuite/cnf-testsuite default_namespace", "points" => nil, "exit_code" => 0, "items" => [{"name" => "default_namespace", "status" => "failed", "type" => "normal", "points" => 0}]}
```

Results on main branch: (Failing - all failing containers on the cluster were caught in the failure logs)
`./cnf-testsuite -l info cnf_setup cnf-config=./sample-cnfs/sample_coredns`
`./cnf-testsuite -l info latest_tag`
```
☺ ➔  ./cnf-testsuite -l info default_namespace                                                                 
I, [2022-06-21 23:13:30 +00:00 #886726]  INFO -- cnf-testsuite-verbose: default_namespace
I, [2022-06-21 23:13:30 +00:00 #886726]  INFO -- cnf-testsuite: task_runner args: #<Sam::Args:0x7f124be7ea40 @arr=[], @named_args={}>
I, [2022-06-21 23:13:30 +00:00 #886726]  INFO -- cnf-testsuite: check_cnf_config args: #<Sam::Args:0x7f124be7ea40 @arr=[], @named_args={}>
I, [2022-06-21 23:13:30 +00:00 #886726]  INFO -- cnf-testsuite: check_cnf_config cnf: 
I, [2022-06-21 23:13:30 +00:00 #886726]  INFO -- cnf-testsuite: cnf_config_list
I, [2022-06-21 23:13:30 +00:00 #886726]  INFO -- cnf-testsuite: find: find cnfs/* -name "cnf-testsuite.yml"
I, [2022-06-21 23:13:30 +00:00 #886726]  INFO -- cnf-testsuite: find response: ["cnfs/coredns/cnf-testsuite.yml"]
I, [2022-06-21 23:13:30 +00:00 #886726]  INFO -- cnf-testsuite: CNF configs found: 1
I, [2022-06-21 23:13:30 +00:00 #886726]  INFO -- cnf-testsuite: airgapped: false
I, [2022-06-21 23:13:30 +00:00 #886726]  INFO -- cnf-testsuite: generate_tar_mode: false
I, [2022-06-21 23:13:30 +00:00 #886726]  INFO -- cnf-testsuite: ensure_cnf_testsuite_yml_path
I, [2022-06-21 23:13:30 +00:00 #886726]  INFO -- cnf-testsuite: generate_and_set_release_name
I, [2022-06-21 23:13:30 +00:00 #886726]  INFO -- cnf-testsuite: generate_and_set_release_name config_yml_path: cnfs/coredns/cnf-testsuite.yml
I, [2022-06-21 23:13:30 +00:00 #886726]  INFO -- cnf-testsuite: airgapped mode: false
I, [2022-06-21 23:13:30 +00:00 #886726]  INFO -- cnf-testsuite: generate_tar_mode: false
I, [2022-06-21 23:13:30 +00:00 #886726]  INFO -- cnf-testsuite: ensure_cnf_testsuite_yml_path
I, [2022-06-21 23:13:30 +00:00 #886726]  INFO -- cnf-testsuite: ensure_cnf_testsuite_yml_dir
I, [2022-06-21 23:13:30 +00:00 #886726]  INFO -- cnf-testsuite: parsed_config_file: cnfs/coredns/cnf-testsuite.yml
I, [2022-06-21 23:13:30 +00:00 #886726]  INFO -- cnf-testsuite: parsed_config_file: cnfs/coredns/cnf-testsuite.yml
I, [2022-06-21 23:13:30 +00:00 #886726]  INFO -- cnf-testsuite: cnf_installation_method
I, [2022-06-21 23:13:30 +00:00 #886726]  INFO -- cnf-testsuite: cnf_installation_method config: #<Totem::Config:0x7f1253d47be0>
I, [2022-06-21 23:13:30 +00:00 #886726]  INFO -- cnf-testsuite: cnf_installation_method config: cnfs/coredns/cnf-testsuite.yml
I, [2022-06-21 23:13:30 +00:00 #886726]  INFO -- cnf-testsuite: directory_parameter_split : chart
I, [2022-06-21 23:13:30 +00:00 #886726]  INFO -- cnf-testsuite: directory_parameter_split : chart
I, [2022-06-21 23:13:30 +00:00 #886726]  INFO -- cnf-testsuite: directory : chart parameters: 
I, [2022-06-21 23:13:30 +00:00 #886726]  INFO -- cnf-testsuite: release_name: coredns
I, [2022-06-21 23:13:30 +00:00 #886726]  INFO -- cnf-testsuite: helm_directory: chart
I, [2022-06-21 23:13:30 +00:00 #886726]  INFO -- cnf-testsuite: manifest_directory: 
I, [2022-06-21 23:13:30 +00:00 #886726]  INFO -- cnf-testsuite: Building helm_directory and manifest_directory full paths
I, [2022-06-21 23:13:30 +00:00 #886726]  INFO -- cnf-testsuite: full_helm_directory: /home/pair/src/denver/cnf-testsuite/cnfs/coredns/chart exists? true
I, [2022-06-21 23:13:30 +00:00 #886726]  INFO -- cnf-testsuite: full_manifest_directory: /home/pair/src/denver/cnf-testsuite/cnfs/coredns/ exists? true
I, [2022-06-21 23:13:30 +00:00 #886726]  INFO -- cnf-testsuite: helm_directory not empty, using: /home/pair/src/denver/cnf-testsuite/cnfs/coredns/chart
I, [2022-06-21 23:13:30 +00:00 #886726]  INFO -- cnf-testsuite: cnf_destination_dir config_file: cnfs/coredns/cnf-testsuite.yml
I, [2022-06-21 23:13:30 +00:00 #886726]  INFO -- cnf-testsuite: parsed_config_file: cnfs/coredns/cnf-testsuite.yml
I, [2022-06-21 23:13:30 +00:00 #886726]  INFO -- cnf-testsuite: release_name: coredns
I, [2022-06-21 23:13:30 +00:00 #886726]  INFO -- cnf-testsuite: cnf destination dir: /home/pair/src/denver/cnf-testsuite/cnfs/coredns
I, [2022-06-21 23:13:30 +00:00 #886726]  INFO -- cnf-testsuite: ensure_cnf_testsuite_yml_dir
I, [2022-06-21 23:13:30 +00:00 #886726]  INFO -- cnf-testsuite: NOT USING EXPORTED CHART PATH
I, [2022-06-21 23:13:30 +00:00 #886726]  INFO -- cnf-testsuite: kyverno_policy_path command: ls /home/pair/src/denver/cnf-testsuite/tools/kyverno-policies/best-practices/disallow_default_namespace/disallow_default_namespace.yaml
I, [2022-06-21 23:13:30 +00:00 #886726]  INFO -- cnf-testsuite: kyverno_policy_path output: /home/pair/src/denver/cnf-testsuite/tools/kyverno-policies/best-practices/disallow_default_namespace/disallow_default_namespace.yaml

I, [2022-06-21 23:13:30 +00:00 #886726]  INFO -- cnf-testsuite: Kyverno::PolicyAudit.run command: /home/pair/src/denver/cnf-testsuite/tools/kyverno apply /home/pair/src/denver/cnf-testsuite/tools/kyverno-policies/best-practices/disallow_default_namespace/disallow_default_namespace.yaml --cluster --policy-report
✖️  FAILED: Resources are created in the default namespace 🏷️❌
Deployment coredns-coredns in default namespace failed. validation error: Using 'default' namespace is not allowed for pod controllers. Rule validate-podcontroller-namespace failed at path /metadata/namespace/
Deployment corednstag-coredns in default namespace failed. validation error: Using 'default' namespace is not allowed for pod controllers. Rule validate-podcontroller-namespace failed at path /metadata/namespace/
Pod coredns-coredns-5946d7df55-5p6cq in default namespace failed. validation error: Using 'default' namespace is not allowed. Rule validate-namespace failed at path /metadata/namespace/
Pod corednstag-coredns-b7cc94cf8-6s4mp in default namespace failed. validation error: Using 'default' namespace is not allowed. Rule validate-namespace failed at path /metadata/namespace/
I, [2022-06-21 23:13:31 +00:00 #886726]  INFO -- cnf-testsuite: cmd: /home/pair/src/denver/cnf-testsuite/cnf-testsuite default_namespace
I, [2022-06-21 23:13:31 +00:00 #886726]  INFO -- cnf-testsuite: task_type_by_task
I, [2022-06-21 23:13:31 +00:00 #886726]  INFO -- cnf-testsuite: points: {"name" => "default_namespace", "tags" => "configuration, dynamic, workload, cert, normal"}
I, [2022-06-21 23:13:31 +00:00 #886726]  INFO -- cnf-testsuite: resp: ["configuration", "dynamic", "workload", "cert", "normal"]
I, [2022-06-21 23:13:31 +00:00 #886726]  INFO -- cnf-testsuite: task_type x: configuration acc: 
I, [2022-06-21 23:13:31 +00:00 #886726]  INFO -- cnf-testsuite: task_type x: dynamic acc: 
I, [2022-06-21 23:13:31 +00:00 #886726]  INFO -- cnf-testsuite: task_type x: workload acc: 
I, [2022-06-21 23:13:31 +00:00 #886726]  INFO -- cnf-testsuite: task_type x: cert acc: 
I, [2022-06-21 23:13:31 +00:00 #886726]  INFO -- cnf-testsuite: task_type x: normal acc: cert
I, [2022-06-21 23:13:31 +00:00 #886726]  INFO -- cnf-testsuite: task_type: normal
I, [2022-06-21 23:13:31 +00:00 #886726]  INFO -- cnf-testsuite: upsert_task: task: default_namespace has status: failed and is awarded: 0 points
I, [2022-06-21 23:13:31 +00:00 #886726]  INFO -- cnf-testsuite: results yaml: {"name" => "cnf testsuite", "status" => nil, "command" => "/home/pair/src/denver/cnf-testsuite/cnf-testsuite default_namespace", "points" => nil, "exit_code" => 0, "items" => [{"name" => "default_namespace", "status" => "failed", "type" => "normal", "points" => 0}]}
```

## Issues:
Refs: #1513

## How has this been tested:
 - [ ] Covered by existing integration testing
 - [ ] Added integration testing to cover
 - [ ] Verified all A/C passes
     * [ ] develop
     * [ ] master
     * [ ] tag/other branch
 - [ ] Test environment
    * [ ] Shared Packet K8s cluster
    * [ ] New Packet K8s cluster
    * [ ] Kind cluster
 - [ ] Have not tested

## Types of changes:
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [ ] Documentation update

## Checklist:
**Documentation**
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] No updates required.

**Code Review**
- [ ] Does the test handle fatal exceptions, ie. rescue block

**Issue**
- [ ] Tasks in issue are checked off
