### PR TITLE
Maintenance/#1742 registry k8s URL update

### DIFF
--- a/sample-cnfs/multi_helm_directories/multiple/directory/chart/values.yaml
+++ b/sample-cnfs/multi_helm_directories/multiple/directory/chart/values.yaml
@@ -165,7 +165,7 @@ autoscaler:
   nodesPerReplica: 16
 
   image:
-    repository: k8s.gcr.io/cluster-proportional-autoscaler-amd64
+    repository: registry.k8s.io/cluster-proportional-autoscaler-amd64
     tag: "1.7.1"
     pullPolicy: IfNotPresent
 

--- a/sample-cnfs/sample-appliciation-credentials/chart/values.yaml
+++ b/sample-cnfs/sample-appliciation-credentials/chart/values.yaml
@@ -165,7 +165,7 @@ autoscaler:
   nodesPerReplica: 16
 
   image:
-    repository: k8s.gcr.io/cluster-proportional-autoscaler-amd64
+    repository: registry.k8s.io/cluster-proportional-autoscaler-amd64
     tag: "1.7.1"
     pullPolicy: IfNotPresent
 

--- a/sample-cnfs/sample-bad_helm_coredns-cnf/chart/values.yaml
+++ b/sample-cnfs/sample-bad_helm_coredns-cnf/chart/values.yaml
@@ -162,7 +162,7 @@ autoscaler:
   nodesPerReplica: 16
 
   image:
-    repository: k8s.gcr.io/cluster-proportional-autoscaler-amd64
+    repository: registry.k8s.io/cluster-proportional-autoscaler-amd64
     tag: "1.7.1"
     pullPolicy: IfNotPresent
 

--- a/sample-cnfs/sample-fragile-state/chart/values.yaml
+++ b/sample-cnfs/sample-fragile-state/chart/values.yaml
@@ -165,7 +165,7 @@ autoscaler:
   nodesPerReplica: 16
 
   image:
-    repository: k8s.gcr.io/cluster-proportional-autoscaler-amd64
+    repository: registry.k8s.io/cluster-proportional-autoscaler-amd64
     tag: "1.7.1"
     pullPolicy: IfNotPresent
 

--- a/sample-cnfs/sample-insecure-capabilities/chart/values.yaml
+++ b/sample-cnfs/sample-insecure-capabilities/chart/values.yaml
@@ -249,7 +249,7 @@ autoscaler:
   preventSinglePointFailure: true
 
   image:
-    repository: k8s.gcr.io/cluster-proportional-autoscaler-amd64
+    repository: registry.k8s.io/cluster-proportional-autoscaler-amd64
     tag: "1.8.1"
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.

--- a/sample-cnfs/sample-large-cnf/chart/values.yaml
+++ b/sample-cnfs/sample-large-cnf/chart/values.yaml
@@ -165,7 +165,7 @@ autoscaler:
   nodesPerReplica: 16
 
   image:
-    repository: k8s.gcr.io/cluster-proportional-autoscaler-amd64
+    repository: registry.k8s.io/cluster-proportional-autoscaler-amd64
     tag: "1.7.1"
     pullPolicy: IfNotPresent
 

--- a/sample-cnfs/sample-local-storage/chart/values.yaml
+++ b/sample-cnfs/sample-local-storage/chart/values.yaml
@@ -165,7 +165,7 @@ autoscaler:
   nodesPerReplica: 16
 
   image:
-    repository: k8s.gcr.io/cluster-proportional-autoscaler-amd64
+    repository: registry.k8s.io/cluster-proportional-autoscaler-amd64
     tag: "1.7.1"
     pullPolicy: IfNotPresent
 

--- a/sample-cnfs/sample-privilege-escalation/chart/values.yaml
+++ b/sample-cnfs/sample-privilege-escalation/chart/values.yaml
@@ -165,7 +165,7 @@ autoscaler:
   nodesPerReplica: 16
 
   image:
-    repository: k8s.gcr.io/cluster-proportional-autoscaler-amd64
+    repository: registry.k8s.io/cluster-proportional-autoscaler-amd64
     tag: "1.7.1"
     pullPolicy: IfNotPresent
 

--- a/sample-cnfs/sample-prom-pod-discovery/chart/values.yaml
+++ b/sample-cnfs/sample-prom-pod-discovery/chart/values.yaml
@@ -165,7 +165,7 @@ autoscaler:
   nodesPerReplica: 16
 
   image:
-    repository: k8s.gcr.io/cluster-proportional-autoscaler-amd64
+    repository: registry.k8s.io/cluster-proportional-autoscaler-amd64
     tag: "1.7.1"
     pullPolicy: IfNotPresent
 

--- a/sample-cnfs/sample_coredns/chart/values.yaml
+++ b/sample-cnfs/sample_coredns/chart/values.yaml
@@ -165,7 +165,7 @@ autoscaler:
   nodesPerReplica: 16
 
   image:
-    repository: k8s.gcr.io/cluster-proportional-autoscaler-amd64
+    repository: registry.k8s.io/cluster-proportional-autoscaler-amd64
     tag: "1.7.1"
     pullPolicy: IfNotPresent
 

