### PR TITLE
[bug/1597] Allow configuring insecure docker registries and image registry FQDNs

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -153,6 +153,7 @@ jobs:
         DOCKERHUB_PASSWORDS: ${{ secrets.DOCKERHUB_PASSWORDS }}
         DOCKERHUB_EMAIL: ${{ secrets.DOCKERHUB_EMAIL }}
         IMAGE_REPO: ${{ secrets.IMAGE_REPO }}
+        CNF_TESTSUITE_DIR: "/tmp/cnf-testsuite-home"
       run: |
         USERNAME_ARRAY=($DOCKERHUB_USERNAMES)
         PASSWORD_ARRAY=($DOCKERHUB_PASSWORDS)

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -153,7 +153,6 @@ jobs:
         DOCKERHUB_PASSWORDS: ${{ secrets.DOCKERHUB_PASSWORDS }}
         DOCKERHUB_EMAIL: ${{ secrets.DOCKERHUB_EMAIL }}
         IMAGE_REPO: ${{ secrets.IMAGE_REPO }}
-        CNF_TESTSUITE_DIR: "/tmp/cnf-testsuite-home"
       run: |
         USERNAME_ARRAY=($DOCKERHUB_USERNAMES)
         PASSWORD_ARRAY=($DOCKERHUB_PASSWORDS)

--- a/CNF_TESTSUITE_YML_USAGE.md
+++ b/CNF_TESTSUITE_YML_USAGE.md
@@ -151,3 +151,29 @@ Example setting:
 `--set myvalue=42`
 
 
+#### `image_registry_fqdns`
+
+When using a private registry hosted on the cluster, the image references in the CNF's helm chart may refer to the registry host with the Kubernetes service name alone. The CNF Testsuite runs a docker daemon in a separate `cnf-testsuite` namespace on the Kubernetes cluster. So it is required for the testsuite to be aware of the FQDN of the service, along with the port.
+
+Use this option to configure FQDNs of image registries for the testsuite to access.
+
+If the CNF's helm charts use the image url `foobar:5000/hello:latest`, then please use the configuration in below in `cnf-testsuite.yml` to provide the FQDN mapping for the image registry.
+
+```yaml
+image_registry_fqdns:
+    "foobar:5000": "foobar.default.svc.cluster.local:5000"
+```
+
+> *The above example assumes that the `foobar` registry service is running on the `default` namespace.*
+
+#### `docker_insecure_registries`
+
+The docker client expects the image registries to be using an HTTPS API endpoint. This option is used to configure insecure registries that the docker client should be allowed to access.
+
+Please use this option to configure Docker to use HTTP to access the registry API.
+
+For an image registry service named `foobar`, running in `default` namespace, on port `5000`, the following would be the expected configuration.
+
+```yaml
+docker_insecure_registries: ["foobar.default.svc.cluster.local:5000"]
+```

--- a/src/tasks/constants.cr
+++ b/src/tasks/constants.cr
@@ -27,7 +27,6 @@ TESTSUITE_NAMESPACE = "cnf-testsuite"
 
 #Embedded global text variables
 EmbeddedFileManager.node_failure_values
-EmbeddedFileManager.dockerd_manifest
 EmbeddedFileManager.falco_rules
 EmbeddedFileManager.reboot_daemon
 EmbeddedFileManager.chaos_network_loss

--- a/src/tasks/utils/config.cr
+++ b/src/tasks/utils/config.cr
@@ -32,7 +32,7 @@ module CNFManager
                                      rolling_update_tag: String,
                                      container_names: Array(Hash(String, String )) | Nil,
                                      white_list_container_names: Array(String),
-                                     docker_insecure_registries: Array(String),
+                                     docker_insecure_registries: Array(String) | Nil,
                                      image_registry_fqdns: Hash(String, String ) | Nil)
 
     def self.parse_config_yml(config_yml_path : String, airgapped=false, generate_tar_mode=false) : CNFManager::Config
@@ -113,16 +113,16 @@ module CNFManager
       end
 
       docker_insecure_registries = [] of String
-      if config["docker_insecure_registries"]?
+      if config["docker_insecure_registries"]? && !config["docker_insecure_registries"].nil?
         docker_insecure_registries = config["docker_insecure_registries"].as_a.map do |c|
           "#{c.as_s?}"
         end
       end
 
       image_registry_fqdns = Hash(String, String).new
