### PR TITLE
[1751] Semver releases for shards + Crystal update for GitHub Runner image

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -119,6 +119,12 @@ jobs:
         key: lib-${{ hashFiles('**/shard.lock') }}
         restore-keys: |
           lib-
+    - name: Display crystal version
+      run: |
+        helm repo add stable https://cncf.gitlab.io/stable
+        git fetch --all --tags --force
+        echo "Crystal version"
+        crystal version
     - name: Setup CNF-Conformance
       run: |
         helm repo add stable https://cncf.gitlab.io/stable

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -119,12 +119,6 @@ jobs:
         key: lib-${{ hashFiles('**/shard.lock') }}
         restore-keys: |
           lib-
-    - name: Display crystal version
-      run: |
-        helm repo add stable https://cncf.gitlab.io/stable
-        git fetch --all --tags --force
-        echo "Crystal version"
-        crystal version
     - name: Setup CNF-Conformance
       run: |
         helm repo add stable https://cncf.gitlab.io/stable

--- a/shard.lock
+++ b/shard.lock
@@ -1,4 +1,3 @@
-# NOTICE: This lockfile contains some overrides from shard.override.yml
 version: 2.0
 shards:
   airgap:
@@ -7,11 +6,11 @@ shards:
 
   ameba:
     git: https://github.com/crystal-ameba/ameba.git
-    version: 0.14.4
+    version: 1.3.1
 
   cluster_tools:
     git: https://github.com/cnf-testsuite/cluster_tools.git
-    version: 0.1.1+git.commit.bb918898577d166175d24a1a090d2354be663f73
+    version: 1.0.0
 
   commander:
     git: https://github.com/mrrooijen/commander.git
@@ -19,7 +18,7 @@ shards:
 
   docker_client:
     git: https://github.com/cnf-testsuite/docker_client.git
-    version: 0.1.0+git.commit.394f8652859ae635f0504fe9134f96f40975db3c
+    version: 1.0.0
 
   find:
     git: https://github.com/cnf-testsuite/find.git
@@ -27,7 +26,7 @@ shards:
 
   git:
     git: https://github.com/cnf-testsuite/git.git
-    version: 0.1.0+git.commit.9ce4e77987400c7e45bc60fcc36554b9bf1ae59d
+    version: 1.0.0
 
   halite:
     git: https://github.com/icyleaf/halite.git
@@ -35,7 +34,7 @@ shards:
 
   helm:
     git: https://github.com/cnf-testsuite/helm.git
-    version: 0.1.0+git.commit.12b1152fcb8d55806d6c5949716a1ff116c4d3d2
+    version: 1.0.1
 
   icr:
     git: https://github.com/crystal-community/icr.git
@@ -43,19 +42,19 @@ shards:
 
   k8s_kernel_introspection:
     git: https://github.com/cnf-testsuite/k8s_kernel_introspection.git
-    version: 0.1.0+git.commit.c167b740dc6ae771640a46d574749126854bbdd4
+    version: 1.0.0
 
   k8s_netstat:
     git: https://github.com/cnf-testsuite/k8s_netstat.git
-    version: 0.1.0+git.commit.5fb198ea9230311ca571d75c5901a0568b20921a
+    version: 1.0.0
 
   kernel_introspection:
     git: https://github.com/cnf-testsuite/kernel_introspection.git
-    version: 0.1.0+git.commit.a267babbb77bcab877ded6895f9416854a11a67b
+    version: 0.1.0
 
-  kubectl_client: # Overridden
+  kubectl_client:
     git: https://github.com/cnf-testsuite/kubectl_client.git
-    version: 0.1.1+git.commit.a59a4ae02bd948eea19f40d30184b4698217d53d
+    version: 1.0.1
 
   popcorn:
     git: https://github.com/icyleaf/popcorn.git

--- a/shard.override.yml
+++ b/shard.override.yml
@@ -1,4 +1,0 @@
-dependencies:
-  kubectl_client:
-    github: cnf-testsuite/kubectl_client
-    branch: exec-background

--- a/shard.yml
+++ b/shard.yml
@@ -43,28 +43,28 @@ dependencies:
     branch: main
   git:
     github: cnf-testsuite/git
-    branch: main
+    version: ~> 1.0.0
   docker_client:
     github: cnf-testsuite/docker_client
