### PR TITLE
GitHub Runners Image Update to 2.299.1

### DIFF
--- a/tools/github-runner/Dockerfile
+++ b/tools/github-runner/Dockerfile
@@ -1,4 +1,4 @@
-FROM myoung34/github-runner:2.298.2-ubuntu-bionic
+FROM myoung34/github-runner:2.299.1-ubuntu-bionic
 
 ARG CRYSTAL_VERSION=1.0.0
 ARG CRYSTAL_URL=https://github.com/crystal-lang/crystal/releases/download

--- a/tools/github-runner/create_runners.sh
+++ b/tools/github-runner/create_runners.sh
@@ -29,7 +29,7 @@ VIPS=(
 
 RUNNER_COUNT=0
 for node in "${!RUNNERS[@]}"; do
-    export RUNNER_IMAGE="conformance/github-runner:v2.298.2" # don't forget the v
+    export RUNNER_IMAGE="conformance/github-runner:v2.299.1" # don't forget the v
     ssh root@${RUNNERS[$node]} "docker pull $RUNNER_IMAGE"
     RUNNERS_PER_NODE=4
     until [ $RUNNERS_PER_NODE -eq 0 ]; do


### PR DESCRIPTION
## Description
Had to update github runners to latest image as they were no longer picking up jobs for PR, branch pushes and updates.

## Issues:
Refs: #NNN

