### PR TITLE
Update require_labels test to only check the CNF's Resources #1524

### DIFF
--- a/src/tasks/workload/configuration.cr
+++ b/src/tasks/workload/configuration.cr
@@ -34,11 +34,15 @@ desc "Check if the CNF is running containers with labels configured?"
 task "require_labels" do |_, args|
   Log.for("verbose").info { "require-labels" }
   Kyverno.install
+  emoji_passed = "🏷️✔️"
+  emoji_failed = "🏷️❌"
+  policy_path = Kyverno.best_practice_policy("require_labels/require_labels.yaml")
+  failures = Kyverno::PolicyAudit.run(policy_path, EXCLUDE_NAMESPACES)
+
   CNFManager::Task.task_runner(args) do |args, config|
-    emoji_passed = "🏷️✔️"
-    emoji_failed = "🏷️❌"
-    policy_path = Kyverno.best_practice_policy("require_labels/require_labels.yaml")
-    failures = Kyverno::PolicyAudit.run(policy_path, EXCLUDE_NAMESPACES)
+
+    resource_keys = CNFManager.workload_resource_keys(args, config)
+    failures = Kyverno.filter_failures_for_cnf_resources(resource_keys, failures)
 
     if failures.size == 0
       resp = upsert_passed_task("require_labels", "✔️  PASSED: Pods have the app.kubernetes.io/name label #{emoji_passed}")


### PR DESCRIPTION
## Description
Testing:

Install a container on the cluster without required_labels(outside of the CNF being tested):
`kubectl create -f sample-cnfs/k8s-non-helm/manifests/`

