### PR TITLE
raise exception when cluster tools namespace does not exist #1624

### DIFF
--- a/spec/cluster_setup_spec.cr
+++ b/spec/cluster_setup_spec.cr
@@ -1,0 +1,40 @@
+require "./spec_helper"
+require "colorize"
+require "../src/tasks/utils/utils.cr"
+require "kubectl_client"
+require "cluster_tools"
+
+describe "Cluster Setup" do
+
+  before_each do
+    `./cnf-testsuite cleanup`
+    $?.success?.should be_true
+  end
+
+  it "'install_cluster_tools' should give a message if namespace does not exist", tags: ["cluster_setup"]  do
+    KubectlClient::Delete.command("namespace #{ClusterTools.namespace}")
+    response_s = `./cnf-testsuite install_cluster_tools`
+    LOGGING.info response_s
+    $?.success?.should be_false
+    (/please run cnf-testsuite setup/ =~ response_s).should_not be_nil
+  end
+  
+  it "'install_cluster_tools' should give a message if namespace does not exist even after setup", tags: ["cluster_setup"]  do
+    `./cnf-testsuite setup`
+
+    KubectlClient::Delete.command("namespace #{ClusterTools.namespace}")
+
+    response_s = `./cnf-testsuite install_cluster_tools`
+    LOGGING.info response_s
+    $?.success?.should be_false
+    (/please run cnf-testsuite setup/ =~ response_s).should_not be_nil
+  end
+
+  it "'uninstall_cluster_tools' should give a message if namespace does not exist", tags: ["cluster_setup"]  do
+    response_s = `./cnf-testsuite uninstall_cluster_tools`
+    LOGGING.info response_s
+    $?.success?.should be_false
+    (/please run cnf-testsuite setup/ =~ response_s).should_not be_nil
+  end
+
+end

--- a/spec/setup_spec.cr
+++ b/spec/setup_spec.cr
@@ -15,7 +15,6 @@ describe "Setup" do
   end
 
   it "'setup' should completely setup the cnf testsuite environment before installing cnfs", tags: ["setup"]  do
-
     response_s = `./cnf-testsuite setup`
     LOGGING.info response_s
     $?.success?.should be_true

--- a/src/tasks/cluster_setup.cr
+++ b/src/tasks/cluster_setup.cr
@@ -1,6 +1,7 @@
 require "sam"
 require "file_utils"
 require "colorize"
+require "cluster_tools"
 require "totem"
 require "./utils/utils.cr"
 
@@ -10,10 +11,19 @@ require "./utils/utils.cr"
 desc "Install CNF Test Suite Cluster Tools"
 task "install_cluster_tools" do |_, args|
   Log.info { "install_cluster_tools" }
-  ClusterTools.install
+
+  begin
+    ClusterTools.install
+  rescue e : ClusterTools::NamespaceDoesNotExistException 
+    raise "#{e.message}. please run cnf-testsuite setup!"
+  end
 end
 
 desc "Uninstall CNF Test Suite Cluster Tools"
 task "uninstall_cluster_tools" do |_, args|
-  ClusterTools.uninstall
+  begin
+    ClusterTools.uninstall
+  rescue e : ClusterTools::NamespaceDoesNotExistException 
+    raise "#{e.message}. please run cnf-testsuite setup!"
+  end
 end


### PR DESCRIPTION
## Description

redo of https://github.com/cncf/cnf-testsuite/pull/1746

which was accidentally merged from a bad force push.

blocked by https://github.com/cncf/cnf-testsuite/pull/1766

## Issues:
Refs: #1624 

depends on https://github.com/cnf-testsuite/cluster_tools/pull/12

## How has this been tested:
 - [ ] Covered by existing integration testing
 - [ ] Added integration testing to cover
 - [ ] Verified all A/C passes
     * [ ] develop
     * [ ] master
     * [ ] tag/other branch
 - [ ] Test environment
    * [ ] Shared Packet K8s cluster
    * [ ] New Packet K8s cluster
    * [ ] Kind cluster
 - [ ] Have not tested

## Types of changes:
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [ ] Documentation update

## Checklist:
**Documentation**
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] No updates required.

**Code Review**
- [ ] Does the test handle fatal exceptions, ie. rescue block

**Issue**
- [ ] Tasks in issue are checked off