-      if config["image_registry_fqdns"]?
-        config["docker_insecure_registries"].each do |key, value|
-          image_registry_fqdns[key] = value
+      if config["image_registry_fqdns"]? && !config["image_registry_fqdns"].nil?
+        config["image_registry_fqdns"].as_h.each do |key, value|
+          image_registry_fqdns[key] = value.as_s
         end
       end
 

--- a/src/tasks/utils/config.cr
+++ b/src/tasks/utils/config.cr
@@ -31,7 +31,8 @@ module CNFManager
                                      helm_install_namespace: String,
                                      rolling_update_tag: String,
                                      container_names: Array(Hash(String, String )) | Nil,
-                                     white_list_container_names: Array(String)) 
+                                     white_list_container_names: Array(String),
+                                     docker_insecure_registries: Array(String))
 
     def self.parse_config_yml(config_yml_path : String, airgapped=false, generate_tar_mode=false) : CNFManager::Config
       LOGGING.debug "parse_config_yml config_yml_path: #{config_yml_path}"
@@ -110,6 +111,13 @@ module CNFManager
          }]
       end
 
+      docker_insecure_registries = [] of String
+      if config["docker_insecure_registries"]?
+        docker_insecure_registries = config["docker_insecure_registries"].as_a.map do |c|
+          "#{c.as_s?}"
+        end
+      end
+
       # if you change this, change instantiation in task.cr/single_task_runner as well
       new({ destination_cnf_dir: destination_cnf_dir,
                                source_cnf_file: source_cnf_file,
@@ -129,7 +137,8 @@ module CNFManager
                                helm_install_namespace: helm_install_namespace,
                                rolling_update_tag: "",
                                container_names: container_names,
-                               white_list_container_names: white_list_container_names })
+                               white_list_container_names: white_list_container_names,
+                               docker_insecure_registries: docker_insecure_registries})
 
     end
     def self.install_method_by_config_file(config_file) : Helm::InstallMethod

--- a/src/tasks/utils/config.cr
+++ b/src/tasks/utils/config.cr
@@ -32,7 +32,8 @@ module CNFManager
                                      rolling_update_tag: String,
                                      container_names: Array(Hash(String, String )) | Nil,
                                      white_list_container_names: Array(String),
-                                     docker_insecure_registries: Array(String))
+                                     docker_insecure_registries: Array(String),
+                                     image_registry_fqdns: Hash(String, String ) | Nil)
 
     def self.parse_config_yml(config_yml_path : String, airgapped=false, generate_tar_mode=false) : CNFManager::Config
       LOGGING.debug "parse_config_yml config_yml_path: #{config_yml_path}"
@@ -118,6 +119,13 @@ module CNFManager
         end
       end
 
+      image_registry_fqdns = Hash(String, String).new
+      if config["image_registry_fqdns"]?
+        config["docker_insecure_registries"].each do |key, value|
+          image_registry_fqdns[key] = value
+        end
+      end
+
       # if you change this, change instantiation in task.cr/single_task_runner as well
       new({ destination_cnf_dir: destination_cnf_dir,
                                source_cnf_file: source_cnf_file,
@@ -138,7 +146,8 @@ module CNFManager
                                rolling_update_tag: "",
                                container_names: container_names,
                                white_list_container_names: white_list_container_names,
-                               docker_insecure_registries: docker_insecure_registries})
+                               docker_insecure_registries: docker_insecure_registries,
+                               image_registry_fqdns: image_registry_fqdns,})
 
     end
     def self.install_method_by_config_file(config_file) : Helm::InstallMethod

--- a/src/tasks/utils/dockerd.cr
+++ b/src/tasks/utils/dockerd.cr
@@ -1,7 +1,22 @@
 module Dockerd
