### PR TITLE
remove shard.override.yml

### DIFF
--- a/shard.override.yml
+++ b/shard.override.yml
@@ -1,4 +1,0 @@
-dependencies:
-  kubectl_client:
-    github: cnf-testsuite/kubectl_client
-    branch: exec-background


### PR DESCRIPTION


## Description
shard.override.yml should not have been committed  once the exec-background branch of

https://github.com/cnf-testsuite/kubectl_client/pull/5 was merged

after conversation with @wavell and @denverwilliams 

## Issues:
blocks: #1746

refs: #1726

## How has this been tested:
 - [ ] Covered by existing integration testing
 - [ ] Added integration testing to cover
 - [ ] Verified all A/C passes
     * [ ] develop
     * [ ] master
     * [ ] tag/other branch
 - [ ] Test environment
    * [ ] Shared Packet K8s cluster
    * [ ] New Packet K8s cluster
    * [ ] Kind cluster
 - [ ] Have not tested

## Types of changes:
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [ ] Documentation update

## Checklist:
**Documentation**
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] No updates required.

**Code Review**
- [ ] Does the test handle fatal exceptions, ie. rescue block

**Issue**
- [ ] Tasks in issue are checked off
