### PR TITLE
Add note about schedulable nodes to node_drain skip message

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -495,6 +495,8 @@ Make sure that your CNFs containers are not shareing the same [database](https:/
 ./cnf-testsuite node_drain
 ```
 
+Please note, that this test requires a cluster with atleast two schedulable nodes.
+
 <b>Remediation for failing this test</b> 
 Ensure that your CNF can be successfully rescheduled when a node fails or is [drained](https://kubernetes.io/docs/tasks/administer-cluster/safely-drain-node/)
 </b>

--- a/spec/workload/resilience/node_drain_spec.cr
+++ b/spec/workload/resilience/node_drain_spec.cr
@@ -22,7 +22,7 @@ describe "Resilience Node Drain Chaos" do
       if KubectlClient::Get.schedulable_nodes_list.size > 1
         (/PASSED: node_drain chaos test passed/ =~ response_s).should_not be_nil
       else
-        (/SKIPPED: node_drain chaos test skipped/ =~ response_s).should_not be_nil
+        (/SKIPPED: node_drain chaos test requires the cluster to have atleast two/ =~ response_s).should_not be_nil
       end
     ensure
       `./cnf-testsuite cnf_cleanup cnf-config=sample-cnfs/sample-coredns-cnf/cnf-testsuite.yml`

--- a/src/tasks/workload/state.cr
+++ b/src/tasks/workload/state.cr
@@ -331,7 +331,7 @@ task "node_drain", ["install_litmus"] do |t, args|
     end
     if skipped
       Log.for("verbose").warn{"The node_drain test needs minimum 2 schedulable nodes, current number of nodes: #{KubectlClient::Get.schedulable_nodes_list.size}"} if check_verbose(args)
-      resp = upsert_skipped_task("node_drain","⏭️  🏆 SKIPPED: node_drain chaos test skipped 🗡️💀♻️")
+      resp = upsert_skipped_task("node_drain","⏭️  🏆 SKIPPED: node_drain chaos test requires the cluster to have atleast two schedulable nodes 🗡️💀♻️")
     elsif task_response
       resp = upsert_passed_task("node_drain","✔️  🏆 PASSED: node_drain chaos test passed 🗡️💀♻️")
     else


### PR DESCRIPTION
## Issues:
Refs: #1574

## Description
* `node_drain` test skip message informs user about the requirement of a multi-node cluster.
* Updated USAGE.md with note about multi-node requirement for `node_drain` test.
* Updated assertion in spec test to use the new skip message for the test.

<img width="1600" alt="CleanShot 2022-08-01 at 15 14 05@2x" src="https://user-images.githubusercontent.com/84005/182121384-64536b1d-d1b5-4520-bbff-f460617c2c05.png">


## How has this been tested:
 - [x] Covered by existing integration testing
 - [ ] Added integration testing to cover
 - [ ] Verified all A/C passes
     * [ ] develop
     * [ ] master
     * [ ] tag/other branch
 - [ ] Test environment
    * [ ] Shared Packet K8s cluster
    * [ ] New Packet K8s cluster
    * [ ] Kind cluster
 - [ ] Have not tested

## Types of changes:
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [x] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [x] Documentation update

## Checklist:
**Documentation**
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] No updates required.

**Code Review**
- [ ] Does the test handle fatal exceptions, ie. rescue block

**Issue**
- [ ] Tasks in issue are checked off
