### PR TITLE
[1595, 1603] Update Kubescape test parser to return message about failed resources

### DIFF
--- a/src/tasks/utils/kubescape.cr
+++ b/src/tasks/utils/kubescape.cr
@@ -104,8 +104,8 @@ module Kubescape
 
       # If object is a cluster-wide resource then name is directly under root key.
       name = parse_k8s_object_name(
-        k8s_obj.dig("name"),
-        k8s_obj.dig("metadata", "name")
+        k8s_obj.dig?("name"),
+        k8s_obj.dig?("metadata", "name")
       )
 
       namespace = parse_k8s_object_namespace(k8s_obj.dig?("metadata", "namespace"))

--- a/src/tasks/utils/kubescape.cr
+++ b/src/tasks/utils/kubescape.cr
@@ -131,11 +131,11 @@ module Kubescape
     # Used if rule response alert message is an empty string
 
     def get_alert_message(name : String, kind : String, namespace : Nil)
-      "Failed resource: #{kind} #{name} in #{namespace}"
+      "Failed resource: #{kind} #{name}"
     end
 
     def get_alert_message(name : String, kind : String, namespace : String)
-      "Failed resource: #{kind} #{name} in #{namespace}"
+      "Failed resource: #{kind} #{name} in #{namespace} namespace"
     end
 
     def parse_k8s_object_name(name : Nil, metadata_name : JSON::Any) : String


### PR DESCRIPTION
## Issues
Refs: #1594, #1603

## Description
* Construct alert messages for Kubescape-based tests if `alertMessage` in the Kubescape test report is empty. This is required to display the failed resources to the user.
* Refactored Kubescape test report parser into new `Kubescape::TestReportParser`.

## Validations for Kubescape tests

### `privilege_escalation`  

```
# FAIL scenario
./cnf-testsuite cnf_setup cnf-config=./sample-cnfs/sample-privilege-escalation/cnf-testsuite.yml
./cnf-testsuite privilege_escalation
./cnf-testsuite cnf_cleanup cnf-config=./sample-cnfs/sample-privilege-escalation/cnf-testsuite.yml

# PASS scenario
./cnf-testsuite cnf_setup cnf-config=./sample-cnfs/sample-nonroot-containers/cnf-testsuite.yml
./cnf-testsuite privilege_escalation
./cnf-testsuite cnf_cleanup cnf-config=./sample-cnfs/sample-nonroot-containers/cnf-testsuite.yml
```

