### PR TITLE
[BUG] Update github actions chaos tests to use Ubuntu 22.04 image

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -186,7 +186,7 @@ jobs:
   chaos:
     name: Chaos Tests
     needs: [tests]
-    runs-on: [ubuntu-18.04]
+    runs-on: [ubuntu-22.04]
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## Description
Update to the latest Ubuntu 22.04 image for Chaos Tests to avoid the expiring Ubuntu 18.04 brown out periods where the jobs will be cancelled and not run.

## Issues:
Refs: #NNN

## How has this been tested:
 - [ ] Covered by existing integration testing
 - [ ] Added integration testing to cover
 - [ ] Verified all A/C passes
     * [ ] develop
     * [ ] master
     * [ ] tag/other branch
 - [ ] Test environment
    * [ ] Shared Packet K8s cluster
    * [ ] New Packet K8s cluster
    * [ ] Kind cluster
 - [ ] Have not tested

## Types of changes:
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [ ] Documentation update

## Checklist:
**Documentation**
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] No updates required.

**Code Review**
- [ ] Does the test handle fatal exceptions, ie. rescue block

**Issue**
- [ ] Tasks in issue are checked off
