### PR TITLE
[#1668] ContainerID is not available when pod is being initialized on Kubernetes `1.25.0`

### DIFF
--- a/src/tasks/utils/kernel_instrospection.cr
+++ b/src/tasks/utils/kernel_instrospection.cr
@@ -262,9 +262,9 @@ module KernelIntrospection
               container_statuses = status["containerStatuses"].as_a
             Log.debug { "container_statuses: #{container_statuses}" }
             container_statuses.map do |container_status|
-              container_id = container_status.dig("containerID").as_s
               ready = container_status.dig("ready").as_bool
-              next unless ready 
+              next unless ready
+              container_id = container_status.dig("containerID").as_s
               pid = ClusterTools.node_pid_by_container_id(container_id, node)
               # there are some nodes that wont have a proc with this pid in it
               # e.g. a stand alone pod gets installed on only one node
@@ -299,9 +299,9 @@ module KernelIntrospection
             container_statuses = status["containerStatuses"].as_a
             Log.debug { "container_statuses: #{container_statuses}" }
             container_statuses.map do |container_status|
-              container_id = container_status.dig("containerID").as_s
               ready = container_status.dig("ready").as_bool
-              next unless ready 
+              next unless ready
+              container_id = container_status.dig("containerID").as_s
               pid = ClusterTools.node_pid_by_container_id(container_id, node)
               # there are some nodes that wont have a proc with this pid in it
               # e.g. a stand alone pod gets installed on only one node


### PR DESCRIPTION
## Issues:
Refs: #1668

## Description
When looking for prometheus, the containerID is not available for pods when the pods are being initialized. This cause a crash due to missing containerID key.

The change now looks for the containerID only if the pod is ready.

The crash reported in Issue-1668 can only be reproduced on Kubernetes 1.25.0. Version information below:

<img width="1918" alt="CleanShot 2022-10-05 at 09 32 47@2x" src="https://user-images.githubusercontent.com/84005/193978883-e032cbad-449a-449a-8d30-5665008fd298.png">


## Validation scenarios
![CleanShot 2022-10-05 at 09 04 48@2x](https://user-images.githubusercontent.com/84005/193978055-77593336-a268-46ca-ae32-e2f98fd5d2d2.png)

![CleanShot 2022-10-05 at 09 13 21@2x](https://user-images.githubusercontent.com/84005/193978088-1e323571-c050-4776-9989-fd3ef0d67847.png)

## How has this been tested:
 - [x] Covered by existing integration testing
 - [ ] Added integration testing to cover
 - [ ] Verified all A/C passes
     * [ ] develop
     * [ ] master
     * [ ] tag/other branch
 - [ ] Test environment
    * [ ] Shared Packet K8s cluster
    * [ ] New Packet K8s cluster
    * [ ] Kind cluster
 - [ ] Have not tested

## Types of changes:
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [ ] Documentation update

## Checklist:
**Documentation**
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] No updates required.

**Code Review**
- [ ] Does the test handle fatal exceptions, ie. rescue block

**Issue**
- [ ] Tasks in issue are checked off
