### PR TITLE
[bug/1600] `cni_compatible` no longer outputs docker version info to stdout

### DIFF
--- a/spec/utils/system_information/docker_spec.cr
+++ b/spec/utils/system_information/docker_spec.cr
@@ -16,9 +16,9 @@ describe "Docker" do
     (docker_local_response(true)).should eq("") 
   end
 
-  it "'docker_version()' should return the information about the docker version", tags: ["docker-prereq"]  do
-    (docker_version(docker_global_response)).should match(/(([0-9]{1,3}[\.]){1,2}[0-9]{1,3})/)
-    (docker_version(docker_local_response)).should contain("")
+  it "'parse_docker_version()' should return the information about the docker version", tags: ["docker-prereq"]  do
+    (parse_docker_version(docker_global_response)).should match(/(([0-9]{1,3}[\.]){1,2}[0-9]{1,3})/)
+    (parse_docker_version(docker_local_response)).should contain("")
   end
 
   it "'docker_version_info()' should return the information about the docker installation", tags: ["docker-prereq"]  do

--- a/spec/utils/system_information/docker_spec.cr
+++ b/spec/utils/system_information/docker_spec.cr
@@ -21,7 +21,9 @@ describe "Docker" do
     (docker_version(docker_local_response)).should contain("")
   end
 
-  it "'docker_installations()' should return the information about the docker installation", tags: ["docker-prereq"]  do
-    (docker_installation(true)).should contain("docker found")
+  it "'docker_version_info()' should return the information about the docker installation", tags: ["docker-prereq"]  do
+    docker_version = docker_version_info()
+    typeof(docker_version).should eq(DockerVersion)
+    typeof(docker_version.installed?).should eq(Bool)
   end
 end

--- a/src/tasks/workload/compatibility.cr
+++ b/src/tasks/workload/compatibility.cr
@@ -616,32 +616,31 @@ task "cni_compatible" do |_, args|
 
     docker_condition = docker_installation.includes?("docker found") 
     if docker_condition
+      ensure_kubeconfig!
+      kubeconfig_orig = ENV["KUBECONFIG"]
 
-    ensure_kubeconfig!
-    kubeconfig_orig = ENV["KUBECONFIG"]
+      if args.named["offline"]? && args.named["offline"]? != "false"
+        offline = true
+      else
+        offline = false
+      end
 
-    if args.named["offline"]? && args.named["offline"]? != "false"
-      offline = true
-    else
-      offline = false
-    end
+      calico_cluster = setup_calico_cluster("calico-test", offline)
+      Log.info { "calico kubeconfig: #{calico_cluster.kubeconfig}" }
+      calico_cnf_passed = CNFManager.cnf_to_new_cluster(config, calico_cluster.kubeconfig, offline)
+      Log.info { "calico_cnf_passed: #{calico_cnf_passed}" }
+      puts "CNF failed to install on Calico CNI cluster".colorize(:red) unless calico_cnf_passed
 
-    calico_cluster = setup_calico_cluster("calico-test", offline)
-    Log.info { "calico kubeconfig: #{calico_cluster.kubeconfig}" }
-    calico_cnf_passed = CNFManager.cnf_to_new_cluster(config, calico_cluster.kubeconfig, offline)
-    Log.info { "calico_cnf_passed: #{calico_cnf_passed}" }
-    puts "CNF failed to install on Calico CNI cluster".colorize(:red) unless calico_cnf_passed
+      cilium_cluster = setup_cilium_cluster("cilium-test", offline)
+      cilium_cnf_passed = CNFManager.cnf_to_new_cluster(config, cilium_cluster.kubeconfig, offline)
+      Log.info { "cilium_cnf_passed: #{cilium_cnf_passed}" }
+      puts "CNF failed to install on Cilium CNI cluster".colorize(:red) unless cilium_cnf_passed
 
-    cilium_cluster = setup_cilium_cluster("cilium-test", offline)
-    cilium_cnf_passed = CNFManager.cnf_to_new_cluster(config, cilium_cluster.kubeconfig, offline)
-    Log.info { "cilium_cnf_passed: #{cilium_cnf_passed}" }
-    puts "CNF failed to install on Cilium CNI cluster".colorize(:red) unless cilium_cnf_passed
-
-    if calico_cnf_passed && cilium_cnf_passed
-      upsert_passed_task("cni_compatible", "✔️  PASSED: CNF compatible with both Calico and Cilium #{emoji_security}")
-    else
-      upsert_failed_task("cni_compatible", "✖️  FAILED: CNF not compatible with either Calico or Cillium #{emoji_security}")
-    end
+      if calico_cnf_passed && cilium_cnf_passed
+        upsert_passed_task("cni_compatible", "✔️  PASSED: CNF compatible with both Calico and Cilium #{emoji_security}")
+      else
+        upsert_failed_task("cni_compatible", "✖️  FAILED: CNF not compatible with either Calico or Cillium #{emoji_security}")
+      end
     else
       upsert_skipped_task("cni_compatible", "✖️  SKIPPED: Docker not installed #{emoji_security}")
     end

--- a/src/tasks/workload/compatibility.cr
+++ b/src/tasks/workload/compatibility.cr
@@ -609,13 +609,11 @@ end
 desc "CNFs should work with any Certified Kubernetes product and any CNI-compatible network that meet their functionality requirements."
 task "cni_compatible" do |_, args|
   CNFManager::Task.task_runner(args) do |args, config|
-
     Log.for("verbose").info { "cni_compatible" } if check_verbose(args)
-
     emoji_security="🔓🔑"
 
-    docker_condition = docker_installation.includes?("docker found") 
-    if docker_condition
+    docker_version = docker_version_info()
+    if docker_version.installed?
       ensure_kubeconfig!
       kubeconfig_orig = ENV["KUBECONFIG"]
 


### PR DESCRIPTION
## Issues
Refs: #1600

## Description
* Adds `DockerVersion` class with an `installed?` method.
* Renames `docker_installation` helper to `docker_version_info`.
* `docker_version_info` returns a new `DockerVersion` object.
* Updates `cni_compatible` test to use the new `docker_version_info` helper
* Updates specs for the docker helpers to check for `docker_version_info` helper.
* Renames `docker_version` to `parse_docker_version`

## Validation for the `cni_compatible` test

```
./cnf-testsuite cnf_setup cnf-config=./sample-cnfs/sample-coredns-cnf
./cnf-testsuite cni_compatible
```

![CleanShot 2022-08-17 at 20 25 43@2x](https://user-images.githubusercontent.com/84005/185172510-0a77d3d5-433b-45b2-8ef9-0bdc4130f07d.png)


## How has this been tested:
 - [x] Covered by existing integration testing
 - [ ] Added integration testing to cover
 - [ ] Verified all A/C passes
     * [ ] develop
     * [ ] master
     * [ ] tag/other branch
 - [ ] Test environment
    * [ ] Shared Packet K8s cluster
    * [ ] New Packet K8s cluster
    * [ ] Kind cluster
 - [ ] Have not tested

## Types of changes:
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [ ] Documentation update

## Checklist:
**Documentation**
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] No updates required.

**Code Review**
- [ ] Does the test handle fatal exceptions, ie. rescue block

**Issue**
- [ ] Tasks in issue are checked off
