### PR TITLE
[feature/1472] Print testsuite version when cert and setup commands are run

### DIFF
--- a/src/tasks/cert/cert.cr
+++ b/src/tasks/cert/cert.cr
@@ -7,7 +7,7 @@ require "../utils/utils.cr"
 
 desc "The CNF Test Suite program certifies a CNF based on passing some percentage of essential tests."
 #task "cert", ["cert_security"] do  |_, args|
-task "cert", ["cert_compatibility", "cert_state", "cert_security", "cert_configuration", "cert_observability", "cert_microservice", "cert_resilience"] do  |_, args|
+task "cert", ["version", "cert_compatibility", "cert_state", "cert_security", "cert_configuration", "cert_observability", "cert_microservice", "cert_resilience"] do  |_, args|
 # task "cert", ["cert_compatibility", "cert_state", "cert_security", "cert_configuration", "cert_observability", "cert_microservice", "cert_resilience", "latest_tag", "selinux_options", "single_process_type", "node_drain","liveness", "readiness", "log_output", "container_sock_mounts", "privileged_containers", "non_root_containers", "resource_policies", "hostport_not_used", "hardcoded_ip_addresses_in_k8s_runtime_configuration"] do  |_, args|
   VERBOSE_LOGGING.info "cert" if check_verbose(args)
 

--- a/src/tasks/setup.cr
+++ b/src/tasks/setup.cr
@@ -5,7 +5,7 @@ require "totem"
 
 desc "Sets up the CNF test suite, the K8s cluster, and upstream projects"
 
-task "setup", ["offline", "helm_local_install", "prereqs", "create_namespace", "configuration_file_setup", "install_apisnoop", "install_sonobuoy", "install_chart_testing", "cnf_testsuite_setup", "install_kind"] do  |_, args|
+task "setup", ["version", "offline", "helm_local_install", "prereqs", "create_namespace", "configuration_file_setup", "install_apisnoop", "install_sonobuoy", "install_chart_testing", "cnf_testsuite_setup", "install_kind"] do  |_, args|
   stdout_success "Setup complete"
 end
 

--- a/src/tasks/utils/points.cr
+++ b/src/tasks/utils/points.cr
@@ -70,6 +70,7 @@ module CNFManager
         end
         File.open("#{Results.file}", "w") do |f|
           YAML.dump({name: results["name"],
+                     testsuite_version: CnfTestSuite::VERSION,
                      status: results["status"],
                      exit_code: results["exit_code"],
                      points: results["points"],
@@ -395,6 +396,7 @@ module CNFManager
       result_items << YAML.parse "{name: #{task}, status: #{status}, type: #{task_type_by_task(task)}, points: #{points}}"
       File.open("#{Results.file}", "w") do |f|
         YAML.dump({name: results["name"],
+                   testsuite_version: CnfTestSuite::VERSION,
                    status: results["status"],
                    command: cmd,
                    points: results["points"],
@@ -541,6 +543,7 @@ module CNFManager
   #TODO add tags for category summaries
   YAML.parse <<-END
 name: cnf testsuite
+testsuite_version: <%= CnfTestSuite::VERSION %>
 status:
 points:
 exit_code: 0


### PR DESCRIPTION
## Description
* Print testsuite version when running setup and cert commands.
* Add testsuite_version to results file.

### Screenshot: setup command

<img width="809" alt="CleanShot 2023-01-18 at 22 13 29@2x" src="https://user-images.githubusercontent.com/84005/213209298-67cc9897-dd9c-4e55-8312-9ced84f3eb89.png">

### Screenshot cert command 

<img width="800" alt="CleanShot 2023-01-18 at 22 17 08@2x" src="https://user-images.githubusercontent.com/84005/213209961-d88ac659-2261-490f-bd27-3a32a86e1901.png">

### Testsuite version in results file

<img width="1145" alt="CleanShot 2023-01-18 at 23 57 18@2x" src="https://user-images.githubusercontent.com/84005/213245768-786ffff6-c411-4c57-985b-af3bff7962ec.png">

## Issues:
Refs: #1472

## How has this been tested:
 - [x] Covered by existing integration testing
 - [ ] Added integration testing to cover
 - [ ] Verified all A/C passes
     * [ ] develop
     * [ ] master
     * [ ] tag/other branch
 - [ ] Test environment
    * [ ] Shared Packet K8s cluster
    * [ ] New Packet K8s cluster
    * [ ] Kind cluster
 - [ ] Have not tested

## Types of changes:
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [x] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [ ] Documentation update

## Checklist:
**Documentation**
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] No updates required.

**Code Review**
- [ ] Does the test handle fatal exceptions, ie. rescue block

**Issue**
- [ ] Tasks in issue are checked off
