### PR TITLE
[bug/1634] Add separate failure messages for `increase_decrease_capacity` test

### DIFF
--- a/src/tasks/workload/compatibility.cr
+++ b/src/tasks/workload/compatibility.cr
@@ -179,55 +179,66 @@ task "increase_decrease_capacity" do |t, args|
   VERBOSE_LOGGING.info "increase_decrease_capacity" if check_verbose(args)
   CNFManager::Task.task_runner(args) do |args, config|
     VERBOSE_LOGGING.info "increase_capacity" if check_verbose(args)
-    emoji_increase_capacity="📦📈"
 
-    increased_replicas = "3"
-    base_replicas = "1"
+    increase_test_base_replicas = "1"
+    increase_test_target_replicas = "3"
     # TODO scale replicatsets separately
     # https://kubernetes.io/docs/concepts/workloads/controllers/replicaset/#scaling-a-replicaset
     # resource["kind"].as_s.downcase == "replicaset"
     increase_task_response = CNFManager.cnf_workload_resources(args, config) do | resource|
       if resource["kind"].as_s.downcase == "deployment" ||
           resource["kind"].as_s.downcase == "statefulset"
-        final_count = change_capacity(base_replicas, increased_replicas, args, config, resource)
-        increased_replicas == final_count
+        final_count = change_capacity(increase_test_base_replicas, increase_test_target_replicas, args, config, resource)
+        increase_test_target_replicas == final_count
       else
         true
       end
     end
 
-    target_replicas = "1"
-    base_replicas = "3"
-    task_response = CNFManager.cnf_workload_resources(args, config) do | resource|
+    decrease_test_base_replicas = "3"
+    decrease_test_target_replicas = "1"
+    decrease_task_response = CNFManager.cnf_workload_resources(args, config) do | resource|
       # TODO scale replicatsets separately
       # https://kubernetes.io/docs/concepts/workloads/controllers/replicaset/#scaling-a-replicaset
       # resource["kind"].as_s.downcase == "replicaset"
       if resource["kind"].as_s.downcase == "deployment" ||
           resource["kind"].as_s.downcase == "statefulset"
-        final_count = change_capacity(base_replicas, target_replicas, args, config, resource)
-        target_replicas == final_count
+        final_count = change_capacity(decrease_test_base_replicas, decrease_test_target_replicas, args, config, resource)
+        decrease_test_target_replicas == final_count
       else
         true
       end
     end
-    emoji_decrease_capacity="📦📉"
 
-    if increase_task_response.none?(false) && task_response.none?(false) 
-      ret = upsert_passed_task("increase_decrease_capacity", "✔️  PASSED: Replicas increased to #{increased_replicas} and decreased to #{target_replicas} #{emoji_decrease_capacity}")
+    emoji_capacity = "📦📈📉"
+
+    if increase_task_response.none?(false) && decrease_task_response.none?(false)
+      pass_msg = "✔️  PASSED: Replicas increased to #{increase_test_target_replicas} and decreased to #{decrease_test_target_replicas} #{emoji_capacity}"
+      upsert_passed_task("increase_decrease_capacity", pass_msg)
     else
-      ret = upsert_failed_task("increase_decrease_capacity", increase_decrease_capacity_failure_msg(target_replicas, emoji_decrease_capacity))
+      upsert_failed_task("increase_decrease_capacity", "✖️  FAILURE: Capacity change test failed #{emoji_capacity}")
+
+      # If increased capacity failed
+      if increase_task_response.any?(false)
+        stdout_failure("Failed to increase capacity from #{increase_base_target_replicas} to #{increase_test_target_replicas}")
+      end
+
+      # If decrease capacity failed
+      if decrease_task_response.any?(false)
+        stdout_failure("Failed to decrease capacity from #{decrease_test_base_replicas} to #{decrease_test_target_replicas}")
+      end
+
+      stdout_failure(increase_decrease_remedy_msg())
     end
   end
 end
 
 
