### PR TITLE
[1610] Add `install_cluster_tools` as dependency for `routed_logs`

### DIFF
--- a/src/tasks/workload/observability.cr
+++ b/src/tasks/workload/observability.cr
@@ -172,7 +172,7 @@ task "open_metrics", ["prometheus_traffic"] do |_, args|
 end
 
 desc "Are the CNF's logs captured by a logging system"
-task "routed_logs" do |_, args|
+task "routed_logs", ["install_cluster_tools"] do |_, args|
   Log.info { "Running: routed_logs" }
   next if args.named["offline"]?
     emoji_observability="📶☠️"


### PR DESCRIPTION
## Issues
Refs: #1610

## Description
When `routed_logs` is run after any test that uninstalls ClusterTools, then the test fails with an error.
This PR adds a task dependency to install ClusterTools before running the `routed_logs` test.

## To reproduce reported issue

```
# routed_logs test requires fluentd or fluent-bit to be installed to run as expected.
helm repo add fluent https://fluent.github.io/helm-charts
helm install --values ./embedded_files/fluentbit-config.yml -n cnf-testsuite fluent-bit fluent/fluent-bit

# Install sample CNF
./cnf-testsuite cnf_setup cnf-path=sample-cnfs/sample_coredns

# This test uninstalls ClusterTools
./cnf-testsuite host_network

# This test requires ClusterTools
./cnf-testsuite routed_logs
```

![CleanShot 2022-09-06 at 05 00 37](https://user-images.githubusercontent.com/84005/188520546-42aab9ec-5d40-4aa5-b2b4-84abc5f6eb41.png)

## Validate changes in PR

![CleanShot 2022-09-06 at 05 02 12](https://user-images.githubusercontent.com/84005/188520609-88f26c2a-cafc-48d7-b131-440a0e128ad7.png)


## How has this been tested:
 - [x] Covered by existing integration testing
 - [ ] Added integration testing to cover
 - [ ] Verified all A/C passes
     * [ ] develop
     * [ ] master
     * [ ] tag/other branch
 - [ ] Test environment
    * [ ] Shared Packet K8s cluster
    * [ ] New Packet K8s cluster
    * [ ] Kind cluster
 - [ ] Have not tested

## Types of changes:
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [ ] Documentation update

## Checklist:
**Documentation**
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] No updates required.

**Code Review**
- [ ] Does the test handle fatal exceptions, ie. rescue block

**Issue**
- [ ] Tasks in issue are checked off