-  def self.install
+  def self.install(insecure_registries : Array(String) = [])
+    # These are default values to help speed up the cluster setup for the CNF
+    insecure_registries_default = ["registry:5000", "registry.default.svc.cluster.local:5000"]
+    if insecure_registries != []
+      insecure_registries = insecure_registries_default
+    end
+
+    # If configmaps/docker-config is not present, create one using the default template.
+    docker_config_check = KubectlClient::Get.resource("configmaps", "docker-config", TESTSUITE_NAMESPACE)
+    if docker_config_check["kind"].nil?
+      Log.info { "Install dockerd from manifest" }
+      KubectlClient::Apply.file(docker_config_manifest_file, namespace: TESTSUITE_NAMESPACE)
+    else
+      Log.info { "Skipping docker-config. ConfigMap exists." }
+    end
+
     Log.info { "Install dockerd from manifest" }
-    KubectlClient::Apply.file(manifest_file, namespace: TESTSUITE_NAMESPACE)
+    KubectlClient::Apply.file(dockerd_manifest_file, namespace: TESTSUITE_NAMESPACE)
     wait_for_install
   end
 
@@ -12,18 +27,47 @@ module Dockerd
 
   def self.uninstall
     Log.info { "Uninstall dockerd from manifest" }
-    KubectlClient::Delete.file(manifest_file, namespace: TESTSUITE_NAMESPACE)
+    KubectlClient::Delete.file(dockerd_manifest_file, namespace: TESTSUITE_NAMESPACE)
+
+    Log.info { "Uninstall docker-config from manifest" }
+    KubectlClient::Delete.command("configmaps/docker-config -n #{TESTSUITE_NAMESPACE}")
   end
 
   def self.exec(cli, force_output : Bool = false)
     KubectlClient.exec("dockerd -t -- #{cli}", namespace: TESTSUITE_NAMESPACE, force_output: force_output)
   end
 
-  def self.manifest_file
+  def self.dockerd_manifest_file
     manifest_path = "./#{TOOLS_DIR}/dockerd-manifest.yml"
     unless File.exists?(manifest_path)
-      File.write(manifest_path, DOCKERD_MANIFEST)
+      template = DockerdManifest.new.to_s
+      File.write(manifest_path, template)
     end
     manifest_path
   end
+
+  # Ignore existing file and overwrite everytime to ensure latest config is present
+  def self.docker_config_manifest_file(insecure_registries : Array(String) = [])
+    insecure_registries_str = insecure_registries.join(",")
+    manifest_path = "./#{TOOLS_DIR}/docker-config-manifest.yml"
+    template = DockerConfigManifest.new(insecure_registries_str).to_s
+    File.write(manifest_path, template)
+    manifest_path
+  end
+
+  class DockerdManifest
+    def initialize()
+    end
+    ECR.def_to_s("src/templates/dockerd-manifest.yml.ecr")
+  end
+
+  class DockerConfigManifest
+    # The argument for insecure_registries is a string
+    # because the template only writes the content
+    # and expects a list of comma separated strings.
+    def initialize(@insecure_registries : String)
+    end
+    ECR.def_to_s("src/templates/docker-config.yml.ecr")
+  end
+
 end

--- a/src/tasks/utils/dockerd.cr
+++ b/src/tasks/utils/dockerd.cr
@@ -49,7 +49,7 @@ module Dockerd
   # Ignore existing file and overwrite everytime to ensure latest config is present
   def self.docker_config_manifest_file(insecure_registries : Array(String) = [] of String)
     insecure_registries_str = insecure_registries.map {|i| "\"#{i}\""}.join(",")
-    manifest_path = "./#{TOOLS_DIR}/docker-config-manifest.yml"
+    manifest_path = "./#{tools_path}/docker-config-manifest.yml"
     template = DockerConfigManifest.new(insecure_registries_str).to_s
     File.write(manifest_path, template)
     manifest_path

--- a/src/tasks/utils/dockerd.cr
+++ b/src/tasks/utils/dockerd.cr
@@ -49,7 +49,7 @@ module Dockerd
   # Ignore existing file and overwrite everytime to ensure latest config is present
   def self.docker_config_manifest_file(insecure_registries : Array(String) = [] of String)
     insecure_registries_str = insecure_registries.map {|i| "\"#{i}\""}.join(",")
-    manifest_path = "./#{tools_path}/docker-config-manifest.yml"
+    manifest_path = "#{tools_path}/docker-config-manifest.yml"
     template = DockerConfigManifest.new(insecure_registries_str).to_s
     File.write(manifest_path, template)
     manifest_path

