### PR TITLE
change office hours to Tuesdays at 15:15 UTC

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -120,7 +120,7 @@ For general advice on how to submit a pull request, please see [Creating a pull 
 
 ## Community Meeting:
 
-The CNF Test Suite team meets once a week on Thursdays at 14:15-15:00 UTC (during Daylight Savings Time)
+The CNF Test Suite team meets once a week on Tuesdays at 15:15-16:00 UTC (7:15-8:00 AM Pacific Standard Time)
 
 - Meeting minutes are [here](https://docs.google.com/document/d/1IbrgjqIkOCvrrSG0DRE6X62UUZpBq-818Mn8q0nkkd0/edit#)
 


### PR DESCRIPTION
The CNF Test Suite team meets once a week on Tuesdays at 15:15-16:00 UTC (7:15-8:00 AM Pacific Standard Time)


Signed-off-by: Lucina Stricko <lucina@vulk.coop>

## Description
(name of issue/change)

## Issues:
Refs: #NNN

## How has this been tested:
 - [ ] Covered by existing integration testing
 - [ ] Added integration testing to cover
 - [ ] Verified all A/C passes
     * [ ] develop
     * [ ] master
     * [ ] tag/other branch
 - [ ] Test environment
    * [ ] Shared Packet K8s cluster
    * [ ] New Packet K8s cluster
    * [ ] Kind cluster
 - [ ] Have not tested

## Types of changes:
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [ ] Documentation update

## Checklist:
**Documentation**
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] No updates required.

**Code Review**
- [ ] Does the test handle fatal exceptions, ie. rescue block

**Issue**
- [ ] Tasks in issue are checked off
