### PR TITLE
[bug/1579, bug/1586] Falco should be uninstalled when cleanup_all is run

### DIFF
--- a/src/tasks/cleanup.cr
+++ b/src/tasks/cleanup.cr
@@ -43,7 +43,7 @@ task "samples_cleanup" do  |_, args|
 end
 
 desc "Cleans up the CNF Test Suite helper tools and containers"
-task "tools_cleanup", ["helm_local_cleanup", "sonobuoy_cleanup", "uninstall_chaosmesh","uninstall_litmus", "uninstall_dockerd", "uninstall_kubescape","uninstall_cluster_tools", "uninstall_opa"] do  |_, args|
+task "tools_cleanup", ["helm_local_cleanup", "sonobuoy_cleanup", "uninstall_chaosmesh","uninstall_litmus", "uninstall_dockerd", "uninstall_kubescape","uninstall_cluster_tools", "uninstall_opa", "uninstall_falco"] do  |_, args|
 end
 
 desc "Cleans up the CNF Test Suite sample projects, helper tools, and containers"

--- a/src/tasks/cleanup.cr
+++ b/src/tasks/cleanup.cr
@@ -43,7 +43,20 @@ task "samples_cleanup" do  |_, args|
 end
 
 desc "Cleans up the CNF Test Suite helper tools and containers"
-task "tools_cleanup", ["helm_local_cleanup", "sonobuoy_cleanup", "uninstall_chaosmesh","uninstall_litmus", "uninstall_dockerd", "uninstall_kubescape","uninstall_cluster_tools", "uninstall_opa", "uninstall_falco"] do  |_, args|
+task "tools_cleanup", [
+    "sonobuoy_cleanup",
+    "uninstall_chaosmesh",
+    "uninstall_litmus",
+    "uninstall_dockerd",
+    "uninstall_kubescape",
+    "uninstall_cluster_tools",
+    "uninstall_opa",
+    "uninstall_falco",
+ 
+    # Helm needs to be uninstalled last to allow other uninstalls to use helm if necessary.
+    # Check this issue for details - https://github.com/cncf/cnf-testsuite/issues/1586
+    "helm_local_cleanup"
+  ] do  |_, args|
 end
 
 desc "Cleans up the CNF Test Suite sample projects, helper tools, and containers"


### PR DESCRIPTION
## Issues:
Refs: #1579, #1586

## Description
* Added `uninstall_falco` as dependency to `tools_cleanup`. Falco is now uninstalled when `cleanup_all` is run.
* Also updated the order of dependencies for `tools_cleanup` (for #1586), which was also affecting uninstallation for other third-party tools.

![CleanShot 2022-08-01 at 13 36 58@2x](https://user-images.githubusercontent.com/84005/182103099-824785eb-d807-4a28-ba35-8c76c9b7f8af.png)

## How has this been tested:
 - [x] Covered by existing integration testing
 - [ ] Added integration testing to cover
 - [ ] Verified all A/C passes
     * [ ] develop
     * [ ] master
     * [ ] tag/other branch
 - [ ] Test environment
    * [ ] Shared Packet K8s cluster
    * [ ] New Packet K8s cluster
    * [ ] Kind cluster
 - [ ] Have not tested

## Types of changes:
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [ ] Documentation update

## Checklist:
**Documentation**
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] No updates required.

**Code Review**
- [ ] Does the test handle fatal exceptions, ie. rescue block

**Issue**
- [ ] Tasks in issue are checked off