--- a/src/tasks/utils/dockerd.cr
+++ b/src/tasks/utils/dockerd.cr
@@ -1,8 +1,8 @@
 module Dockerd
-  def self.install(insecure_registries : Array(String) = [])
+  def self.install(insecure_registries : Array(String) = [] of String)
     # These are default values to help speed up the cluster setup for the CNF
     insecure_registries_default = ["registry:5000", "registry.default.svc.cluster.local:5000"]
-    if insecure_registries != []
+    if !insecure_registries.empty?
       insecure_registries = insecure_registries_default
     end
 
@@ -47,7 +47,7 @@ module Dockerd
   end
 
   # Ignore existing file and overwrite everytime to ensure latest config is present
-  def self.docker_config_manifest_file(insecure_registries : Array(String) = [])
+  def self.docker_config_manifest_file(insecure_registries : Array(String) = [] of String)
     insecure_registries_str = insecure_registries.join(",")
     manifest_path = "./#{TOOLS_DIR}/docker-config-manifest.yml"
     template = DockerConfigManifest.new(insecure_registries_str).to_s

--- a/src/tasks/utils/dockerd.cr
+++ b/src/tasks/utils/dockerd.cr
@@ -11,7 +11,6 @@ module Dockerd
     if !docker_config_check["kind"]?
       Log.info { "Install dockerd from manifest" }
       KubectlClient::Apply.file(docker_config_manifest_file(insecure_registries), namespace: TESTSUITE_NAMESPACE)
-      KubectlClient::Get.resource_wait_for_install("configmap", "docker-config", 180, TESTSUITE_NAMESPACE)
     else
       Log.info { "Skipping docker-config. ConfigMap exists." }
     end
@@ -49,7 +48,7 @@ module Dockerd
 
   # Ignore existing file and overwrite everytime to ensure latest config is present
   def self.docker_config_manifest_file(insecure_registries : Array(String) = [] of String)
-    insecure_registries_str = insecure_registries.join(",")
+    insecure_registries_str = insecure_registries.map {|i| "\"#{i}\""}.join(",")
     manifest_path = "./#{TOOLS_DIR}/docker-config-manifest.yml"
     template = DockerConfigManifest.new(insecure_registries_str).to_s
     File.write(manifest_path, template)

--- a/src/tasks/utils/embedded_file_manager.cr
+++ b/src/tasks/utils/embedded_file_manager.cr
@@ -3,10 +3,7 @@ require "colorize"
 require "log"
 require "halite"
 
-module EmbeddedFileManager 
-  macro dockerd_manifest
-    DOCKERD_MANIFEST = Base64.decode_string("{{ `cat ./tools/dockerd/manifest.yml | base64` }}")
-  end
+module EmbeddedFileManager
   macro falco_rules
     FALCO_RULES = Base64.decode_string("{{ `cat ./embedded_files/falco_rule.yaml | base64` }}")
   end

--- a/src/tasks/utils/task.cr
+++ b/src/tasks/utils/task.cr
@@ -80,7 +80,8 @@ module CNFManager
                                             helm_install_namespace: "",
                                             rolling_update_tag: "",
                                             container_names: [{"name" =>  "", "rolling_update_test_tag" => ""}],
-                                            white_list_container_names: [""]} )
+                                            white_list_container_names: [""],
+                                            docker_insecure_registries: [] of String} )
         end
         ret = yield args, config
         #todo lax mode, never returns 1

--- a/src/tasks/utils/task.cr
+++ b/src/tasks/utils/task.cr
@@ -81,11 +81,12 @@ module CNFManager
                                             rolling_update_tag: "",
                                             container_names: [{"name" =>  "", "rolling_update_test_tag" => ""}],
                                             white_list_container_names: [""],
-                                            docker_insecure_registries: [] of String} )
+                                            docker_insecure_registries: [] of String,
+                                            image_registry_fqdns: Hash(String, String).new} )
         end
         ret = yield args, config
         #todo lax mode, never returns 1
-        if args.raw.includes? "strict" 
+        if args.raw.includes? "strict"
           if CNFManager::Points.failed_required_tasks.size > 0
             stdout_failure "Test Suite failed in strict mode. Stopping executing."
             stdout_failure "Failed required tasks: #{CNFManager::Points.failed_required_tasks.inspect}"

