### PR TITLE
[#1670] Disable PSP when installing gatekeeper on k8s server >= v1.25.0

### DIFF
--- a/src/tasks/opa_setup.cr
+++ b/src/tasks/opa_setup.cr
@@ -9,14 +9,27 @@ OPA_OFFLINE_DIR = "#{TarClient::TAR_REPOSITORY_DIR}/gatekeeper_gatekeeper"
 
 desc "Sets up OPA in the K8s Cluster"
 task "install_opa", ["helm_local_install", "create_namespace"] do |_, args|
+  helm_install_args_list = [
+    "--set auditInterval=1",
+    "--set postInstall.labelNamespace.enabled=false",
+    "-n #{TESTSUITE_NAMESPACE}"
+  ]
+
+  k8s_server_version = KubectlClient.server_version
+  if !version_less_than(k8s_server_version, "1.25.0")
+    helm_install_args_list.push("--set psp.enabled=false")
+  end
+
+  helm_install_args = helm_install_args_list.join(" ")
+
   if args.named["offline"]?
     LOGGING.info "Intalling OPA Gatekeeper in Offline Mode"
     chart = Dir.entries(OPA_OFFLINE_DIR).first
-    Helm.install("--set auditInterval=1 --set postInstall.labelNamespace.enabled=false opa-gatekeeper #{OPA_OFFLINE_DIR}/#{chart} -n #{TESTSUITE_NAMESPACE}")
+    Helm.install("#{helm_install_args} opa-gatekeeper #{OPA_OFFLINE_DIR}/#{chart}")
   else
     Helm.helm_repo_add("gatekeeper", "https://open-policy-agent.github.io/gatekeeper/charts")
     begin
-      Helm.install("--set auditInterval=1 --set postInstall.labelNamespace.enabled=false opa-gatekeeper gatekeeper/gatekeeper -n #{TESTSUITE_NAMESPACE}")
+      Helm.install("#{helm_install_args} opa-gatekeeper gatekeeper/gatekeeper")
     rescue e : Helm::CannotReuseReleaseNameError
       stdout_warning "gatekeeper already installed"
     end


### PR DESCRIPTION
## Issues
Refs: #1670

## Description
Installing OPA on Kubernetes server v1.25.0 causes the testsuite to crash. This is required for the versioned_tag test to work.

PodSecurityPolicy has been removed in Kubernetes v1.25.0. It has to be disabled on Gatekeeper install by passing a value to the helm chart. The change in this PR checks the k8s version of the current cluster and sets the value for the gatekeeper helm chart if required.

## Validation

Checks `versioned_tag` test on different Kubernetes server versions.

![CleanShot 2022-10-05 at 14 30 03@2x](https://user-images.githubusercontent.com/84005/194022684-1298b267-b6ca-4196-b823-56dcca5d64cb.png)

![CleanShot 2022-10-05 at 14 31 47@2x](https://user-images.githubusercontent.com/84005/194022907-9c79aa26-bf98-4235-93b0-34a5ef849b0d.png)


## How has this been tested:
 - [x] Covered by existing integration testing
 - [ ] Added integration testing to cover
 - [ ] Verified all A/C passes
     * [ ] develop
     * [ ] master
     * [ ] tag/other branch
 - [ ] Test environment
    * [ ] Shared Packet K8s cluster
    * [ ] New Packet K8s cluster
    * [ ] Kind cluster
 - [ ] Have not tested

## Types of changes:
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [ ] Documentation update

## Checklist:
**Documentation**
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] No updates required.

**Code Review**
- [ ] Does the test handle fatal exceptions, ie. rescue block

**Issue**
- [ ] Tasks in issue are checked off
