### PR TITLE
[#1582] Add helm option to disable namespace update job for OPA Gatekeeper

### DIFF
--- a/src/tasks/opa_setup.cr
+++ b/src/tasks/opa_setup.cr
@@ -16,7 +16,7 @@ task "install_opa" do |_, args|
   else
     Helm.helm_repo_add("gatekeeper", "https://open-policy-agent.github.io/gatekeeper/charts")
     begin
-      Helm.install("--set auditInterval=1 opa-gatekeeper gatekeeper/gatekeeper")
+      Helm.install("--set auditInterval=1 --set postInstall.labelNamespace.enabled=false opa-gatekeeper gatekeeper/gatekeeper")
     rescue e : Helm::CannotReuseReleaseNameError
       stdout_warning "gatekeeper already installed"
     end


### PR DESCRIPTION
## Description
* Add helm option to disable namespace update job for OPA Gatekeeper.
* This speeds up the Gatekeeper install since the namespace update job (which has an error), would not be installed.
* With this fix the gatekeeper install time is reduced from 5min to around 25 secs.

Notes and screenshots about this issue are on [this hackmd doc](https://hackmd.io/M7qWnl5sRKCGBkCCXK190w).

## Issues:
Refs: #1582

## How has this been tested:
 - [x] Covered by existing integration testing
 - [ ] Added integration testing to cover
 - [ ] Verified all A/C passes
     * [ ] develop
     * [ ] master
     * [ ] tag/other branch
 - [ ] Test environment
    * [ ] Shared Packet K8s cluster
    * [ ] New Packet K8s cluster
    * [ ] Kind cluster
 - [ ] Have not tested

## Types of changes:
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [ ] Documentation update

## Checklist:
**Documentation**
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] No updates required.

**Code Review**
- [ ] Does the test handle fatal exceptions, ie. rescue block

**Issue**
- [ ] Tasks in issue are checked off