--- a/src/tasks/workload/microservice.cr
+++ b/src/tasks/workload/microservice.cr
@@ -200,7 +200,7 @@ desc "Does the CNF have a reasonable container image size (< 5GB)?"
 task "reasonable_image_size" do |_, args|
   CNFManager::Task.task_runner(args) do |args,config|
     docker_insecure_registries = [] of String
-    if !config.cnf_config[:docker_insecure_registries].empty?
+    if config.cnf_config[:docker_insecure_registries]? && !config.cnf_config[:docker_insecure_registries].nil?
       docker_insecure_registries = config.cnf_config[:docker_insecure_registries]
     end
     unless Dockerd.install(docker_insecure_registries)
@@ -228,7 +228,7 @@ task "reasonable_image_size" do |_, args|
 
         # If FQDN mapping is available for the registry,
         # replace the host in the fqdn_image
-        if !config.cnf_config[:image_registry_fqdns].empty?
+        if config.cnf_config[:image_registry_fqdns]? && !config.cnf_config[:image_registry_fqdns].nil?
           image_registry_fqdns = config.cnf_config[:image_registry_fqdns]
           if image_registry_fqdns[image_host]?
             image_url_parts[0] = image_registry_fqdns[image_host]

--- a/src/tasks/workload/microservice.cr
+++ b/src/tasks/workload/microservice.cr
@@ -199,7 +199,7 @@ end
 desc "Does the CNF have a reasonable container image size (< 5GB)?"
 task "reasonable_image_size" do |_, args|
   CNFManager::Task.task_runner(args) do |args,config|
-    docker_insecure_registries = []
+    docker_insecure_registries = [] of String
     if !config.cnf_config[:docker_insecure_registries].empty?
       docker_insecure_registries = config.cnf_config[:docker_insecure_registries]
     end

--- a/src/tasks/workload/microservice.cr
+++ b/src/tasks/workload/microservice.cr
@@ -199,7 +199,11 @@ end
 desc "Does the CNF have a reasonable container image size (< 5GB)?"
 task "reasonable_image_size" do |_, args|
   CNFManager::Task.task_runner(args) do |args,config|
-    unless Dockerd.install
+    docker_insecure_registries = []
+    if !config.cnf_config[:docker_insecure_registries].empty?
+      docker_insecure_registries = config.cnf_config[:docker_insecure_registries]
+    end
+    unless Dockerd.install(docker_insecure_registries)
       upsert_skipped_task("reasonable_image_size", "⏭️  SKIPPED: Skipping reasonable_image_size: Dockerd tool failed to install")
       next
     end

--- a/src/tasks/workload/microservice.cr
+++ b/src/tasks/workload/microservice.cr
@@ -201,7 +201,7 @@ task "reasonable_image_size" do |_, args|
   CNFManager::Task.task_runner(args) do |args,config|
     docker_insecure_registries = [] of String
     if config.cnf_config[:docker_insecure_registries]? && !config.cnf_config[:docker_insecure_registries].nil?
-      docker_insecure_registries = config.cnf_config[:docker_insecure_registries]
+      docker_insecure_registries = config.cnf_config[:docker_insecure_registries].not_nil!
     end
     unless Dockerd.install(docker_insecure_registries)
       upsert_skipped_task("reasonable_image_size", "⏭️  SKIPPED: Skipping reasonable_image_size: Dockerd tool failed to install")
@@ -229,7 +229,7 @@ task "reasonable_image_size" do |_, args|
         # If FQDN mapping is available for the registry,
         # replace the host in the fqdn_image
         if config.cnf_config[:image_registry_fqdns]? && !config.cnf_config[:image_registry_fqdns].nil?
-          image_registry_fqdns = config.cnf_config[:image_registry_fqdns]
+          image_registry_fqdns = config.cnf_config[:image_registry_fqdns].not_nil!
           if image_registry_fqdns[image_host]?
             image_url_parts[0] = image_registry_fqdns[image_host]
             fqdn_image = image_url_parts.join("/")

--- a/src/templates/docker-config.yml.ecr
+++ b/src/templates/docker-config.yml.ecr
@@ -6,5 +6,5 @@ metadata:
 data:
   config.yaml: |
     {
-      "insecure-registries" : [<% @insecure_registries %>]
+      "insecure-registries" : [<%= @insecure_registries %>]
     }

