### PR TITLE
[#1514] Move policy audit outside of task_runner

### DIFF
--- a/src/tasks/workload/security.cr
+++ b/src/tasks/workload/security.cr
@@ -42,11 +42,11 @@ task "sysctls" do |_, args|
   Log.for("verbose").info { "sysctls" }
   Kyverno.install
 
-  CNFManager::Task.task_runner(args) do |args, config|
-    emoji_security = "🔓🔑"
-    policy_path = Kyverno.policy_path("pod-security/baseline/restrict-sysctls/restrict-sysctls.yaml")
-    failures = Kyverno::PolicyAudit.run(policy_path, EXCLUDE_NAMESPACES)
+  emoji_security = "🔓🔑"
+  policy_path = Kyverno.policy_path("pod-security/baseline/restrict-sysctls/restrict-sysctls.yaml")
+  failures = Kyverno::PolicyAudit.run(policy_path, EXCLUDE_NAMESPACES)
 
+  CNFManager::Task.task_runner(args) do |args, config|
     resource_keys = CNFManager.workload_resource_keys(args, config)
     failures = Kyverno.filter_failures_for_cnf_resources(resource_keys, failures)
 


### PR DESCRIPTION
## Description
Moves Kyverno policy audit outside of `task_runner` for the `sysctls` test.

## Issues:
Refs: #1514

## How has this been tested:
 - [x] Covered by existing integration testing
 - [ ] Added integration testing to cover
 - [ ] Verified all A/C passes
     * [ ] develop
     * [ ] master
     * [ ] tag/other branch
 - [ ] Test environment
    * [ ] Shared Packet K8s cluster
    * [ ] New Packet K8s cluster
    * [ ] Kind cluster
 - [ ] Have not tested

## Types of changes:
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [ ] Documentation update

## Checklist:
**Documentation**
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] No updates required.

**Code Review**
- [ ] Does the test handle fatal exceptions, ie. rescue block

**Issue**
- [ ] Tasks in issue are checked off
