### PR TITLE
[bug/1583] Format IP addresses in the output appropriately in `ip_addresses` test

### DIFF
--- a/src/tasks/workload/configuration.cr
+++ b/src/tasks/workload/configuration.cr
@@ -135,14 +135,15 @@ task "ip_addresses" do |_, args|
         end
       end
       Dir.cd(cdir)
-      parsed_resp = response.to_s.split("\n")
+      parsed_resp = response.to_s
       if parsed_resp.size > 0
+        response_lines = parsed_resp.split("\n")
         stdout_failure("Lines with hard-coded IP addresses:")
-        parsed_resp.each do |line|
+        response_lines.each do |line|
           line_parts = line.split(":")
           file_name = line_parts.shift()
           matching_line = line_parts.join(":").strip()
-          stdout_failure("  * In file: #{file_name}: #{matching_line}")
+          stdout_failure("  * In file #{file_name}: #{matching_line}")
         end
         resp = upsert_failed_task("ip_addresses","✖️  FAILED: IP addresses found")
       else

--- a/src/tasks/workload/configuration.cr
+++ b/src/tasks/workload/configuration.cr
@@ -137,8 +137,13 @@ task "ip_addresses" do |_, args|
       Dir.cd(cdir)
       parsed_resp = response.to_s
       if parsed_resp.size > 0
-        puts "HARD CODED IP ADDRESSES".colorize(:red)
-        puts parsed_resp
+        stdout_failure("Lines with hard-coded IP addresses:")
+        parsed_resp.each do |line|
+          line_parts = line.split(":")
+          file_name = line_parts.shift()
+          matching_line = line_parts.join(":").strip()
+          stdout_failure("  * In file: #{file_name}: #{matching_line}")
+        end
         resp = upsert_failed_task("ip_addresses","✖️  FAILED: IP addresses found")
       else
         resp = upsert_passed_task("ip_addresses", "✔️  PASSED: No IP addresses found")

--- a/src/tasks/workload/configuration.cr
+++ b/src/tasks/workload/configuration.cr
@@ -135,7 +135,7 @@ task "ip_addresses" do |_, args|
         end
       end
       Dir.cd(cdir)
-      parsed_resp = response.to_s
+      parsed_resp = response.to_s.split("\n")
       if parsed_resp.size > 0
         stdout_failure("Lines with hard-coded IP addresses:")
         parsed_resp.each do |line|


### PR DESCRIPTION
## Issues:
Refs: #1583

## Description

* It looks like the white lines in the output of the `ip_addresses` test were intended to be shown to the user to fix the test.
* This PR improves the formatting of the output instead of outputting the raw grep output.

### Info for validation

> *The changes can be validated with the `lighty` branch, which has the testsuite config for the lighty-rnc CNF. The branch has the changes from this PR.*

```
# Run the test for the sample-coredns-cnf CNF (should pass the test)
#
./cnf-testsuite cnf_setup cnf-config=sample-cnfs/sample-coredns-cnf
./cnf-testsuite ip_addresses
./cnf-testsuite cnf_cleanup cnf-config=sample-cnfs/sample-coredns-cnf

# Run the test for the sample-rnc lighty CNF (should fail the test)
#
./cnf-testsuite cnf_setup cnf-config=sample-lighty-rnc/cnf-testsuite.yml
./cnf-testsuite ip_addresses
./cnf-testsuite cnf_cleanup cnf-config=sample-lighty-rnc/cnf-testsuite.yml
```

Screenshot below shows the output for both when the test passes and when it fails.

<img width="1601" alt="CleanShot 2022-08-01 at 16 48 59@2x" src="https://user-images.githubusercontent.com/84005/182137060-6868b364-2a52-4d71-a6eb-2662f75d4077.png">


## How has this been tested:
 - [x] Covered by existing integration testing
 - [ ] Added integration testing to cover
 - [ ] Verified all A/C passes
     * [ ] develop
     * [ ] master
     * [ ] tag/other branch
 - [ ] Test environment
    * [ ] Shared Packet K8s cluster
    * [ ] New Packet K8s cluster
    * [ ] Kind cluster
 - [ ] Have not tested

## Types of changes:
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [ ] Documentation update

## Checklist:
**Documentation**
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] No updates required.

**Code Review**
- [ ] Does the test handle fatal exceptions, ie. rescue block

**Issue**
- [ ] Tasks in issue are checked off