Results on require_labels#1524 branch: (Passing)
`./cnf-testsuite -l info cnf_setup cnf-config=./sample-cnfs/sample_coredns`
`./cnf-testsuite -l info require_labels`
```
☺ ➔  ./cnf-testsuite -l info require_labels
I, [2022-06-22 23:35:45 +00:00 #1072970]  INFO -- cnf-testsuite-verbose: require-labels
I, [2022-06-22 23:35:45 +00:00 #1072970]  INFO -- cnf-testsuite: kyverno_policy_path command: ls /home/pair/src/denver/cnf-testsuite/tools/kyverno-policies/best-practices/require_labels/require_labels.yaml
I, [2022-06-22 23:35:45 +00:00 #1072970]  INFO -- cnf-testsuite: kyverno_policy_path output: /home/pair/src/denver/cnf-testsuite/tools/kyverno-policies/best-practices/require_labels/require_labels.yaml

I, [2022-06-22 23:35:45 +00:00 #1072970]  INFO -- cnf-testsuite: Kyverno::PolicyAudit.run command: /home/pair/src/denver/cnf-testsuite/tools/kyverno apply /home/pair/src/denver/cnf-testsuite/tools/kyverno-policies/best-practices/require_labels/require_labels.yaml --cluster --policy-report
I, [2022-06-22 23:35:46 +00:00 #1072970]  INFO -- cnf-testsuite: task_runner args: #<Sam::Args:0x7f9398b2aa40 @arr=[], @named_args={}>
I, [2022-06-22 23:35:46 +00:00 #1072970]  INFO -- cnf-testsuite: check_cnf_config args: #<Sam::Args:0x7f9398b2aa40 @arr=[], @named_args={}>
I, [2022-06-22 23:35:46 +00:00 #1072970]  INFO -- cnf-testsuite: check_cnf_config cnf: 
I, [2022-06-22 23:35:46 +00:00 #1072970]  INFO -- cnf-testsuite: cnf_config_list
I, [2022-06-22 23:35:46 +00:00 #1072970]  INFO -- cnf-testsuite: find: find cnfs/* -name "cnf-testsuite.yml"
I, [2022-06-22 23:35:46 +00:00 #1072970]  INFO -- cnf-testsuite: find response: ["cnfs/coredns/cnf-testsuite.yml"]
I, [2022-06-22 23:35:46 +00:00 #1072970]  INFO -- cnf-testsuite: CNF configs found: 1
I, [2022-06-22 23:35:46 +00:00 #1072970]  INFO -- cnf-testsuite: airgapped: false
I, [2022-06-22 23:35:46 +00:00 #1072970]  INFO -- cnf-testsuite: generate_tar_mode: false
I, [2022-06-22 23:35:46 +00:00 #1072970]  INFO -- cnf-testsuite: ensure_cnf_testsuite_yml_path
I, [2022-06-22 23:35:46 +00:00 #1072970]  INFO -- cnf-testsuite: generate_and_set_release_name
I, [2022-06-22 23:35:46 +00:00 #1072970]  INFO -- cnf-testsuite: generate_and_set_release_name config_yml_path: cnfs/coredns/cnf-testsuite.yml
I, [2022-06-22 23:35:46 +00:00 #1072970]  INFO -- cnf-testsuite: airgapped mode: false
I, [2022-06-22 23:35:46 +00:00 #1072970]  INFO -- cnf-testsuite: generate_tar_mode: false
I, [2022-06-22 23:35:46 +00:00 #1072970]  INFO -- cnf-testsuite: ensure_cnf_testsuite_yml_path
I, [2022-06-22 23:35:46 +00:00 #1072970]  INFO -- cnf-testsuite: ensure_cnf_testsuite_yml_dir
I, [2022-06-22 23:35:46 +00:00 #1072970]  INFO -- cnf-testsuite: parsed_config_file: cnfs/coredns/cnf-testsuite.yml
I, [2022-06-22 23:35:46 +00:00 #1072970]  INFO -- cnf-testsuite: parsed_config_file: cnfs/coredns/cnf-testsuite.yml
I, [2022-06-22 23:35:46 +00:00 #1072970]  INFO -- cnf-testsuite: cnf_installation_method
I, [2022-06-22 23:35:46 +00:00 #1072970]  INFO -- cnf-testsuite: cnf_installation_method config: #<Totem::Config:0x7f93a09f3be0>
I, [2022-06-22 23:35:46 +00:00 #1072970]  INFO -- cnf-testsuite: cnf_installation_method config: cnfs/coredns/cnf-testsuite.yml
I, [2022-06-22 23:35:46 +00:00 #1072970]  INFO -- cnf-testsuite: directory_parameter_split : chart
I, [2022-06-22 23:35:46 +00:00 #1072970]  INFO -- cnf-testsuite: directory_parameter_split : chart
I, [2022-06-22 23:35:46 +00:00 #1072970]  INFO -- cnf-testsuite: directory : chart parameters: 
I, [2022-06-22 23:35:46 +00:00 #1072970]  INFO -- cnf-testsuite: release_name: coredns
I, [2022-06-22 23:35:46 +00:00 #1072970]  INFO -- cnf-testsuite: helm_directory: chart
I, [2022-06-22 23:35:46 +00:00 #1072970]  INFO -- cnf-testsuite: manifest_directory: 
I, [2022-06-22 23:35:46 +00:00 #1072970]  INFO -- cnf-testsuite: Building helm_directory and manifest_directory full paths
I, [2022-06-22 23:35:46 +00:00 #1072970]  INFO -- cnf-testsuite: full_helm_directory: /home/pair/src/denver/cnf-testsuite/cnfs/coredns/chart exists? true
I, [2022-06-22 23:35:46 +00:00 #1072970]  INFO -- cnf-testsuite: full_manifest_directory: /home/pair/src/denver/cnf-testsuite/cnfs/coredns/ exists? true
I, [2022-06-22 23:35:46 +00:00 #1072970]  INFO -- cnf-testsuite: helm_directory not empty, using: /home/pair/src/denver/cnf-testsuite/cnfs/coredns/chart
I, [2022-06-22 23:35:46 +00:00 #1072970]  INFO -- cnf-testsuite: cnf_destination_dir config_file: cnfs/coredns/cnf-testsuite.yml
I, [2022-06-22 23:35:46 +00:00 #1072970]  INFO -- cnf-testsuite: parsed_config_file: cnfs/coredns/cnf-testsuite.yml
I, [2022-06-22 23:35:46 +00:00 #1072970]  INFO -- cnf-testsuite: release_name: coredns
I, [2022-06-22 23:35:46 +00:00 #1072970]  INFO -- cnf-testsuite: cnf destination dir: /home/pair/src/denver/cnf-testsuite/cnfs/coredns
I, [2022-06-22 23:35:46 +00:00 #1072970]  INFO -- cnf-testsuite: ensure_cnf_testsuite_yml_dir
I, [2022-06-22 23:35:46 +00:00 #1072970]  INFO -- cnf-testsuite: NOT USING EXPORTED CHART PATH
I, [2022-06-22 23:35:46 +00:00 #1072970]  INFO -- cnf-testsuite: cnf_workload_resources
I, [2022-06-22 23:35:46 +00:00 #1072970]  INFO -- cnf-testsuite: cnf_installation_method config : CNFManager::Config
I, [2022-06-22 23:35:46 +00:00 #1072970]  INFO -- cnf-testsuite: config_cnf_config: {destination_cnf_dir: "/home/pair/src/denver/cnf-testsuite/cnfs/coredns", source_cnf_file: "cnfs/coredns/cnf-testsuite.yml", source_cnf_dir: "cnfs/coredns/", yml_file_path: "cnfs/coredns/", install_method: {HelmDirectory, "/home/pair/src/denver/cnf-testsuite/cnfs/coredns/chart"}, manifest_directory: "", helm_directory: "chart ", source_helm_directory: "chart", helm_chart_path: "/home/pair/src/denver/cnf-testsuite/cnfs/coredns/chart ", manifest_file_path: "/home/pair/src/denver/cnf-testsuite/cnfs/coredns/temp_template.yml", release_name: "coredns", service_name: "", helm_repository: {name: "stable", repo_url: "https://cncf.gitlab.io/stable"}, helm_chart: "", helm_install_namespace: "", rolling_update_tag: "", container_names: [{"name" => "", "rolling_update_test_tag" => "", "rolling_downgrade_test_tag" => "", "rolling_version_change_test_tag" => "", "rollback_from_tag" => ""}], white_list_container_names: []}
I, [2022-06-22 23:35:46 +00:00 #1072970]  INFO -- cnf-testsuite: parsed_config_file: cnfs/coredns/cnf-testsuite.yml
I, [2022-06-22 23:35:46 +00:00 #1072970]  INFO -- cnf-testsuite: cnf_installation_method
I, [2022-06-22 23:35:46 +00:00 #1072970]  INFO -- cnf-testsuite: cnf_installation_method config: #<Totem::Config:0x7f93a09f3aa0>
I, [2022-06-22 23:35:46 +00:00 #1072970]  INFO -- cnf-testsuite: cnf_installation_method config: cnfs/coredns/cnf-testsuite.yml
I, [2022-06-22 23:35:46 +00:00 #1072970]  INFO -- cnf-testsuite: directory_parameter_split : chart
I, [2022-06-22 23:35:46 +00:00 #1072970]  INFO -- cnf-testsuite: directory_parameter_split : chart
I, [2022-06-22 23:35:46 +00:00 #1072970]  INFO -- cnf-testsuite: directory : chart parameters: 
I, [2022-06-22 23:35:46 +00:00 #1072970]  INFO -- cnf-testsuite: release_name: coredns
I, [2022-06-22 23:35:46 +00:00 #1072970]  INFO -- cnf-testsuite: helm_directory: chart
I, [2022-06-22 23:35:46 +00:00 #1072970]  INFO -- cnf-testsuite: manifest_directory: 
I, [2022-06-22 23:35:46 +00:00 #1072970]  INFO -- cnf-testsuite: Building helm_directory and manifest_directory full paths
I, [2022-06-22 23:35:46 +00:00 #1072970]  INFO -- cnf-testsuite: full_helm_directory: /home/pair/src/denver/cnf-testsuite/cnfs/coredns/chart exists? true
I, [2022-06-22 23:35:46 +00:00 #1072970]  INFO -- cnf-testsuite: full_manifest_directory: /home/pair/src/denver/cnf-testsuite/cnfs/coredns/ exists? true
I, [2022-06-22 23:35:46 +00:00 #1072970]  INFO -- cnf-testsuite: helm_directory not empty, using: /home/pair/src/denver/cnf-testsuite/cnfs/coredns/chart
I, [2022-06-22 23:35:46 +00:00 #1072970]  INFO -- cnf-testsuite: EXPORTED CHART PATH: /home/pair/src/denver/cnf-testsuite/cnfs/coredns/chart 
I, [2022-06-22 23:35:46 +00:00 #1072970]  INFO -- cnf-testsuite: Helm::generate_manifest_from_templates command: helm template coredns /home/pair/src/denver/cnf-testsuite/cnfs/coredns/chart  > /home/pair/src/denver/cnf-testsuite/cnfs/coredns/temp_template.yml
I, [2022-06-22 23:35:46 +00:00 #1072970]  INFO -- cnf-testsuite: before generate command: ls -alR /home/pair/src/denver/cnf-testsuite/cnfs/coredns/chart 
I, [2022-06-22 23:35:46 +00:00 #1072970]  INFO -- cnf-testsuite: before generate command: ls -alR cnfs
I, [2022-06-22 23:35:46 +00:00 #1072970]  INFO -- cnf-testsuite: helm command: helm template coredns /home/pair/src/denver/cnf-testsuite/cnfs/coredns/chart  > /home/pair/src/denver/cnf-testsuite/cnfs/coredns/temp_template.yml
I, [2022-06-22 23:35:46 +00:00 #1072970]  INFO -- cnf-testsuite: Helm.template output: 
I, [2022-06-22 23:35:46 +00:00 #1072970]  INFO -- cnf-testsuite: Helm.template stderr: 
I, [2022-06-22 23:35:46 +00:00 #1072970]  INFO -- cnf-testsuite: after generate command: ls -alR /home/pair/src/denver/cnf-testsuite/cnfs/coredns/chart 
I, [2022-06-22 23:35:46 +00:00 #1072970]  INFO -- cnf-testsuite: after generate command: ls -alR cnfs
✔️  PASSED: Pods have the app.kubernetes.io/name label 🏷️✔️
I, [2022-06-22 23:35:46 +00:00 #1072970]  INFO -- cnf-testsuite: parse_manifest_as_ymls template_file_name: /home/pair/src/denver/cnf-testsuite/cnfs/coredns/temp_template.yml
I, [2022-06-22 23:35:46 +00:00 #1072970]  INFO -- cnf-testsuite: workload_resource_by_kind kind: Deployment
I, [2022-06-22 23:35:46 +00:00 #1072970]  INFO -- cnf-testsuite: workload_resource_by_kind kind: Service
I, [2022-06-22 23:35:46 +00:00 #1072970]  INFO -- cnf-testsuite: workload_resource_by_kind kind: Pod
I, [2022-06-22 23:35:46 +00:00 #1072970]  INFO -- cnf-testsuite: workload_resource_by_kind kind: ReplicaSet
I, [2022-06-22 23:35:46 +00:00 #1072970]  INFO -- cnf-testsuite: workload_resource_by_kind kind: StatefulSet
I, [2022-06-22 23:35:46 +00:00 #1072970]  INFO -- cnf-testsuite: workload_resource_by_kind kind: DaemonSet
I, [2022-06-22 23:35:46 +00:00 #1072970]  INFO -- cnf-testsuite: task_points: task: require_labels is worth: 5 points
I, [2022-06-22 23:35:46 +00:00 #1072970]  INFO -- cnf-testsuite: cmd: /home/pair/src/denver/cnf-testsuite/cnf-testsuite require_labels
I, [2022-06-22 23:35:46 +00:00 #1072970]  INFO -- cnf-testsuite: task_type_by_task
I, [2022-06-22 23:35:46 +00:00 #1072970]  INFO -- cnf-testsuite: points: {"name" => "require_labels", "tags" => "configuration, dynamic, workload, cert, normal"}
I, [2022-06-22 23:35:46 +00:00 #1072970]  INFO -- cnf-testsuite: resp: ["configuration", "dynamic", "workload", "cert", "normal"]
I, [2022-06-22 23:35:46 +00:00 #1072970]  INFO -- cnf-testsuite: task_type x: configuration acc: 
I, [2022-06-22 23:35:46 +00:00 #1072970]  INFO -- cnf-testsuite: task_type x: dynamic acc: 
I, [2022-06-22 23:35:46 +00:00 #1072970]  INFO -- cnf-testsuite: task_type x: workload acc: 
I, [2022-06-22 23:35:46 +00:00 #1072970]  INFO -- cnf-testsuite: task_type x: cert acc: 
I, [2022-06-22 23:35:46 +00:00 #1072970]  INFO -- cnf-testsuite: task_type x: normal acc: cert
I, [2022-06-22 23:35:46 +00:00 #1072970]  INFO -- cnf-testsuite: task_type: normal
I, [2022-06-22 23:35:46 +00:00 #1072970]  INFO -- cnf-testsuite: upsert_task: task: require_labels has status: passed and is awarded: 5 points
I, [2022-06-22 23:35:46 +00:00 #1072970]  INFO -- cnf-testsuite: results yaml: {"name" => "cnf testsuite", "status" => nil, "command" => "/home/pair/src/denver/cnf-testsuite/cnf-testsuite require_labels", "points" => nil, "exit_code" => 0, "items" => [{"name" => "require_labels", "status" => "passed", "type" => "normal", "points" => 5}]}

```