![image](https://user-images.githubusercontent.com/84005/184929002-d1734427-5f61-48d4-aeeb-6ac17adc73c1.png)


### `symlink_file_system`

```
# PASS scenario
./cnf-testsuite cnf_setup cnf-config=./sample-cnfs/sample-privilege-escalation/cnf-testsuite.yml
./cnf-testsuite symlink_file_system
./cnf-testsuite cnf_cleanup cnf-config=./sample-cnfs/sample-privilege-escalation/cnf-testsuite.yml
```

![image](https://user-images.githubusercontent.com/84005/184929029-d38e9a49-f9ed-4552-a53e-c10b3f6109d2.png)


### `application_credentials`  

```
# FAIL scenario
./cnf-testsuite cnf_setup cnf-config=./sample-cnfs/sample-appliciation-credentials/cnf-testsuite.yml
./cnf-testsuite application_credentials
./cnf-testsuite cnf_cleanup cnf-config=./sample-cnfs/sample-appliciation-credentials/cnf-testsuite.yml
```

![image](https://user-images.githubusercontent.com/84005/184929049-7569486b-d478-4a62-a065-943d13feb6cc.png)


### `host_network`  

```
# PASS scenario
./cnf-testsuite cnf_setup cnf-config=./sample-cnfs/sample-privilege-escalation/cnf-testsuite.yml
./cnf-testsuite host_network
./cnf-testsuite cnf_cleanup cnf-config=./sample-cnfs/sample-privilege-escalation/cnf-testsuite.yml
```

![image](https://user-images.githubusercontent.com/84005/184929075-7be8c869-3644-489a-a4ec-8690685fa957.png)


### `service_account_mapping` 

```
# FAIL scenario
./cnf-testsuite cnf_setup cnf-config=./sample-cnfs/sample-service-accounts/cnf-testsuite.yml
./cnf-testsuite service_account_mapping
./cnf-testsuite cnf_cleanup cnf-config=./sample-cnfs/sample-service-accounts/cnf-testsuite.yml
```

![image](https://user-images.githubusercontent.com/84005/184929094-bef6ba6f-c07e-4003-8686-f5617fdc8d72.png)


### `linux_hardening`  

```
# FAIL scenario
./cnf-testsuite cnf_setup cnf-config=./sample-cnfs/sample-coredns-cnf
./cnf-testsuite linux_hardening
./cnf-testsuite cnf_cleanup cnf-config=./sample-cnfs/sample-coredns-cnf
```

![image](https://user-images.githubusercontent.com/84005/184929111-496d0ad4-2b48-4fe8-9ec3-ae7524792757.png)


### `insecure_capabilities`  

```
# PASS scenario
./cnf-testsuite cnf_setup cnf-config=./sample-cnfs/sample-coredns-cnf
./cnf-testsuite insecure_capabilities
./cnf-testsuite cnf_cleanup cnf-config=./sample-cnfs/sample-coredns-cnf

# FAIL scenario
./cnf-testsuite cnf_setup cnf-config=./sample-cnfs/sample-insecure-capabilities/cnf-testsuite.yml
./cnf-testsuite insecure_capabilities
./cnf-testsuite cnf_cleanup cnf-config=./sample-cnfs/sample-insecure-capabilities/cnf-testsuite.yml
```

![image](https://user-images.githubusercontent.com/84005/184929135-0190cab4-7cfb-4fd6-b947-733dab972e99.png)

### `resource_policies`

```
# PASS scenario
./cnf-testsuite cnf_setup cnf-config=./sample-cnfs/sample-coredns-cnf
./cnf-testsuite resource_policies
./cnf-testsuite cnf_cleanup cnf-config=./sample-cnfs/sample-coredns-cnf
```

![image](https://user-images.githubusercontent.com/84005/184929175-71b1303a-06af-4af2-80fd-eb84b6e81a7a.png)

### `ingress_egress_blocked`

```
# FAIL scenario
./cnf-testsuite cnf_setup cnf-config=./sample-cnfs/sample-coredns-cnf
./cnf-testsuite ingress_egress_blocked
./cnf-testsuite cnf_cleanup cnf-config=./sample-cnfs/sample-coredns-cnf
```

![image](https://user-images.githubusercontent.com/84005/184928858-d8cb929c-faa8-4555-8b70-8987349acfe7.png)

### `host_pid_ipc_privileges`  

```
# PASS scenario
./cnf-testsuite cnf_setup cnf-config=./sample-cnfs/sample-coredns-cnf
./cnf-testsuite host_pid_ipc_privileges
./cnf-testsuite cnf_cleanup cnf-config=./sample-cnfs/sample-coredns-cnf
```

![image](https://user-images.githubusercontent.com/84005/184928807-f56a8543-ac15-4c7c-98da-3019fe2fca12.png)

### `non_root_containers`  

```
# PASS scenario
./cnf-testsuite cnf_setup cnf-config=./sample-cnfs/sample-nonroot-containers
./cnf-testsuite non_root_containers
./cnf-testsuite cnf_cleanup cnf-config=./sample-cnfs/sample-nonroot-containers

# FAIL scenario
./cnf-testsuite cnf_setup cnf-config=./sample-cnfs/sample-coredns-cnf
./cnf-testsuite non_root_containers
./cnf-testsuite cnf_cleanup cnf-config=./sample-cnfs/sample-coredns-cnf
```

![image](https://user-images.githubusercontent.com/84005/184928772-6dcce4cb-2512-4ed7-8845-5dbd4a67db86.png)


### `privileged_containers`  

```
# PASS scenario
./cnf-testsuite cnf_setup cnf-config=./sample-cnfs/sample-coredns-cnf
./cnf-testsuite privileged_containers
./cnf-testsuite cnf_cleanup cnf-config=./sample-cnfs/sample-coredns-cnf
```

![image](https://user-images.githubusercontent.com/84005/184928708-69f07dc8-b1cd-4efc-aa7e-73256dec9788.png)

### `immutable_file_systems`  

```
# PASS scenario
./cnf-testsuite cnf_setup cnf-config=./sample-cnfs/sample-immutable-fs
./cnf-testsuite immutable_file_systems
./cnf-testsuite cnf_cleanup cnf-config=./sample-cnfs/sample-immutable-fs

# FAIL scenario
./cnf-testsuite cnf_setup cnf-config=./sample-cnfs/sample-coredns-cnf
./cnf-testsuite immutable_file_systems
./cnf-testsuite cnf_cleanup cnf-config=./sample-cnfs/sample-coredns-cnf
```

![image](https://user-images.githubusercontent.com/84005/184928674-8498b67d-68b8-4a18-87c0-3a61987b80da.png)


### `hostpath_mounts`  

```
# PASS scenario
./cnf-testsuite cnf_setup cnf-config=./sample-cnfs/sample-coredns-cnf
./cnf-testsuite hostpath_mounts
./cnf-testsuite cnf_cleanup cnf-config=./sample-cnfs/sample-coredns-cnf

# FAIL scenario
./cnf-testsuite cnf_setup cnf-config=./sample-cnfs/sample-hostpath
./cnf-testsuite hostpath_mounts
./cnf-testsuite cnf_cleanup cnf-config=./sample-cnfs/sample-hostpath
```

![image](https://user-images.githubusercontent.com/84005/184928619-4eb4f181-485f-4052-9311-5c24dc0320a7.png)

### `control_plane_hardening` (Platform test)  

```
./cnf-testsuite platform:control_plane_hardening
```

![image](https://user-images.githubusercontent.com/84005/184928584-30490010-4097-491d-a1bc-3585bd63fdb5.png)


### `cluster_admin` (Platform test)  

```
./cnf-testsuite platform:cluster_admin
```

![image](https://user-images.githubusercontent.com/84005/184928478-716bd7ff-562b-49ad-bc86-a6dd959149ee.png)


### `exposed_dashboard` (Platform test)

```
# PASS scenario
./cnf-testsuite platform:exposed_dashboard

# FAIL scenario
kubectl apply -f https://raw.githubusercontent.com/kubernetes/dashboard/v2.0.0/aio/deploy/recommended.yaml
kubectl patch service kubernetes-dashboard \
	 -n kubernetes-dashboard \
	 -p '{"spec":{"type":"NodePort","ports":[{"nodePort":30500,"port":443,"protocol":"TCP","targetPort":8443}]}}'
./cnf-testsuite platform:exposed_dashboard
```

![image](https://user-images.githubusercontent.com/84005/184928416-7c0fb1eb-a079-4c7d-a1f6-6af6001c9b3e.png)


## How has this been tested:
 - [x] Covered by existing integration testing
 - [ ] Added integration testing to cover
 - [ ] Verified all A/C passes
     * [ ] develop
     * [ ] master
     * [ ] tag/other branch
 - [ ] Test environment
    * [ ] Shared Packet K8s cluster
    * [ ] New Packet K8s cluster
    * [ ] Kind cluster
 - [ ] Have not tested

## Types of changes:
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [ ] Documentation update

## Checklist:
**Documentation**
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] No updates required.

**Code Review**
- [ ] Does the test handle fatal exceptions, ie. rescue block

**Issue**
- [ ] Tasks in issue are checked off