--- a/src/templates/docker-config.yml.ecr
+++ b/src/templates/docker-config.yml.ecr
@@ -1,0 +1,10 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: docker-config
+data:
+  config.yaml: |
+    {
+      "insecure-registries" : [<% @insecure_registries %>]
+    }

--- a/src/templates/dockerd-manifest.yml.ecr
+++ b/src/templates/dockerd-manifest.yml.ecr
@@ -1,15 +1,5 @@
 ---
 apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: docker-config
-data:
-  config.yaml: |
-    {
-      "insecure-registries" : ["registry:5000", "registry.default.svc.cluster.local:5000"]
-    }
----
-apiVersion: v1
 kind: Pod
 metadata:
     name: dockerd


### PR DESCRIPTION
## Issues
Refs: #1597

## Description

The `reasonable_image_size` test would throw an `Int64` error. This was due to two issues:

#### 1. Insecure access was not configurable for the docker daemon being setup by the testsuite

Private registries hosted on the cluster usually have to be trusted to use registry API endpoints via HTTP. The docker daemon has to be configured to be allowed to access the private image registry on the cluster via HTTP endpoints.

#### 2. Docker daemon requires FQDN to use a private registry

The Docker daemon is setup by the testsuite on the `cnf-testsuite` namespace. For the `reasonable_image_size` test, when the testsuite is referring to an image registry on another namespace, the testsuite requires the service discovery url for the service. It cannot access the registry with just the service name.

So if the helm chart mentions `foobar:5000/coredns:1.6.7`, the docker daemon wouldn't know which namespace the service is on.

## Solution in this PR

This PR adds support for two options in `cnf-testsuite.yml` to support private image registries.

### `image_registry_fqdns` option

When using a private registry hosted on the cluster, the image references in the CNF's helm chart may refer to the registry host with the Kubernetes service name alone. The CNF Testsuite runs a docker daemon in a separate `cnf-testsuite` namespace on the Kubernetes cluster. So it is required for the testsuite to be aware of the FQDN of the service, along with the port.

Use this option to configure FQDNs of image registries for the testsuite to access.

If the CNF's helm charts use the image url `foobar:5000/hello:latest`, then please use the configuration in below in `cnf-testsuite.yml` to provide the FQDN mapping for the image registry.

```yaml
image_registry_fqdns:
    "foobar:5000": "foobar.default.svc.cluster.local:5000"
```

> *The above example assumes that the `foobar` registry service is running on the `default` namespace.*

### `docker_insecure_registries` option

The docker client expects the image registries to be using an HTTPS API endpoint. This option is used to configure insecure registries that the docker client should be allowed to access.

Please use this option to configure Docker to use HTTP to access the registry API.

For an image registry service named `foobar`, running in `default` namespace, on port `5000`, the following would be the expected configuration.

```yaml
docker_insecure_registries: ["foobar.default.svc.cluster.local:5000"]
```

## Validating the issue & verifying this PR

The git repo <https://git.sr.ht/~akash/cnf-testsuite-issue-1597> has notes on reproducing this issue.

### Example CNF to reproduce the error

```shell
./cnf-testsuite cnf_setup cnf-path=sample-coredns
./cnf-testsuite reasonable_image_size
# This should fail
```

### Example CNF to test the new `cnf-testsuite.yml` options that resolves the error

There is a second CNF in the same git repo mentioned above which has a config that uses new testsuite options introduced in this PR.

```shell
./cnf-testsuite cnf_setup cnf-path=sample-coredns-FIXED
./cnf-testsuite reasonable_image_size
# This should pass
```

## Checklist

 - [x] Covered by existing integration testing
 - [ ] Added integration testing to cover
 - [ ] Verified all A/C passes
     * [ ] develop
     * [ ] master
     * [ ] tag/other branch
 - [ ] Test environment
    * [ ] Shared Packet K8s cluster
    * [ ] New Packet K8s cluster
    * [ ] Kind cluster
 - [ ] Have not tested

## Types of changes:
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [x] Documentation update

## Checklist:
**Documentation**
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] No updates required.

**Code Review**
- [ ] Does the test handle fatal exceptions, ie. rescue block

**Issue**
- [ ] Tasks in issue are checked off