-    branch: main
+    version: ~> 1.0.0
   kubectl_client:
     github: cnf-testsuite/kubectl_client
-    branch: main
+    version: ~> 1.0.1
   cluster_tools:
     github: cnf-testsuite/cluster_tools
-    branch: main 
+    version: ~> 1.0.0
   kernel_introspection:
     github: cnf-testsuite/kernel_introspection
-    branch: main
+    version: ~> 0.1.0
   k8s_kernel_introspection:
     github: cnf-testsuite/k8s_kernel_introspection
-    branch: main
+    version: ~> 1.0.0
   helm:
     github: cnf-testsuite/helm
-    branch: main
+    version: ~> 1.0.1
   k8s_netstat:
     github: cnf-testsuite/k8s_netstat
-    branch: main
+    version: ~> 1.0.0
   release_manager:
     github: cnf-testsuite/release_manager
     branch: main
@@ -78,6 +78,6 @@ dependencies:
 development_dependencies:
   ameba:
     github: crystal-ameba/ameba
-    version: ~> 0.14.3
+    version: ~> 1.3.1
 
 license: MIT

--- a/tools/github-runner/Dockerfile
+++ b/tools/github-runner/Dockerfile
@@ -24,6 +24,7 @@ RUN apt update && \
     libxml2-dev \
     libyaml-dev \
     libgmp-dev \