-def increase_decrease_capacity_failure_msg(target_replicas, emoji)
+def increase_decrease_remedy_msg()
 <<-TEMPLATE
-✖️  FAILURE: Replicas did not reach #{target_replicas} #{emoji}
 
 Replica failure can be due to insufficent permissions, image pull errors and other issues.
 Learn more on remediation by viewing our USAGE.md doc at https://bit.ly/capacity_remedy
-
 TEMPLATE
 end
 

--- a/src/tasks/workload/compatibility.cr
+++ b/src/tasks/workload/compatibility.cr
@@ -216,16 +216,16 @@ task "increase_decrease_capacity" do |t, args|
       pass_msg = "✔️  PASSED: Replicas increased to #{increase_test_target_replicas} and decreased to #{decrease_test_target_replicas} #{emoji_capacity}"
       upsert_passed_task("increase_decrease_capacity", pass_msg)
     else
-      upsert_failed_task("increase_decrease_capacity", "✖️  FAILURE: Capacity change test failed #{emoji_capacity}")
+      upsert_failed_task("increase_decrease_capacity", "✖️  FAILURE: Capacity change failed #{emoji_capacity}")
 
       # If increased capacity failed
       if increase_task_response.any?(false)
-        stdout_failure("Failed to increase capacity from #{increase_test_base_replicas} to #{increase_test_target_replicas}")
+        stdout_failure("Failed to increase replicas from #{increase_test_base_replicas} to #{increase_test_target_replicas}")
       end
 
       # If decrease capacity failed
       if decrease_task_response.any?(false)
-        stdout_failure("Failed to decrease capacity from #{decrease_test_base_replicas} to #{decrease_test_target_replicas}")
+        stdout_failure("Failed to decrease replicas from #{decrease_test_base_replicas} to #{decrease_test_target_replicas}")
       end
 
       stdout_failure(increase_decrease_remedy_msg())

--- a/src/tasks/workload/compatibility.cr
+++ b/src/tasks/workload/compatibility.cr
@@ -220,7 +220,7 @@ task "increase_decrease_capacity" do |t, args|
 
       # If increased capacity failed
       if increase_task_response.any?(false)
-        stdout_failure("Failed to increase capacity from #{increase_base_target_replicas} to #{increase_test_target_replicas}")
+        stdout_failure("Failed to increase capacity from #{increase_test_base_replicas} to #{increase_test_target_replicas}")
       end
 
       # If decrease capacity failed


### PR DESCRIPTION
## Issues
Refs: #1634

## Description
When increase capacity fails or decrease capacity fails, then the failure messages should be separately reported.
This PR includes changes to report these failures separately.

## Screenshot: Current main branch failure message

![image](https://user-images.githubusercontent.com/84005/216363998-9552d567-a303-46b3-9c1c-a2f3cf77b5f7.png)

## Screenshot: New failure message

To reproduce,
1. Run the testsuite setup command
2. Install the coredns sample CNF
3. `unset KUBECONFIG` env var so that kubectl will not find the cluster
4. Run the test: `./cnf-testsuite increase_decrease_capacity` (both increase and decrease will fail)

![image](https://user-images.githubusercontent.com/84005/216364180-15eea148-74d3-4d35-a95f-d6bcb2901d13.png)

## How has this been tested:
 - [x] Covered by existing integration testing
 - [ ] Added integration testing to cover
 - [ ] Verified all A/C passes
     * [ ] develop
     * [ ] master
     * [ ] tag/other branch
 - [ ] Test environment
    * [ ] Shared Packet K8s cluster
    * [ ] New Packet K8s cluster
    * [ ] Kind cluster
 - [ ] Have not tested

## Types of changes:
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [ ] Documentation update

## Checklist:
**Documentation**
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] No updates required.

**Code Review**
- [ ] Does the test handle fatal exceptions, ie. rescue block

**Issue**
- [ ] Tasks in issue are checked off
