### PR TITLE
Office hours moved to Tuesday

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Welcome! We gladly accept contributions on new tests, example CNFs, updates to d
   - [#cnf-testsuite-dev](https://cloud-native.slack.com/archives/C014TNCEX8R)
 - Join the weekly Office Hours meeting
 
-  - Meetings every Thursday at 14:15 - 15:00 UTC (during Daylight Savings Time)
+  - Meetings every Tuesday at 14:15 - 15:00 UTC (during Daylight Savings Time)
   - Meeting minutes are [here](https://docs.google.com/document/d/1IbrgjqIkOCvrrSG0DRE6X62UUZpBq-818Mn8q0nkkd0/edit)
 
 - Join the weekly [CNF Working Group meeting](https://github.com/cncf/cnf-wg#recurring-meetings)


### PR DESCRIPTION
- Meetings every Tuesday at 14:15 - 15:00 UTC (during Daylight Savings Time)


Signed-off-by: Taylor Carpenter <taylor@vulk.coop>