+    libevent-dev \
     libz-dev && \
     rm -rf /var/lib/apt/lists/*
 

--- a/tools/github-runner/Dockerfile
+++ b/tools/github-runner/Dockerfile
@@ -1,6 +1,6 @@
 FROM myoung34/github-runner:2.303.0-ubuntu-bionic
 
-ARG CRYSTAL_VERSION=1.0.0
+ARG CRYSTAL_VERSION=1.6.2
 ARG CRYSTAL_URL=https://github.com/crystal-lang/crystal/releases/download
 
 RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg --output /usr/share/keyrings/githubcli-archive-keyring.gpg && \

--- a/tools/github-runner/Dockerfile
+++ b/tools/github-runner/Dockerfile
@@ -11,8 +11,10 @@ RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg --o
 
 RUN wget -O /tmp/crystal.tar.gz "$CRYSTAL_URL/$CRYSTAL_VERSION/crystal-$CRYSTAL_VERSION-1-linux-x86_64.tar.gz" --progress=dot:giga && \
     tar -xf /tmp/crystal.tar.gz -C /tmp && \
-    chmod +x /tmp/crystal-${CRYSTAL_VERSION}-1 && \
-    mv /tmp/crystal-${CRYSTAL_VERSION}-1 /usr/local/bin/crystal
+    chmod +x /tmp/crystal-${CRYSTAL_VERSION}-1/bin/crystal && \
+    chmod +x /tmp/crystal-${CRYSTAL_VERSION}-1/bin/shards && \
+    mv /tmp/crystal-${CRYSTAL_VERSION}-1/bin/crystal /usr/local/bin/crystal && \
+    mv /tmp/crystal-${CRYSTAL_VERSION}-1/bin/shards /usr/local/bin/shards
 
 RUN apt update && \
     apt install -y --no-install-recommends \

--- a/tools/github-runner/Dockerfile
+++ b/tools/github-runner/Dockerfile
@@ -10,9 +10,9 @@ RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg --o
     chmod 644 /etc/apt/sources.list.d/github-cli.list
 
 RUN wget -O /tmp/crystal.tar.gz "$CRYSTAL_URL/$CRYSTAL_VERSION/crystal-$CRYSTAL_VERSION-1-linux-x86_64.tar.gz" --progress=dot:giga && \
-    tar -xvf /tmp/crystal.tar.gz -C /tmp && \
-    chmod +x /tmp/crystal && \
-    mv /tmp/crystal /usr/local/bin/
+    tar -xf /tmp/crystal.tar.gz -C /tmp && \
+    chmod +x /tmp/crystal-${CRYSTAL_VERSION}-1 && \
+    mv /tmp/crystal-${CRYSTAL_VERSION}-1 /usr/local/bin/crystal
 
 RUN apt update && \
     apt install -y --no-install-recommends \
@@ -21,8 +21,7 @@ RUN apt update && \
     libxml2-dev \
     libyaml-dev \
     libgmp-dev \
-    libz-dev \
-    ./crystal.deb && \
+    libz-dev && \
     rm -rf /var/lib/apt/lists/*
 
 RUN curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl" && \

--- a/tools/github-runner/Dockerfile
+++ b/tools/github-runner/Dockerfile
@@ -9,8 +9,12 @@ RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg --o
     chmod 644 /usr/share/keyrings/githubcli-archive-keyring.gpg && \
     chmod 644 /etc/apt/sources.list.d/github-cli.list
 
-RUN wget -O crystal.deb "$CRYSTAL_URL/$CRYSTAL_VERSION/crystal_$CRYSTAL_VERSION-1_amd64.deb" --progress=dot:giga && \
-    apt update && \
+RUN wget -O /tmp/crystal.tar.gz "$CRYSTAL_URL/$CRYSTAL_VERSION/crystal-$CRYSTAL_VERSION-1-linux-x86_64.tar.gz" --progress=dot:giga && \
+    tar -xvf /tmp/crystal.tar.gz -C /tmp && \
+    chmod +x /tmp/crystal && \
+    mv /tmp/crystal /usr/local/bin/
+
+RUN apt update && \
     apt install -y --no-install-recommends \
     git \
     libssl-dev \

--- a/tools/github-runner/Dockerfile
+++ b/tools/github-runner/Dockerfile
@@ -9,12 +9,13 @@ RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg --o
     chmod 644 /usr/share/keyrings/githubcli-archive-keyring.gpg && \
     chmod 644 /etc/apt/sources.list.d/github-cli.list
 
-RUN wget -O /tmp/crystal.tar.gz "$CRYSTAL_URL/$CRYSTAL_VERSION/crystal-$CRYSTAL_VERSION-1-linux-x86_64.tar.gz" --progress=dot:giga && \
-    tar -xf /tmp/crystal.tar.gz -C /tmp && \
-    chmod +x /tmp/crystal-${CRYSTAL_VERSION}-1/bin/crystal && \
-    chmod +x /tmp/crystal-${CRYSTAL_VERSION}-1/bin/shards && \
-    mv /tmp/crystal-${CRYSTAL_VERSION}-1/bin/crystal /usr/local/bin/crystal && \
-    mv /tmp/crystal-${CRYSTAL_VERSION}-1/bin/shards /usr/local/bin/shards
+RUN mkdir /crystal && \
+    wget -O /crystal/crystal.tar.gz "$CRYSTAL_URL/$CRYSTAL_VERSION/crystal-$CRYSTAL_VERSION-1-linux-x86_64.tar.gz" --progress=dot:giga && \
+    tar -xf /crystal/crystal.tar.gz -C /tmp && \
+    chmod +x /crystal/crystal-${CRYSTAL_VERSION}-1/bin/crystal && \
+    chmod +x /crystal/crystal-${CRYSTAL_VERSION}-1/bin/shards && \
+    ln -s /crystal/crystal-${CRYSTAL_VERSION}-1/bin/crystal /usr/local/bin/crystal && \
+    ln -s /crystal/crystal-${CRYSTAL_VERSION}-1/bin/shards /usr/local/bin/shards
 
 RUN apt update && \
     apt install -y --no-install-recommends \

--- a/tools/github-runner/Dockerfile
+++ b/tools/github-runner/Dockerfile
@@ -1,4 +1,4 @@
-FROM myoung34/github-runner:2.299.1-ubuntu-bionic
+FROM myoung34/github-runner:2.303.0-ubuntu-bionic
 
 ARG CRYSTAL_VERSION=1.0.0
 ARG CRYSTAL_URL=https://github.com/crystal-lang/crystal/releases/download

--- a/tools/github-runner/create_runners.sh
+++ b/tools/github-runner/create_runners.sh
@@ -29,7 +29,7 @@ VIPS=(
 
 RUNNER_COUNT=0
 for node in "${!RUNNERS[@]}"; do
-    export RUNNER_IMAGE="conformance/github-runner:v2.303.0-2" # don't forget the v
+    export RUNNER_IMAGE="conformance/github-runner:v2.303.0-3" # don't forget the v
     ssh root@${RUNNERS[$node]} "docker pull $RUNNER_IMAGE"
     RUNNERS_PER_NODE=4
     until [ $RUNNERS_PER_NODE -eq 0 ]; do

--- a/tools/github-runner/create_runners.sh
+++ b/tools/github-runner/create_runners.sh
@@ -29,7 +29,7 @@ VIPS=(
 
 RUNNER_COUNT=0
 for node in "${!RUNNERS[@]}"; do
-    export RUNNER_IMAGE="conformance/github-runner:v2.303.0-3" # don't forget the v
+    export RUNNER_IMAGE="conformance/github-runner:v2.303.0-4" # don't forget the v
     ssh root@${RUNNERS[$node]} "docker pull $RUNNER_IMAGE"
     RUNNERS_PER_NODE=4
     until [ $RUNNERS_PER_NODE -eq 0 ]; do

--- a/tools/github-runner/create_runners.sh
+++ b/tools/github-runner/create_runners.sh
@@ -29,7 +29,7 @@ VIPS=(
 
 RUNNER_COUNT=0
 for node in "${!RUNNERS[@]}"; do
-    export RUNNER_IMAGE="conformance/github-runner:v2.303.0" # don't forget the v
+    export RUNNER_IMAGE="conformance/github-runner:v2.303.0-1" # don't forget the v
     ssh root@${RUNNERS[$node]} "docker pull $RUNNER_IMAGE"
     RUNNERS_PER_NODE=4
     until [ $RUNNERS_PER_NODE -eq 0 ]; do

--- a/tools/github-runner/create_runners.sh
+++ b/tools/github-runner/create_runners.sh
@@ -29,7 +29,7 @@ VIPS=(
 
 RUNNER_COUNT=0
 for node in "${!RUNNERS[@]}"; do
-    export RUNNER_IMAGE="conformance/github-runner:v2.303.0-1" # don't forget the v
+    export RUNNER_IMAGE="conformance/github-runner:v2.303.0-2" # don't forget the v
     ssh root@${RUNNERS[$node]} "docker pull $RUNNER_IMAGE"
     RUNNERS_PER_NODE=4
     until [ $RUNNERS_PER_NODE -eq 0 ]; do

--- a/tools/github-runner/create_runners.sh
+++ b/tools/github-runner/create_runners.sh
@@ -29,7 +29,7 @@ VIPS=(
 
 RUNNER_COUNT=0
 for node in "${!RUNNERS[@]}"; do
-    export RUNNER_IMAGE="conformance/github-runner:v2.299.1" # don't forget the v
+    export RUNNER_IMAGE="conformance/github-runner:v2.303.0" # don't forget the v
     ssh root@${RUNNERS[$node]} "docker pull $RUNNER_IMAGE"
     RUNNERS_PER_NODE=4
     until [ $RUNNERS_PER_NODE -eq 0 ]; do

--- a/utils/airgap/shard.yml
+++ b/utils/airgap/shard.yml
@@ -26,13 +26,13 @@ dependencies:
     branch: main
   helm:
     github: cnf-testsuite/helm
-    branch: main
+    version: ~> 1.0.1
   kubectl_client:
     github: cnf-testsuite/kubectl_client
-    branch: main
+    version: ~> 1.0.1
   docker_client:
     github: cnf-testsuite/docker_client
-    branch: main
+    version: ~> 1.0.0
   # find:
   #   path: utils/find
   find:


### PR DESCRIPTION
## Issues:
Refs: #1751, #1760, #1754

## Description
1. Update some shards to point to their semver releases.
2. Update Crystal version to 1.6.2 in GitHub Runner image enable [1] to work.
3. Update GitHub Runner dockerfile to point to new base image version.
4. Update create_runners script to use new image tag.

## How has this been tested:
 - [x] Covered by existing integration testing
 - [ ] Added integration testing to cover
 - [ ] Verified all A/C passes
     * [ ] develop
     * [ ] master
     * [ ] tag/other branch
 - [ ] Test environment
    * [ ] Shared Packet K8s cluster
    * [ ] New Packet K8s cluster
    * [ ] Kind cluster
 - [ ] Have not tested

## Types of changes:
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [x] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [ ] Documentation update

## Checklist:
**Documentation**
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] No updates required.

**Code Review**
- [ ] Does the test handle fatal exceptions, ie. rescue block

**Issue**
- [ ] Tasks in issue are checked off
