### PR TITLE
[bug/1697] If MariaDB is not available on cluster, then `shared_database` test result should be N/A

### DIFF
--- a/spec/utils/cnf_manager_spec.cr
+++ b/spec/utils/cnf_manager_spec.cr
@@ -471,7 +471,7 @@ describe "SampleUtils" do
       Log.info { install }
       response_s = `./cnf-testsuite cert_microservice`
       Log.info { response_s}
-      (/of 4 tests passed/ =~ response_s).should_not be_nil
+      (/of 3 tests passed/ =~ response_s).should_not be_nil
       Log.info { response_s }
     ensure
       Log.info { `./cnf-testsuite cnf_cleanup cnf-path=./sample-cnfs/sample-ndn-privileged` }

--- a/spec/workload/microservice_spec.cr
+++ b/spec/workload/microservice_spec.cr
@@ -19,7 +19,7 @@ describe "Microservice" do
       response_s = `./cnf-testsuite shared_database`
       LOGGING.info response_s
       $?.success?.should be_true
-      (/SKIPPED: \[shared_database\] No MariaDB containers were found/ =~ response_s).should_not be_nil
+      (/N\/A: \[shared_database\] No MariaDB containers were found/ =~ response_s).should_not be_nil
     ensure
       LOGGING.info `./cnf-testsuite cnf_cleanup cnf-path=sample-cnfs/sample_coredns/cnf-testsuite.yml`
       $?.success?.should be_true

--- a/src/tasks/workload/microservice.cr
+++ b/src/tasks/workload/microservice.cr
@@ -28,7 +28,7 @@ task "shared_database", ["install_cluster_tools"] do |_, args|
     db_match = Netstat::Mariadb.match
     
     if db_match[:found] == false
-      upsert_skipped_task("shared_database", "⏭️  SKIPPED: [shared_database] No MariaDB containers were found")
+      upsert_na_task("shared_database", "⏭️  N/A: [shared_database] No MariaDB containers were found")
       next
     end
 


### PR DESCRIPTION
## Description
If MariaDB is not available on cluster, then `shared_database` test should be `N/A` result. This will ensure that the test is not counted for the max number of tests in the category.

### Validation: Run the `microservice` category of tests

<img width="964" alt="CleanShot 2022-11-22 at 18 31 12@2x" src="https://user-images.githubusercontent.com/84005/203303647-dfe0558f-5c31-4618-bf6a-c8ee986868a7.png">


## Issues
Refs: #1697

## How has this been tested
 - [x] Covered by existing integration testing
 - [ ] Added integration testing to cover
 - [ ] Verified all A/C passes
     * [ ] develop
     * [ ] master
     * [ ] tag/other branch
 - [ ] Test environment
    * [ ] Shared Packet K8s cluster
    * [ ] New Packet K8s cluster
    * [ ] Kind cluster
 - [ ] Have not tested

## Types of changes:
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [ ] Documentation update

## Checklist:
**Documentation**
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] No updates required.

**Code Review**
- [ ] Does the test handle fatal exceptions, ie. rescue block

**Issue**
- [ ] Tasks in issue are checked off
