### PR TITLE
[1631, 1630] Fix GitHub Actions Runner issues

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -196,6 +196,14 @@ jobs:
       uses: actions/checkout@v2
       with:
         fetch-depth: 0
+    - name: "Install kind v0.14 as a temporary workaround"
+      run: |
+        wget https://github.com/kubernetes-sigs/kind/releases/download/v0.14.0/kind-linux-amd64 && \
+        mkdir ${GITHUB_WORKSPACE}/kind && \
+        mv kind-linux-amd64 ${GITHUB_WORKSPACE}/kind/kind && \
+        chmod +x ${GITHUB_WORKSPACE}/kind/kind && \
+        echo "Current PATH is: $PATH" && \
+        echo "${GITHUB_WORKSPACE}/kind" >> $GITHUB_PATH
     - name: Create Kind Cluster 
       run: |
         cat << EOF > /tmp/cluster.yml

--- a/tools/github-runner/Dockerfile
+++ b/tools/github-runner/Dockerfile
@@ -3,6 +3,12 @@ FROM myoung34/github-runner:2.296.1-ubuntu-bionic
 ARG CRYSTAL_VERSION=1.0.0
 ARG CRYSTAL_URL=https://github.com/crystal-lang/crystal/releases/download
 
+RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg --output /usr/share/keyrings/githubcli-archive-keyring.gpg && \
+    sudo gpg --dearmor /usr/share/keyrings/githubcli-archive-keyring.gpg && \
+    echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | tee /etc/apt/sources.list.d/github-cli.list && \
+    chmod 644 /usr/share/keyrings/githubcli-archive-keyring.gpg && \
+    chmod 644 /etc/apt/sources.list.d/github-cli.list
+
 RUN wget -O crystal.deb "$CRYSTAL_URL/$CRYSTAL_VERSION/crystal_$CRYSTAL_VERSION-1_amd64.deb" --progress=dot:giga && \
     apt update && \
     apt install -y --no-install-recommends \

--- a/tools/github-runner/Dockerfile
+++ b/tools/github-runner/Dockerfile
@@ -1,4 +1,4 @@
-FROM myoung34/github-runner:2.295.0-ubuntu-bionic
+FROM myoung34/github-runner:2.296.1-ubuntu-bionic
 
 ARG CRYSTAL_VERSION=1.0.0
 ARG CRYSTAL_URL=https://github.com/crystal-lang/crystal/releases/download

--- a/tools/github-runner/create_runners.sh
+++ b/tools/github-runner/create_runners.sh
@@ -29,7 +29,7 @@ VIPS=(
 
 RUNNER_COUNT=0
 for node in "${!RUNNERS[@]}"; do
-    export RUNNER_IMAGE="conformance/github-runner:v2.296.1" # don't forget the v
+    export RUNNER_IMAGE="hashnuke/conformance-gh-runner:v2.296.1" # don't forget the v
     ssh root@${RUNNERS[$node]} "docker pull $RUNNER_IMAGE"
     RUNNERS_PER_NODE=4
     until [ $RUNNERS_PER_NODE -eq 0 ]; do

--- a/tools/github-runner/create_runners.sh
+++ b/tools/github-runner/create_runners.sh
@@ -29,7 +29,7 @@ VIPS=(
 
 RUNNER_COUNT=0
 for node in "${!RUNNERS[@]}"; do
-    export RUNNER_IMAGE="conformance/github-runner:v2.295.0" # don't forget the v
+    export RUNNER_IMAGE="conformance/github-runner:v2.296.1" # don't forget the v
     ssh root@${RUNNERS[$node]} "docker pull $RUNNER_IMAGE"
     RUNNERS_PER_NODE=4
     until [ $RUNNERS_PER_NODE -eq 0 ]; do

--- a/tools/github-runner/create_runners.sh
+++ b/tools/github-runner/create_runners.sh
@@ -29,7 +29,7 @@ VIPS=(
 
 RUNNER_COUNT=0
 for node in "${!RUNNERS[@]}"; do
-    export RUNNER_IMAGE="hashnuke/conformance-gh-runner:v2.296.1" # don't forget the v
+    export RUNNER_IMAGE="conformance/github-runner:v2.296.1" # don't forget the v
     ssh root@${RUNNERS[$node]} "docker pull $RUNNER_IMAGE"
     RUNNERS_PER_NODE=4
     until [ $RUNNERS_PER_NODE -eq 0 ]; do


### PR DESCRIPTION
## Issues
Refs: #1630, #1631

## Description
* [1630] Add GitHub gpg keys to the GitHub Actions Runner image.
* [1631] Updates GitHub Actions Runner to use base image to `myoung34/github-runner:2.296.1-ubuntu-bionic`
* Updates the create runners script to use the new image

Workers have already been recreated to with an updated fork of the image.

## How has this been tested:
 - [x] Covered by existing integration testing
 - [ ] Added integration testing to cover
 - [ ] Verified all A/C passes
     * [ ] develop
     * [ ] master
     * [ ] tag/other branch
 - [ ] Test environment
    * [ ] Shared Packet K8s cluster
    * [ ] New Packet K8s cluster
    * [ ] Kind cluster
 - [ ] Have not tested

## Types of changes:
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [ ] Documentation update

## Checklist:
**Documentation**
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] No updates required.

**Code Review**
- [ ] Does the test handle fatal exceptions, ie. rescue block

**Issue**
- [ ] Tasks in issue are checked off
