### PR TITLE
#1678 kyverno not does not stop the remaining tests from running

### DIFF
--- a/src/tasks/workload/compatibility.cr
+++ b/src/tasks/workload/compatibility.cr
@@ -263,7 +263,7 @@ end
 
 desc "Test decrease capacity by setting replicas to 3 and then decreasing to 1"
 task "decrease_capacity" do |_, args|
-  hi = CNFManager::Task.task_runner(args) do |args, config|
+  CNFManager::Task.task_runner(args) do |args, config|
     VERBOSE_LOGGING.info "decrease_capacity" if check_verbose(args)
     target_replicas = "1"
     base_replicas = "3"
@@ -290,7 +290,6 @@ task "decrease_capacity" do |_, args|
     puts "1 ret: #{ret}"
     ret
   end
-  puts "hi: #{hi}"
 end
 
 

--- a/src/tasks/workload/configuration.cr
+++ b/src/tasks/workload/configuration.cr
@@ -32,14 +32,13 @@ end
 
 desc "Check if the CNF is running containers with labels configured?"
 task "require_labels" do |_, args|
-  Log.for("verbose").info { "require-labels" }
-  Kyverno.install
-  emoji_passed = "🏷️✔️"
-  emoji_failed = "🏷️❌"
-  policy_path = Kyverno.best_practice_policy("require_labels/require_labels.yaml")
-  failures = Kyverno::PolicyAudit.run(policy_path, EXCLUDE_NAMESPACES)
-
   CNFManager::Task.task_runner(args) do |args, config|
+    Log.for("verbose").info { "require-labels" }
+    Kyverno.install
+    emoji_passed = "🏷️✔️"
+    emoji_failed = "🏷️❌"
+    policy_path = Kyverno.best_practice_policy("require_labels/require_labels.yaml")
+    failures = Kyverno::PolicyAudit.run(policy_path, EXCLUDE_NAMESPACES)
 
     resource_keys = CNFManager.workload_resource_keys(args, config)
     failures = Kyverno.filter_failures_for_cnf_resources(resource_keys, failures)
@@ -59,14 +58,13 @@ end
 
 desc "Check if the CNF installs resources in the default namespace"
 task "default_namespace" do |_, args|
-  Log.for("verbose").info { "default_namespace" }
-  Kyverno.install
-  emoji_passed = "🏷️✔️"
-  emoji_failed = "🏷️❌"
-  policy_path = Kyverno.best_practice_policy("disallow_default_namespace/disallow_default_namespace.yaml")
-  failures = Kyverno::PolicyAudit.run(policy_path, EXCLUDE_NAMESPACES)
-
   CNFManager::Task.task_runner(args) do |args, config|
+    Log.for("verbose").info { "default_namespace" }
+    Kyverno.install
+    emoji_passed = "🏷️✔️"
+    emoji_failed = "🏷️❌"
+    policy_path = Kyverno.best_practice_policy("disallow_default_namespace/disallow_default_namespace.yaml")
+    failures = Kyverno::PolicyAudit.run(policy_path, EXCLUDE_NAMESPACES)
 
     resource_keys = CNFManager.workload_resource_keys(args, config)
     failures = Kyverno.filter_failures_for_cnf_resources(resource_keys, failures)
@@ -86,15 +84,14 @@ end
 
 desc "Check if the CNF uses container images with the latest tag"
 task "latest_tag" do |_, args|
-  Log.for("verbose").info { "latest_tag" }
-  Kyverno.install
-
-  emoji_passed = "🏷️✔️"
-  emoji_failed = "🏷️❌"
-  policy_path = Kyverno.best_practice_policy("disallow_latest_tag/disallow_latest_tag.yaml")
-  failures = Kyverno::PolicyAudit.run(policy_path, EXCLUDE_NAMESPACES)
-
   CNFManager::Task.task_runner(args) do |args, config|
+    Log.for("verbose").info { "latest_tag" }
+    Kyverno.install
+
+    emoji_passed = "🏷️✔️"
+    emoji_failed = "🏷️❌"
+    policy_path = Kyverno.best_practice_policy("disallow_latest_tag/disallow_latest_tag.yaml")
+    failures = Kyverno::PolicyAudit.run(policy_path, EXCLUDE_NAMESPACES)
 
     resource_keys = CNFManager.workload_resource_keys(args, config)
     failures = Kyverno.filter_failures_for_cnf_resources(resource_keys, failures)

--- a/src/tasks/workload/security.cr
+++ b/src/tasks/workload/security.cr
@@ -37,14 +37,13 @@ end
 
 desc "Check if pods in the CNF use sysctls with restricted values"
 task "sysctls" do |_, args|
-  Log.for("verbose").info { "sysctls" }
-  Kyverno.install
-
-  emoji_security = "🔓🔑"
-  policy_path = Kyverno.policy_path("pod-security/baseline/restrict-sysctls/restrict-sysctls.yaml")
-  failures = Kyverno::PolicyAudit.run(policy_path, EXCLUDE_NAMESPACES)
-
   CNFManager::Task.task_runner(args) do |args, config|