--- a/sample-cnfs/sample_coredns_bad_liveness/chart/values.yaml
+++ b/sample-cnfs/sample_coredns_bad_liveness/chart/values.yaml
@@ -165,7 +165,7 @@ autoscaler:
   nodesPerReplica: 16
 
   image:
-    repository: k8s.gcr.io/cluster-proportional-autoscaler-amd64
+    repository: registry.k8s.io/cluster-proportional-autoscaler-amd64
     tag: "1.7.1"
     pullPolicy: IfNotPresent
 

--- a/sample-cnfs/sample_coredns_chart_directory/chart/values.yaml
+++ b/sample-cnfs/sample_coredns_chart_directory/chart/values.yaml
@@ -165,7 +165,7 @@ autoscaler:
   nodesPerReplica: 16
 
   image:
-    repository: k8s.gcr.io/cluster-proportional-autoscaler-amd64
+    repository: registry.k8s.io/cluster-proportional-autoscaler-amd64
     tag: "1.7.1"
     pullPolicy: IfNotPresent
 

--- a/sample-cnfs/sample_coredns_hardcoded_ips/chart/values.yaml
+++ b/sample-cnfs/sample_coredns_hardcoded_ips/chart/values.yaml
@@ -165,7 +165,7 @@ autoscaler:
   nodesPerReplica: 16
 
   image:
-    repository: k8s.gcr.io/cluster-proportional-autoscaler-amd64
+    repository: registry.k8s.io/cluster-proportional-autoscaler-amd64
     tag: "1.7.1"
     pullPolicy: IfNotPresent
 

--- a/sample-cnfs/sample_coredns_protected/chart/values.yaml
+++ b/sample-cnfs/sample_coredns_protected/chart/values.yaml
@@ -171,7 +171,7 @@ autoscaler:
   nodesPerReplica: 16
 
   image:
-    repository: k8s.gcr.io/cluster-proportional-autoscaler-amd64
+    repository: registry.k8s.io/cluster-proportional-autoscaler-amd64
     tag: "1.7.1"
     pullPolicy: IfNotPresent
 

--- a/sample-cnfs/sample_coredns_values/chart/values.yaml
+++ b/sample-cnfs/sample_coredns_values/chart/values.yaml
@@ -165,7 +165,7 @@ autoscaler:
   nodesPerReplica: 16
 
   image:
-    repository: k8s.gcr.io/cluster-proportional-autoscaler-amd64
+    repository: registry.k8s.io/cluster-proportional-autoscaler-amd64
     tag: "1.7.1"
     pullPolicy: IfNotPresent
 

--- a/sample-cnfs/sample_immutable_configmap_all/chart/values.yaml
+++ b/sample-cnfs/sample_immutable_configmap_all/chart/values.yaml
@@ -165,7 +165,7 @@ autoscaler:
   nodesPerReplica: 16
 
   image:
-    repository: k8s.gcr.io/cluster-proportional-autoscaler-amd64
+    repository: registry.k8s.io/cluster-proportional-autoscaler-amd64
     tag: "1.7.1"
     pullPolicy: IfNotPresent
 

--- a/sample-cnfs/sample_immutable_configmap_all_plus_env/chart/values.yaml
+++ b/sample-cnfs/sample_immutable_configmap_all_plus_env/chart/values.yaml
@@ -165,7 +165,7 @@ autoscaler:
   nodesPerReplica: 16
 
   image:
-    repository: k8s.gcr.io/cluster-proportional-autoscaler-amd64
+    repository: registry.k8s.io/cluster-proportional-autoscaler-amd64
     tag: "1.7.1"
     pullPolicy: IfNotPresent
 

--- a/sample-cnfs/sample_immutable_configmap_all_plus_env_but_fail/chart/values.yaml
+++ b/sample-cnfs/sample_immutable_configmap_all_plus_env_but_fail/chart/values.yaml
@@ -165,7 +165,7 @@ autoscaler:
   nodesPerReplica: 16
 
   image:
-    repository: k8s.gcr.io/cluster-proportional-autoscaler-amd64
+    repository: registry.k8s.io/cluster-proportional-autoscaler-amd64
     tag: "1.7.1"
     pullPolicy: IfNotPresent
 

--- a/sample-cnfs/sample_immutable_configmap_some/chart/values.yaml
+++ b/sample-cnfs/sample_immutable_configmap_some/chart/values.yaml
@@ -165,7 +165,7 @@ autoscaler:
   nodesPerReplica: 16
 
   image:
-    repository: k8s.gcr.io/cluster-proportional-autoscaler-amd64
+    repository: registry.k8s.io/cluster-proportional-autoscaler-amd64
     tag: "1.7.1"
     pullPolicy: IfNotPresent
 

--- a/sample-cnfs/sample_local_registry/chart/values.yaml
+++ b/sample-cnfs/sample_local_registry/chart/values.yaml
@@ -165,7 +165,7 @@ autoscaler:
   nodesPerReplica: 16
 
   image:
