### PR TITLE
[1604] GitHub Runners image upgrade (16 Aug 2022)

### DIFF
--- a/tools/github-runner/Dockerfile
+++ b/tools/github-runner/Dockerfile
@@ -1,4 +1,4 @@
-FROM myoung34/github-runner:2.294.0-ubuntu-bionic
+FROM myoung34/github-runner:2.295.0-ubuntu-bionic
 
 ARG CRYSTAL_VERSION=1.0.0
 ARG CRYSTAL_URL=https://github.com/crystal-lang/crystal/releases/download

--- a/tools/github-runner/create_runners.sh
+++ b/tools/github-runner/create_runners.sh
@@ -29,7 +29,7 @@ VIPS=(
 
 RUNNER_COUNT=0
 for node in "${!RUNNERS[@]}"; do
-    export RUNNER_IMAGE="conformance/github-runner:v2.294.0" # don't forget the v
+    export RUNNER_IMAGE="conformance/github-runner:v2.295.0" # don't forget the v
     ssh root@${RUNNERS[$node]} "docker pull $RUNNER_IMAGE"
     RUNNERS_PER_NODE=16
     until [ $RUNNERS_PER_NODE -eq 0 ]; do


### PR DESCRIPTION
## Description
Upgrades GitHub Runners base image to latest  version 2.295.0.

## Issues:
Refs: #1604

## How has this been tested:
 - [x] Covered by existing integration testing
 - [ ] Added integration testing to cover
 - [ ] Verified all A/C passes
     * [ ] develop
     * [ ] master
     * [ ] tag/other branch
 - [ ] Test environment
    * [ ] Shared Packet K8s cluster
    * [ ] New Packet K8s cluster
    * [ ] Kind cluster
 - [ ] Have not tested

## Types of changes:
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [ ] Documentation update

## Checklist:
**Documentation**
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] No updates required.

**Code Review**
- [ ] Does the test handle fatal exceptions, ie. rescue block

**Issue**
- [ ] Tasks in issue are checked off
