### PR TITLE
[1633] Updates to Github Actions config to allow Chaos specs to run on kind v0.15

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -196,14 +196,6 @@ jobs:
       uses: actions/checkout@v2
       with:
         fetch-depth: 0
-    - name: "Install kind v0.14 as a temporary workaround"
-      run: |
-        wget https://github.com/kubernetes-sigs/kind/releases/download/v0.14.0/kind-linux-amd64 && \
-        mkdir ${GITHUB_WORKSPACE}/kind && \
-        mv kind-linux-amd64 ${GITHUB_WORKSPACE}/kind/kind && \
-        chmod +x ${GITHUB_WORKSPACE}/kind/kind && \
-        echo "Current PATH is: $PATH" && \
-        echo "${GITHUB_WORKSPACE}/kind" >> $GITHUB_PATH
     - name: Create Kind Cluster 
       run: |
         cat << EOF > /tmp/cluster.yml
@@ -269,7 +261,7 @@ jobs:
             sleep 1
         done
 
-        CLUSTER_RATE_LIMIT=$(kubectl run tmp-shell --restart=Never --rm -i --tty --image ubuntu -- /bin/bash -c "apt update && apt install -y curl jq; export BEARER_TOKEN=\$(curl \"https://auth.docker.io/token?service=registry.docker.io&scope=repository:ratelimitpreview/test:pull\" | jq -r .token); echo \$BEARER_TOKEN; curl --head -H \"Authorization: Bearer \$BEARER_TOKEN\" https://registry-1.docker.io/v2/ratelimitpreview/test/manifests/latest" | grep ratelimit-remaining || true)
+        CLUSTER_RATE_LIMIT=$(kubectl run -it tmp-shell --restart=Never --rm --image ubuntu -- /bin/bash -c "apt update -y && apt install -y curl jq; export BEARER_TOKEN=\$(curl \"https://auth.docker.io/token?service=registry.docker.io&scope=repository:ratelimitpreview/test:pull\" | jq -r .token); echo \$BEARER_TOKEN; curl --head -H \"Authorization: Bearer \$BEARER_TOKEN\" https://registry-1.docker.io/v2/ratelimitpreview/test/manifests/latest" | grep ratelimit-remaining || true)
 
         TOKEN=$(curl "https://auth.docker.io/token?service=registry.docker.io&scope=repository:ratelimitpreview/test:pull" | jq -r .token || true)
         ANONYMOUS_RUNNER_RATE_LIMIT=$(curl --head -H "Authorization: Bearer $TOKEN" https://registry-1.docker.io/v2/ratelimitpreview/test/manifests/latest | grep ratelimit-remaining || echo "Runner Rate Limit Exceeded: $RUNNER_NAME")

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -251,7 +251,7 @@ jobs:
             sleep 1
         done
 
-        CLUSTER_RATE_LIMIT=$(kubectl run -i tmp-shell --restart=Never --rm --image ubuntu -- /bin/bash -c "apt update && apt install -y curl jq; export BEARER_TOKEN=\$(curl \"https://auth.docker.io/token?service=registry.docker.io&scope=repository:ratelimitpreview/test:pull\" | jq -r .token); echo \"Cluster token: \$BEARER_TOKEN"; curl --head -H \"Authorization: Bearer \$BEARER_TOKEN\" https://registry-1.docker.io/v2/ratelimitpreview/test/manifests/latest" | grep ratelimit-remaining || true)
+        CLUSTER_RATE_LIMIT=$(kubectl run -i tmp-shell --restart=Never --rm --image ubuntu -- /bin/bash -c "apt update && apt install -y curl jq; export BEARER_TOKEN=\$(curl \"https://auth.docker.io/token?service=registry.docker.io&scope=repository:ratelimitpreview/test:pull\" | jq -r .token); curl --head -H \"Authorization: Bearer \$BEARER_TOKEN\" https://registry-1.docker.io/v2/ratelimitpreview/test/manifests/latest" | grep ratelimit-remaining || true)
 
         TOKEN=$(curl "https://auth.docker.io/token?service=registry.docker.io&scope=repository:ratelimitpreview/test:pull" | jq -r .token || true)
         ANONYMOUS_RUNNER_RATE_LIMIT=$(curl --head -H "Authorization: Bearer $TOKEN" https://registry-1.docker.io/v2/ratelimitpreview/test/manifests/latest | grep ratelimit-remaining || echo "Runner Rate Limit Exceeded: $RUNNER_NAME")

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -251,10 +251,6 @@ jobs:
             sleep 1
         done
 
-        echo "CLUSTER_RATE_LIMIT_TEST"
-        kubectl run -i tmp-shell --restart=Never --rm --image ubuntu -- /bin/bash -c "apt update && apt install -y curl jq; curl \"https://auth.docker.io/token?service=registry.docker.io&scope=repository:ratelimitpreview/test:pull\""
-        echo "END CLUSTER_RATE_LIMIT_TEST"
-
         CLUSTER_RATE_LIMIT=$(kubectl run -i tmp-shell --restart=Never --rm --image ubuntu -- /bin/bash -c "apt update && apt install -y curl jq; export BEARER_TOKEN=\$(curl \"https://auth.docker.io/token?service=registry.docker.io&scope=repository:ratelimitpreview/test:pull\" | jq -r .token); echo \"Cluster token: \$BEARER_TOKEN"; curl --head -H \"Authorization: Bearer \$BEARER_TOKEN\" https://registry-1.docker.io/v2/ratelimitpreview/test/manifests/latest" | grep ratelimit-remaining || true)
 
         TOKEN=$(curl "https://auth.docker.io/token?service=registry.docker.io&scope=repository:ratelimitpreview/test:pull" | jq -r .token || true)

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -258,6 +258,7 @@ jobs:
             echo "Waiting for kindnet"
             sleep 1
         done
+
         LOCAL_PATH_STORAGE_POD=$(kubectl get pods -l app=kindnet --namespace=kube-system -o jsonpath='{range .items[*]}{.metadata.name}')
         until [[ $(kubectl exec -ti $LOCAL_PATH_STORAGE_POD --namespace=kube-system -- apt update) ]]; do
             echo "Failed to update repositories, retrying"
@@ -267,14 +268,16 @@ jobs:
             echo "Failed to install packages, retrying"
             sleep 1
         done
-        CLUSTER_RATE_LIMIT=$(kubectl exec -ti $LOCAL_PATH_STORAGE_POD --namespace=kube-system -- curl --head -H "Authorization: Bearer $(curl "https://auth.docker.io/token?service=registry.docker.io&scope=repository:ratelimitpreview/test:pull" | jq -r .token)" https://registry-1.docker.io/v2/ratelimitpreview/test/manifests/latest | grep ratelimit-remaining || true)
+
+        CLUSTER_RATE_LIMIT=$(kubectl run tmp-shell --restart=Never --rm -i --tty --image ubuntu -- /bin/bash -c "apt update && apt install -y curl jq; export BEARER_TOKEN=\$(curl \"https://auth.docker.io/token?service=registry.docker.io&scope=repository:ratelimitpreview/test:pull\" | jq -r .token); echo \$BEARER_TOKEN; curl --head -H \"Authorization: Bearer \$BEARER_TOKEN\" https://registry-1.docker.io/v2/ratelimitpreview/test/manifests/latest" | grep ratelimit-remaining || true)
+
         TOKEN=$(curl "https://auth.docker.io/token?service=registry.docker.io&scope=repository:ratelimitpreview/test:pull" | jq -r .token || true)
         ANONYMOUS_RUNNER_RATE_LIMIT=$(curl --head -H "Authorization: Bearer $TOKEN" https://registry-1.docker.io/v2/ratelimitpreview/test/manifests/latest | grep ratelimit-remaining || echo "Runner Rate Limit Exceeded: $RUNNER_NAME")
         TOKEN=$(curl --user "$DOCKERHUB_USERNAME:$DOCKERHUB_PASSWORD" "https://auth.docker.io/token?service=registry.docker.io&scope=repository:ratelimitpreview/test:pull" | jq -r .token)
         AUTH_RATE_LIMIT=$(curl --head -H "Authorization: Bearer $TOKEN" https://registry-1.docker.io/v2/ratelimitpreview/test/manifests/latest | grep ratelimit-remaining || echo "Authenticated Rate Limit Exceeded")
         echo "RUNNER RATE LIMIT: $ANONYMOUS_RUNNER_RATE_LIMIT"
-        echo "CLUSTER RATE LIMIT: $CLUSTER_RATE_LIMIT" 
-        echo "DOCKER USER RATE LIMIT: $AUTH_RATE_LIMIT" 
+        echo "CLUSTER RATE LIMIT: $CLUSTER_RATE_LIMIT"
+        echo "DOCKER USER RATE LIMIT: $AUTH_RATE_LIMIT"
         LOG_LEVEL=info crystal spec --warnings none --tag ${{ matrix.tag }} -v
   # chaos-airgapped:
   #   name: Chaos Tests Airgapped

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -251,7 +251,7 @@ jobs:
             sleep 1
         done
 
-        CLUSTER_RATE_LIMIT=$(kubectl run -it tmp-shell --restart=Never --rm --image ubuntu -- /bin/bash -c "apt update && apt install -y curl jq; export BEARER_TOKEN=\$(curl \"https://auth.docker.io/token?service=registry.docker.io&scope=repository:ratelimitpreview/test:pull\" | jq -r .token); echo \$BEARER_TOKEN; curl --head -H \"Authorization: Bearer \$BEARER_TOKEN\" https://registry-1.docker.io/v2/ratelimitpreview/test/manifests/latest" | grep ratelimit-remaining || true)
+        CLUSTER_RATE_LIMIT=$(kubectl run -i tmp-shell --restart=Never --rm --image ubuntu -- /bin/bash -c "apt update && apt install -y curl jq; export BEARER_TOKEN=\$(curl \"https://auth.docker.io/token?service=registry.docker.io&scope=repository:ratelimitpreview/test:pull\" | jq -r .token); echo \$BEARER_TOKEN; curl --head -H \"Authorization: Bearer \$BEARER_TOKEN\" https://registry-1.docker.io/v2/ratelimitpreview/test/manifests/latest" | grep ratelimit-remaining || true)
 
         TOKEN=$(curl "https://auth.docker.io/token?service=registry.docker.io&scope=repository:ratelimitpreview/test:pull" | jq -r .token || true)
         ANONYMOUS_RUNNER_RATE_LIMIT=$(curl --head -H "Authorization: Bearer $TOKEN" https://registry-1.docker.io/v2/ratelimitpreview/test/manifests/latest | grep ratelimit-remaining || echo "Runner Rate Limit Exceeded: $RUNNER_NAME")

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -251,7 +251,11 @@ jobs:
             sleep 1
         done
 
-        CLUSTER_RATE_LIMIT=$(kubectl run -i tmp-shell --restart=Never --rm --image ubuntu -- /bin/bash -c "apt update && apt install -y curl jq; export BEARER_TOKEN=\$(curl \"https://auth.docker.io/token?service=registry.docker.io&scope=repository:ratelimitpreview/test:pull\" | jq -r .token); echo \$BEARER_TOKEN; curl --head -H \"Authorization: Bearer \$BEARER_TOKEN\" https://registry-1.docker.io/v2/ratelimitpreview/test/manifests/latest" | grep ratelimit-remaining || true)
+        echo "CLUSTER_RATE_LIMIT_TEST"
+        kubectl run -i tmp-shell --restart=Never --rm --image ubuntu -- /bin/bash -c "apt update && apt install -y curl jq; curl \"https://auth.docker.io/token?service=registry.docker.io&scope=repository:ratelimitpreview/test:pull\"
+        echo "END CLUSTER_RATE_LIMIT_TEST"
+
+        CLUSTER_RATE_LIMIT=$(kubectl run -i tmp-shell --restart=Never --rm --image ubuntu -- /bin/bash -c "apt update && apt install -y curl jq; export BEARER_TOKEN=\$(curl \"https://auth.docker.io/token?service=registry.docker.io&scope=repository:ratelimitpreview/test:pull\" | jq -r .token); echo \"Cluster token: \$BEARER_TOKEN"; curl --head -H \"Authorization: Bearer \$BEARER_TOKEN\" https://registry-1.docker.io/v2/ratelimitpreview/test/manifests/latest" | grep ratelimit-remaining || true)
 
         TOKEN=$(curl "https://auth.docker.io/token?service=registry.docker.io&scope=repository:ratelimitpreview/test:pull" | jq -r .token || true)
         ANONYMOUS_RUNNER_RATE_LIMIT=$(curl --head -H "Authorization: Bearer $TOKEN" https://registry-1.docker.io/v2/ratelimitpreview/test/manifests/latest | grep ratelimit-remaining || echo "Runner Rate Limit Exceeded: $RUNNER_NAME")

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -252,7 +252,7 @@ jobs:
         done
 
         echo "CLUSTER_RATE_LIMIT_TEST"
-        kubectl run -i tmp-shell --restart=Never --rm --image ubuntu -- /bin/bash -c "apt update && apt install -y curl jq; curl \"https://auth.docker.io/token?service=registry.docker.io&scope=repository:ratelimitpreview/test:pull\"
+        kubectl run -i tmp-shell --restart=Never --rm --image ubuntu -- /bin/bash -c "apt update && apt install -y curl jq; curl \"https://auth.docker.io/token?service=registry.docker.io&scope=repository:ratelimitpreview/test:pull\""
         echo "END CLUSTER_RATE_LIMIT_TEST"
 
         CLUSTER_RATE_LIMIT=$(kubectl run -i tmp-shell --restart=Never --rm --image ubuntu -- /bin/bash -c "apt update && apt install -y curl jq; export BEARER_TOKEN=\$(curl \"https://auth.docker.io/token?service=registry.docker.io&scope=repository:ratelimitpreview/test:pull\" | jq -r .token); echo \"Cluster token: \$BEARER_TOKEN"; curl --head -H \"Authorization: Bearer \$BEARER_TOKEN\" https://registry-1.docker.io/v2/ratelimitpreview/test/manifests/latest" | grep ratelimit-remaining || true)

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -251,17 +251,7 @@ jobs:
             sleep 1
         done
 
-        LOCAL_PATH_STORAGE_POD=$(kubectl get pods -l app=kindnet --namespace=kube-system -o jsonpath='{range .items[*]}{.metadata.name}')
-        until [[ $(kubectl exec -ti $LOCAL_PATH_STORAGE_POD --namespace=kube-system -- apt update) ]]; do
-            echo "Failed to update repositories, retrying"
-            sleep 1
-        done
-        until [[ $(kubectl exec -ti $LOCAL_PATH_STORAGE_POD --namespace=kube-system -- apt install -y curl jq) ]]; do
-            echo "Failed to install packages, retrying"
-            sleep 1
-        done
-
-        CLUSTER_RATE_LIMIT=$(kubectl run -it tmp-shell --restart=Never --rm --image ubuntu -- /bin/bash -c "apt update -y && apt install -y curl jq; export BEARER_TOKEN=\$(curl \"https://auth.docker.io/token?service=registry.docker.io&scope=repository:ratelimitpreview/test:pull\" | jq -r .token); echo \$BEARER_TOKEN; curl --head -H \"Authorization: Bearer \$BEARER_TOKEN\" https://registry-1.docker.io/v2/ratelimitpreview/test/manifests/latest" | grep ratelimit-remaining || true)
+        CLUSTER_RATE_LIMIT=$(kubectl run -it tmp-shell --restart=Never --rm --image ubuntu -- /bin/bash -c "apt update && apt install -y curl jq; export BEARER_TOKEN=\$(curl \"https://auth.docker.io/token?service=registry.docker.io&scope=repository:ratelimitpreview/test:pull\" | jq -r .token); echo \$BEARER_TOKEN; curl --head -H \"Authorization: Bearer \$BEARER_TOKEN\" https://registry-1.docker.io/v2/ratelimitpreview/test/manifests/latest" | grep ratelimit-remaining || true)
 
         TOKEN=$(curl "https://auth.docker.io/token?service=registry.docker.io&scope=repository:ratelimitpreview/test:pull" | jq -r .token || true)
         ANONYMOUS_RUNNER_RATE_LIMIT=$(curl --head -H "Authorization: Bearer $TOKEN" https://registry-1.docker.io/v2/ratelimitpreview/test/manifests/latest | grep ratelimit-remaining || echo "Runner Rate Limit Exceeded: $RUNNER_NAME")

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -251,7 +251,7 @@ jobs:
             sleep 1
         done
 
-        CLUSTER_RATE_LIMIT=$(kubectl run -i tmp-shell --restart=Never --rm --image ubuntu -- /bin/bash -c "apt update && apt install -y curl jq; export BEARER_TOKEN=\$(curl \"https://auth.docker.io/token?service=registry.docker.io&scope=repository:ratelimitpreview/test:pull\" | jq -r .token); curl --head -H \"Authorization: Bearer \$BEARER_TOKEN\" https://registry-1.docker.io/v2/ratelimitpreview/test/manifests/latest" | grep ratelimit-remaining || true)
+        CLUSTER_RATE_LIMIT=$(kubectl run -i tmp-shell --restart=Never --rm --image ubuntu -- /bin/bash -c "apt update && apt install -y curl jq; curl --head -H \"Authorization: Bearer $(curl "https://auth.docker.io/token?service=registry.docker.io&scope=repository:ratelimitpreview/test:pull" | jq -r .token)\" https://registry-1.docker.io/v2/ratelimitpreview/test/manifests/latest" | grep ratelimit-remaining || true)
 
         TOKEN=$(curl "https://auth.docker.io/token?service=registry.docker.io&scope=repository:ratelimitpreview/test:pull" | jq -r .token || true)
         ANONYMOUS_RUNNER_RATE_LIMIT=$(curl --head -H "Authorization: Bearer $TOKEN" https://registry-1.docker.io/v2/ratelimitpreview/test/manifests/latest | grep ratelimit-remaining || echo "Runner Rate Limit Exceeded: $RUNNER_NAME")


### PR DESCRIPTION
## Issues:
Refs: #1633

## Description
* Uses kubectl-run with an Ubuntu image to check cluster rate limit.
* Removes kind v0.14 install patch from Chaos specs GitHub Actions config.

## How has this been tested:
 - [x] Covered by existing integration testing
 - [ ] Added integration testing to cover
 - [ ] Verified all A/C passes
     * [ ] develop
     * [ ] master
     * [ ] tag/other branch
 - [ ] Test environment
    * [ ] Shared Packet K8s cluster
    * [ ] New Packet K8s cluster
    * [ ] Kind cluster
 - [ ] Have not tested

## Types of changes:
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [ ] Documentation update

## Checklist:
**Documentation**
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] No updates required.

**Code Review**
- [ ] Does the test handle fatal exceptions, ie. rescue block

**Issue**
- [ ] Tasks in issue are checked off