Results on main branch: (Failing)
`./cnf-testsuite -l info cnf_setup cnf-config=./sample-cnfs/sample_coredns`

`./cnf-testsuite -l info require_labels`

```
 ➔  ./cnf-testsuite -l info require_labels                                                                                                                
I, [2022-06-22 23:38:58 +00:00 #1073972]  INFO -- cnf-testsuite-verbose: require-labels
I, [2022-06-22 23:38:58 +00:00 #1073972]  INFO -- cnf-testsuite: task_runner args: #<Sam::Args:0x7fc736daba40 @arr=[], @named_args={}>
I, [2022-06-22 23:38:58 +00:00 #1073972]  INFO -- cnf-testsuite: check_cnf_config args: #<Sam::Args:0x7fc736daba40 @arr=[], @named_args={}>
I, [2022-06-22 23:38:58 +00:00 #1073972]  INFO -- cnf-testsuite: check_cnf_config cnf: 
I, [2022-06-22 23:38:58 +00:00 #1073972]  INFO -- cnf-testsuite: cnf_config_list
I, [2022-06-22 23:38:58 +00:00 #1073972]  INFO -- cnf-testsuite: find: find cnfs/* -name "cnf-testsuite.yml"
I, [2022-06-22 23:38:58 +00:00 #1073972]  INFO -- cnf-testsuite: find response: ["cnfs/coredns/cnf-testsuite.yml"]
I, [2022-06-22 23:38:58 +00:00 #1073972]  INFO -- cnf-testsuite: CNF configs found: 1
I, [2022-06-22 23:38:58 +00:00 #1073972]  INFO -- cnf-testsuite: airgapped: false
I, [2022-06-22 23:38:58 +00:00 #1073972]  INFO -- cnf-testsuite: generate_tar_mode: false
I, [2022-06-22 23:38:58 +00:00 #1073972]  INFO -- cnf-testsuite: ensure_cnf_testsuite_yml_path
I, [2022-06-22 23:38:58 +00:00 #1073972]  INFO -- cnf-testsuite: generate_and_set_release_name
I, [2022-06-22 23:38:58 +00:00 #1073972]  INFO -- cnf-testsuite: generate_and_set_release_name config_yml_path: cnfs/coredns/cnf-testsuite.yml
I, [2022-06-22 23:38:58 +00:00 #1073972]  INFO -- cnf-testsuite: airgapped mode: false
I, [2022-06-22 23:38:58 +00:00 #1073972]  INFO -- cnf-testsuite: generate_tar_mode: false
I, [2022-06-22 23:38:58 +00:00 #1073972]  INFO -- cnf-testsuite: ensure_cnf_testsuite_yml_path
I, [2022-06-22 23:38:58 +00:00 #1073972]  INFO -- cnf-testsuite: ensure_cnf_testsuite_yml_dir
I, [2022-06-22 23:38:58 +00:00 #1073972]  INFO -- cnf-testsuite: parsed_config_file: cnfs/coredns/cnf-testsuite.yml
I, [2022-06-22 23:38:58 +00:00 #1073972]  INFO -- cnf-testsuite: parsed_config_file: cnfs/coredns/cnf-testsuite.yml
I, [2022-06-22 23:38:58 +00:00 #1073972]  INFO -- cnf-testsuite: cnf_installation_method
I, [2022-06-22 23:38:58 +00:00 #1073972]  INFO -- cnf-testsuite: cnf_installation_method config: #<Totem::Config:0x7fc73ec74be0>
I, [2022-06-22 23:38:58 +00:00 #1073972]  INFO -- cnf-testsuite: cnf_installation_method config: cnfs/coredns/cnf-testsuite.yml
I, [2022-06-22 23:38:58 +00:00 #1073972]  INFO -- cnf-testsuite: directory_parameter_split : chart
I, [2022-06-22 23:38:58 +00:00 #1073972]  INFO -- cnf-testsuite: directory_parameter_split : chart
I, [2022-06-22 23:38:58 +00:00 #1073972]  INFO -- cnf-testsuite: directory : chart parameters: 
I, [2022-06-22 23:38:58 +00:00 #1073972]  INFO -- cnf-testsuite: release_name: coredns
I, [2022-06-22 23:38:58 +00:00 #1073972]  INFO -- cnf-testsuite: helm_directory: chart
I, [2022-06-22 23:38:58 +00:00 #1073972]  INFO -- cnf-testsuite: manifest_directory: 
I, [2022-06-22 23:38:58 +00:00 #1073972]  INFO -- cnf-testsuite: Building helm_directory and manifest_directory full paths
I, [2022-06-22 23:38:58 +00:00 #1073972]  INFO -- cnf-testsuite: full_helm_directory: /home/pair/src/denver/cnf-testsuite/cnfs/coredns/chart exists? true
I, [2022-06-22 23:38:58 +00:00 #1073972]  INFO -- cnf-testsuite: full_manifest_directory: /home/pair/src/denver/cnf-testsuite/cnfs/coredns/ exists? true
I, [2022-06-22 23:38:58 +00:00 #1073972]  INFO -- cnf-testsuite: helm_directory not empty, using: /home/pair/src/denver/cnf-testsuite/cnfs/coredns/chart
I, [2022-06-22 23:38:58 +00:00 #1073972]  INFO -- cnf-testsuite: cnf_destination_dir config_file: cnfs/coredns/cnf-testsuite.yml
I, [2022-06-22 23:38:58 +00:00 #1073972]  INFO -- cnf-testsuite: parsed_config_file: cnfs/coredns/cnf-testsuite.yml
I, [2022-06-22 23:38:58 +00:00 #1073972]  INFO -- cnf-testsuite: release_name: coredns
I, [2022-06-22 23:38:58 +00:00 #1073972]  INFO -- cnf-testsuite: cnf destination dir: /home/pair/src/denver/cnf-testsuite/cnfs/coredns
I, [2022-06-22 23:38:58 +00:00 #1073972]  INFO -- cnf-testsuite: ensure_cnf_testsuite_yml_dir
I, [2022-06-22 23:38:58 +00:00 #1073972]  INFO -- cnf-testsuite: NOT USING EXPORTED CHART PATH
I, [2022-06-22 23:38:58 +00:00 #1073972]  INFO -- cnf-testsuite: kyverno_policy_path command: ls /home/pair/src/denver/cnf-testsuite/tools/kyverno-policies/best-practices/require_labels/require_labels.yaml
I, [2022-06-22 23:38:58 +00:00 #1073972]  INFO -- cnf-testsuite: kyverno_policy_path output: /home/pair/src/denver/cnf-testsuite/tools/kyverno-policies/best-practices/require_labels/require_labels.yaml

I, [2022-06-22 23:38:58 +00:00 #1073972]  INFO -- cnf-testsuite: Kyverno::PolicyAudit.run command: /home/pair/src/denver/cnf-testsuite/tools/kyverno apply /home/pair/src/denver/cnf-testsuite/tools/kyverno-policies/best-practices/require_labels/require_labels.yaml --cluster --policy-report
✖️  FAILED: Pods should have the app.kubernetes.io/name label. 🏷️❌
Pod sidecar-container-demo in default namespace failed. validation error: The label `app.kubernetes.io/name` is required. Rule check-for-labels failed at path /metadata/labels/
Pod nginx-webapp-f6d45866c-c8bbh in default namespace failed. validation error: The label `app.kubernetes.io/name` is required. Rule check-for-labels failed at path /metadata/labels/app.kubernetes.io/name/
Pod nginx-webapp-f6d45866c-xxltl in default namespace failed. validation error: The label `app.kubernetes.io/name` is required. Rule check-for-labels failed at path /metadata/labels/app.kubernetes.io/name/
Pod nginx-webapp-f6d45866c-g26bl in default namespace failed. validation error: The label `app.kubernetes.io/name` is required. Rule check-for-labels failed at path /metadata/labels/app.kubernetes.io/name/
Deployment nginx-webapp in default namespace failed. validation error: The label `app.kubernetes.io/name` is required. Rule autogen-check-for-labels failed at path /spec/template/metadata/labels/app.kubernetes.io/name/
Pod nginx-webapp-f6d45866c-dzxhg in default namespace failed. validation error: The label `app.kubernetes.io/name` is required. Rule check-for-labels failed at path /metadata/labels/app.kubernetes.io/name/
Pod nginx-webapp-f6d45866c-mnq6l in default namespace failed. validation error: The label `app.kubernetes.io/name` is required. Rule check-for-labels failed at path /metadata/labels/app.kubernetes.io/name/
I, [2022-06-22 23:39:00 +00:00 #1073972]  INFO -- cnf-testsuite: cmd: /home/pair/src/denver/cnf-testsuite/cnf-testsuite require_labels
I, [2022-06-22 23:39:00 +00:00 #1073972]  INFO -- cnf-testsuite: task_type_by_task
I, [2022-06-22 23:39:00 +00:00 #1073972]  INFO -- cnf-testsuite: points: {"name" => "require_labels", "tags" => "configuration, dynamic, workload, cert, normal"}
I, [2022-06-22 23:39:00 +00:00 #1073972]  INFO -- cnf-testsuite: resp: ["configuration", "dynamic", "workload", "cert", "normal"]
I, [2022-06-22 23:39:00 +00:00 #1073972]  INFO -- cnf-testsuite: task_type x: configuration acc: 
I, [2022-06-22 23:39:00 +00:00 #1073972]  INFO -- cnf-testsuite: task_type x: dynamic acc: 
I, [2022-06-22 23:39:00 +00:00 #1073972]  INFO -- cnf-testsuite: task_type x: workload acc: 
I, [2022-06-22 23:39:00 +00:00 #1073972]  INFO -- cnf-testsuite: task_type x: cert acc: 
I, [2022-06-22 23:39:00 +00:00 #1073972]  INFO -- cnf-testsuite: task_type x: normal acc: cert
I, [2022-06-22 23:39:00 +00:00 #1073972]  INFO -- cnf-testsuite: task_type: normal
I, [2022-06-22 23:39:00 +00:00 #1073972]  INFO -- cnf-testsuite: upsert_task: task: require_labels has status: failed and is awarded: 0 points
I, [2022-06-22 23:39:00 +00:00 #1073972]  INFO -- cnf-testsuite: results yaml: {"name" => "cnf testsuite", "status" => nil, "command" => "/home/pair/src/denver/cnf-testsuite/cnf-testsuite require_labels", "points" => nil, "exit_code" => 0, "items" => [{"name" => "require_labels", "status" => "failed", "type" => "normal", "points" => 0}]}
```


## Issues:
Refs: #1524

## How has this been tested:
 - [ ] Covered by existing integration testing
 - [ ] Added integration testing to cover
 - [ ] Verified all A/C passes
     * [ ] develop
     * [ ] master
     * [ ] tag/other branch
 - [ ] Test environment
    * [ ] Shared Packet K8s cluster
    * [ ] New Packet K8s cluster
    * [ ] Kind cluster
 - [ ] Have not tested

## Types of changes:
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [ ] Documentation update

## Checklist:
**Documentation**
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] No updates required.

**Code Review**
- [ ] Does the test handle fatal exceptions, ie. rescue block

**Issue**
- [ ] Tasks in issue are checked off