+    Log.for("verbose").info { "sysctls" }
+    Kyverno.install
+
+    emoji_security = "🔓🔑"
+    policy_path = Kyverno.policy_path("pod-security/baseline/restrict-sysctls/restrict-sysctls.yaml")
+    failures = Kyverno::PolicyAudit.run(policy_path, EXCLUDE_NAMESPACES)
     resource_keys = CNFManager.workload_resource_keys(args, config)
     failures = Kyverno.filter_failures_for_cnf_resources(resource_keys, failures)
 
@@ -63,13 +62,12 @@ end
 
 desc "Check if the CNF has services with external IPs configured"
 task "external_ips" do |_, args|
-  Log.for("verbose").info { "external_ips" }
-  Kyverno.install
- emoji_security = "🔓🔑"
-  policy_path = Kyverno.best_practice_policy("restrict-service-external-ips/restrict-service-external-ips.yaml")
-  failures = Kyverno::PolicyAudit.run(policy_path, EXCLUDE_NAMESPACES)
-
   CNFManager::Task.task_runner(args) do |args, config|
+    Log.for("verbose").info { "external_ips" }
+    Kyverno.install
+    emoji_security = "🔓🔑"
+    policy_path = Kyverno.best_practice_policy("restrict-service-external-ips/restrict-service-external-ips.yaml")
+    failures = Kyverno::PolicyAudit.run(policy_path, EXCLUDE_NAMESPACES)
 
     resource_keys = CNFManager.workload_resource_keys(args, config)
     failures = Kyverno.filter_failures_for_cnf_resources(resource_keys, failures)
@@ -89,17 +87,17 @@ end
 
 desc "Check if the CNF or the cluster resources have custom SELinux options"
 task "selinux_options" do |_, args|
-  Log.for("verbose").info { "selinux_options" }
-  Kyverno.install
-
-  emoji_security = "🔓🔑"
-  check_policy_path = Kyverno::CustomPolicies::SELinuxEnabled.new.policy_path
-  check_failures = Kyverno::PolicyAudit.run(check_policy_path, EXCLUDE_NAMESPACES)
-
-  disallow_policy_path = Kyverno.policy_path("pod-security/baseline/disallow-selinux/disallow-selinux.yaml")
-  disallow_failures = Kyverno::PolicyAudit.run(disallow_policy_path, EXCLUDE_NAMESPACES)
-
   CNFManager::Task.task_runner(args) do |args, config|
+    Log.for("verbose").info { "selinux_options" }
+    Kyverno.install
+
+    emoji_security = "🔓🔑"
+    check_policy_path = Kyverno::CustomPolicies::SELinuxEnabled.new.policy_path
+    check_failures = Kyverno::PolicyAudit.run(check_policy_path, EXCLUDE_NAMESPACES)
+
+    disallow_policy_path = Kyverno.policy_path("pod-security/baseline/disallow-selinux/disallow-selinux.yaml")
+    disallow_failures = Kyverno::PolicyAudit.run(disallow_policy_path, EXCLUDE_NAMESPACES)
+
     #TODO check for AppArmor as well, and the cnf should have either selinux or apparmor
     # IF SELinux is not enabled, skip this test
     # Else check for SELinux options
@@ -131,9 +129,9 @@ end
 
 desc "Check if the CNF is running containers with container sock mounts"
 task "container_sock_mounts" do |_, args|
-  Log.for("verbose").info { "container_sock_mounts" }
-  Kyverno.install
   CNFManager::Task.task_runner(args) do |args, config|
+    Log.for("verbose").info { "container_sock_mounts" }
+    Kyverno.install
     emoji_security = "🔓🔑"
     policy_path = Kyverno.best_practice_policy("disallow_cri_sock_mount/disallow_cri_sock_mount.yaml")
     failures = Kyverno::PolicyAudit.run(policy_path, EXCLUDE_NAMESPACES)


### PR DESCRIPTION
Signed-off-by: W. Watson <w.watson@vulk.coop>

## Description
Fix bug causing the F5 cert to crash when running security tests.
## Issues:
Refs: #NNN

## How has this been tested:
 - [ ] Covered by existing integration testing
 - [ ] Added integration testing to cover
 - [ ] Verified all A/C passes
     * [ ] develop
     * [ ] master
     * [ ] tag/other branch
 - [ ] Test environment
    * [ ] Shared Packet K8s cluster
    * [ ] New Packet K8s cluster
    * [ ] Kind cluster
 - [ ] Have not tested

## Types of changes:
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [ ] Documentation update

## Checklist:
**Documentation**
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] No updates required.

**Code Review**
- [ ] Does the test handle fatal exceptions, ie. rescue block

**Issue**
- [ ] Tasks in issue are checked off