-    repository: k8s.gcr.io/cluster-proportional-autoscaler-amd64
+    repository: registry.k8s.io/cluster-proportional-autoscaler-amd64
     tag: "1.7.1"
     pullPolicy: IfNotPresent
 

--- a/sample-cnfs/sample_local_registry_org_image/chart/values.yaml
+++ b/sample-cnfs/sample_local_registry_org_image/chart/values.yaml
@@ -165,7 +165,7 @@ autoscaler:
   nodesPerReplica: 16
 
   image:
-    repository: k8s.gcr.io/cluster-proportional-autoscaler-amd64
+    repository: registry.k8s.io/cluster-proportional-autoscaler-amd64
     tag: "1.7.1"
     pullPolicy: IfNotPresent
 

--- a/sample-cnfs/sample_local_registry_rolling/chart/values.yaml
+++ b/sample-cnfs/sample_local_registry_rolling/chart/values.yaml
@@ -165,7 +165,7 @@ autoscaler:
   nodesPerReplica: 16
 
   image:
-    repository: k8s.gcr.io/cluster-proportional-autoscaler-amd64
+    repository: registry.k8s.io/cluster-proportional-autoscaler-amd64
     tag: "1.7.1"
     pullPolicy: IfNotPresent
 

--- a/sample-cnfs/sample_network_loss/chart/values.yaml
+++ b/sample-cnfs/sample_network_loss/chart/values.yaml
@@ -165,7 +165,7 @@ autoscaler:
   nodesPerReplica: 16
 
   image:
-    repository: k8s.gcr.io/cluster-proportional-autoscaler-amd64
+    repository: registry.k8s.io/cluster-proportional-autoscaler-amd64
     tag: "1.7.1"
     pullPolicy: IfNotPresent
 

--- a/sample-cnfs/sample_operator/chart/values.yaml
+++ b/sample-cnfs/sample_operator/chart/values.yaml
@@ -165,7 +165,7 @@ autoscaler:
   nodesPerReplica: 16
 
   image:
-    repository: k8s.gcr.io/cluster-proportional-autoscaler-amd64
+    repository: registry.k8s.io/cluster-proportional-autoscaler-amd64
     tag: "1.7.1"
     pullPolicy: IfNotPresent
 

--- a/sample-cnfs/sample_privileged_cnf/chart/values.yaml
+++ b/sample-cnfs/sample_privileged_cnf/chart/values.yaml
@@ -162,7 +162,7 @@ autoscaler:
   nodesPerReplica: 16
 
   image:
-    repository: k8s.gcr.io/cluster-proportional-autoscaler-amd64
+    repository: registry.k8s.io/cluster-proportional-autoscaler-amd64
     tag: "1.7.1"
     pullPolicy: IfNotPresent
 

--- a/sample-cnfs/sample_rolling/chart/values.yaml
+++ b/sample-cnfs/sample_rolling/chart/values.yaml
@@ -165,7 +165,7 @@ autoscaler:
   nodesPerReplica: 16
 
   image:
-    repository: k8s.gcr.io/cluster-proportional-autoscaler-amd64
+    repository: registry.k8s.io/cluster-proportional-autoscaler-amd64
     tag: "1.7.1"
     pullPolicy: IfNotPresent
 

--- a/sample-cnfs/sample_rolling_invalid_version/chart/values.yaml
+++ b/sample-cnfs/sample_rolling_invalid_version/chart/values.yaml
@@ -165,7 +165,7 @@ autoscaler:
   nodesPerReplica: 16
 
   image:
-    repository: k8s.gcr.io/cluster-proportional-autoscaler-amd64
+    repository: registry.k8s.io/cluster-proportional-autoscaler-amd64
     tag: "1.7.1"
     pullPolicy: IfNotPresent
 

--- a/sample-cnfs/sample_whitelisted_privileged_cnf/chart/values.yaml
+++ b/sample-cnfs/sample_whitelisted_privileged_cnf/chart/values.yaml
@@ -162,7 +162,7 @@ autoscaler:
   nodesPerReplica: 16
 
   image:
-    repository: k8s.gcr.io/cluster-proportional-autoscaler-amd64
+    repository: registry.k8s.io/cluster-proportional-autoscaler-amd64
     tag: "1.7.1"
     pullPolicy: IfNotPresent
 


### PR DESCRIPTION
## Description
The registry URL for k8s images is changing. This pull request in the below issue addresses this URL where we use within our sample-cnfs available in our code base and spec tests.

## Issues:
Refs: #1742 

## How has this been tested:
 - [ ] Covered by existing integration testing
 - [ ] Added integration testing to cover
 - [ ] Verified all A/C passes
     * [ ] develop
     * [ ] master
     * [ ] tag/other branch
 - [ ] Test environment
    * [ ] Shared Packet K8s cluster
    * [ ] New Packet K8s cluster
    * [ ] Kind cluster
 - [ ] Have not tested

## Types of changes:
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [ ] Documentation update

## Checklist:
**Documentation**
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] No updates required.

**Code Review**
- [ ] Does the test handle fatal exceptions, ie. rescue block

**Issue**
- [ ] Tasks in issue are checked off
