### PR TITLE
[1807] Add task runtime info to results file if `TASK_TIMESTAMPS` env var is set

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -113,8 +113,8 @@ jobs:
         KIND_VERSION: v0.17.0
         KIND_URL: https://kind.sigs.k8s.io/dl
       run: |
-        echo $(which kind)
-        sudo rm $(which kind)
+        echo "Existing kind binary path: $(which kind)"
+        if [[ -s $(which kind) ]]; then sudo rm $(which kind); fi
         wget -O kind "$KIND_URL/$KIND_VERSION/kind-linux-amd64" --progress=dot:giga; 
         chmod +x ./kind
         sudo mv ./kind /usr/local/bin/kind
@@ -221,8 +221,8 @@ jobs:
         KIND_VERSION: v0.17.0
         KIND_URL: https://kind.sigs.k8s.io/dl
       run: |
-        echo $(which kind)
-        sudo rm $(which kind)
+        echo "Existing kind binary path: $(which kind)"
+        if [[ -s $(which kind) ]]; then sudo rm $(which kind); fi
         wget -O kind "$KIND_URL/$KIND_VERSION/kind-linux-amd64" --progress=dot:giga; 
         chmod +x ./kind
         sudo mv ./kind /usr/local/bin/kind
@@ -792,8 +792,8 @@ jobs:
         KIND_VERSION: v0.17.0
         KIND_URL: https://kind.sigs.k8s.io/dl
       run: |
-        echo $(which kind)
-        sudo rm $(which kind)
+        echo "Existing kind binary path: $(which kind)"
+        if [[ -s $(which kind) ]]; then sudo rm $(which kind); fi
         wget -O kind "$KIND_URL/$KIND_VERSION/kind-linux-amd64" --progress=dot:giga; 
         chmod +x ./kind
         sudo mv ./kind /usr/local/bin/kind
@@ -872,8 +872,8 @@ jobs:
         KIND_VERSION: v0.17.0
         KIND_URL: https://kind.sigs.k8s.io/dl
       run: |
-        echo $(which kind)
-        sudo rm $(which kind)
+        echo "Existing kind binary path: $(which kind)"
+        if [[ -s $(which kind) ]]; then sudo rm $(which kind); fi
         wget -O kind "$KIND_URL/$KIND_VERSION/kind-linux-amd64" --progress=dot:giga; 
         chmod +x ./kind
         sudo mv ./kind /usr/local/bin/kind
@@ -942,8 +942,8 @@ jobs:
         KIND_VERSION: v0.17.0
         KIND_URL: https://kind.sigs.k8s.io/dl
       run: |
-        echo $(which kind)
-        sudo rm $(which kind)
+        echo "Existing kind binary path: $(which kind)"
+        if [[ -s $(which kind) ]]; then sudo rm $(which kind); fi
         wget -O kind "$KIND_URL/$KIND_VERSION/kind-linux-amd64" --progress=dot:giga; 
         chmod +x ./kind
         sudo mv ./kind /usr/local/bin/kind

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -113,8 +113,7 @@ jobs:
         KIND_VERSION: v0.17.0
         KIND_URL: https://kind.sigs.k8s.io/dl
       run: |
-        kind --version
-        which kind
+        echo $(which kind)
         sudo rm $(which kind)
         wget -O kind "$KIND_URL/$KIND_VERSION/kind-linux-amd64" --progress=dot:giga; 
         chmod +x ./kind
@@ -222,8 +221,7 @@ jobs:
         KIND_VERSION: v0.17.0
         KIND_URL: https://kind.sigs.k8s.io/dl
       run: |
-        kind --version
-        which kind
+        echo $(which kind)
         sudo rm $(which kind)
         wget -O kind "$KIND_URL/$KIND_VERSION/kind-linux-amd64" --progress=dot:giga; 
         chmod +x ./kind
@@ -794,8 +792,7 @@ jobs:
         KIND_VERSION: v0.17.0
         KIND_URL: https://kind.sigs.k8s.io/dl
       run: |
-        kind --version
-        which kind
+        echo $(which kind)
         sudo rm $(which kind)
         wget -O kind "$KIND_URL/$KIND_VERSION/kind-linux-amd64" --progress=dot:giga; 
         chmod +x ./kind
@@ -875,8 +872,7 @@ jobs:
         KIND_VERSION: v0.17.0
         KIND_URL: https://kind.sigs.k8s.io/dl
       run: |
-        kind --version
-        which kind
+        echo $(which kind)
         sudo rm $(which kind)
         wget -O kind "$KIND_URL/$KIND_VERSION/kind-linux-amd64" --progress=dot:giga; 
         chmod +x ./kind
@@ -946,8 +942,7 @@ jobs:
         KIND_VERSION: v0.17.0
         KIND_URL: https://kind.sigs.k8s.io/dl
       run: |
-        kind --version
-        which kind
+        echo $(which kind)
         sudo rm $(which kind)
         wget -O kind "$KIND_URL/$KIND_VERSION/kind-linux-amd64" --progress=dot:giga; 
         chmod +x ./kind

--- a/spec/utils/cnf_manager_spec.cr
+++ b/spec/utils/cnf_manager_spec.cr
@@ -81,7 +81,7 @@ describe "SampleUtils" do
 
   it "'upsert_task' insert task in the results file", tags: ["tasks"]  do
     CNFManager::Points.clean_results_yml
-   CNFManager::Points.upsert_task("liveness", PASSED, CNFManager::Points.task_points("liveness"))
+   CNFManager::Points.upsert_task("liveness", PASSED, CNFManager::Points.task_points("liveness"), Time.utc)
     yaml = File.open("#{CNFManager::Points::Results.file}") do |file|
       YAML.parse(file)
     end
@@ -91,8 +91,8 @@ describe "SampleUtils" do
 
   it "'upsert_task' should find and update an existing task in the file", tags: ["tasks"]  do
     CNFManager::Points.clean_results_yml
-   CNFManager::Points.upsert_task("liveness", PASSED, CNFManager::Points.task_points("liveness"))
-   CNFManager::Points.upsert_task("liveness", PASSED, CNFManager::Points.task_points("liveness"))
+   CNFManager::Points.upsert_task("liveness", PASSED, CNFManager::Points.task_points("liveness"), Time.utc)
+   CNFManager::Points.upsert_task("liveness", PASSED, CNFManager::Points.task_points("liveness"), Time.utc)
     yaml = File.open("#{CNFManager::Points::Results.file}") do |file|
       YAML.parse(file)
     end
@@ -103,15 +103,15 @@ describe "SampleUtils" do
 
   it "'CNFManager::Points.total_points' should sum the total amount of points in the results", tags: ["points"] do
     CNFManager::Points.clean_results_yml
-   CNFManager::Points.upsert_task("liveness", PASSED, CNFManager::Points.task_points("liveness"))
+   CNFManager::Points.upsert_task("liveness", PASSED, CNFManager::Points.task_points("liveness"), Time.utc)
     (CNFManager::Points.total_points).should eq(100)
   end
 
   it "'CNFManager::Points.total_max_points' should not include na in the total potential points", tags: ["points"] do
     CNFManager::Points.clean_results_yml
-      upsert_passed_task("liveness", "✔️  PASSED: CNF had a reasonable startup time ")
+      upsert_passed_task("liveness", "✔️  PASSED: CNF had a reasonable startup time ", Time.utc)
     resp1 = CNFManager::Points.total_max_points
-      upsert_na_task("readiness", "✔️  NA")
+      upsert_na_task("readiness", "✔️  NA", Time.utc)
     resp2 = CNFManager::Points.total_max_points
    
     LOGGING.info "readiness points: #{CNFManager::Points.task_points("readiness").not_nil!.to_i}"
@@ -174,12 +174,12 @@ describe "SampleUtils" do
 
   it "'CNFManager::Points.all_result_test_names' should return the tasks assigned to a tag", tags: ["points"] do
     CNFManager::Points.clean_results_yml
-   CNFManager::Points.upsert_task("liveness", PASSED, CNFManager::Points.task_points("liveness"))
+   CNFManager::Points.upsert_task("liveness", PASSED, CNFManager::Points.task_points("liveness"), Time.utc)
     (CNFManager::Points.all_result_test_names(CNFManager::Points::Results.file)).should eq(["liveness"])
   end
   it "'CNFManager::Points.results_by_tag' should return a list of results by tag", tags: ["points"] do
     CNFManager::Points.clean_results_yml
-   CNFManager::Points.upsert_task("liveness", PASSED, CNFManager::Points.task_points("liveness"))
+   CNFManager::Points.upsert_task("liveness", PASSED, CNFManager::Points.task_points("liveness"), Time.utc)
     (CNFManager::Points.results_by_tag("resilience")).should eq([{"name" => "liveness", "status" => "passed", "type" => "essential", "points" => 100}])
     (CNFManager::Points.results_by_tag("does-not-exist")).should eq([] of YAML::Any) 
   end

--- a/spec/utils/utils_spec.cr
+++ b/spec/utils/utils_spec.cr
@@ -58,7 +58,7 @@ describe "Utils" do
 
   it "'upsert_skipped_task' should put a 0 in the results file", tags: ["task_runner"]  do
     CNFManager::Points.clean_results_yml
-    resp = upsert_skipped_task("ip_addresses","✖️  FAILED: IP addresses found")
+    resp = upsert_skipped_task("ip_addresses","✖️  FAILED: IP addresses found", Time.utc)
     yaml = File.open("#{CNFManager::Points::Results.file}") do |file|
       YAML.parse(file)
     end
@@ -100,9 +100,9 @@ describe "Utils" do
       Log.debug { "violator list: #{violation_list.flatten}" }
       emoji_security=""
       if resource_response 
-        resp = upsert_passed_task("privileged", "✔️  PASSED: No privileged containers")
+        resp = upsert_passed_task("privileged", "✔️  PASSED: No privileged containers", Time.utc)
       else
-        resp = upsert_failed_task("privileged", "✖️  FAILED: Found #{violation_list.size} privileged containers: #{violation_list.inspect}")
+        resp = upsert_failed_task("privileged", "✖️  FAILED: Found #{violation_list.size} privileged containers: #{violation_list.inspect}", Time.utc)
       end
       Log.info { resp }
       resp
@@ -129,14 +129,14 @@ describe "Utils" do
         end
         Dir.cd(cdir)
         if response.to_s.size > 0
-          resp = upsert_failed_task("ip_addresses","✖️  FAILED: IP addresses found")
+          resp = upsert_failed_task("ip_addresses","✖️  FAILED: IP addresses found", Time.utc)
         else
-          resp = upsert_passed_task("ip_addresses", "✔️  PASSED: No IP addresses found")
+          resp = upsert_passed_task("ip_addresses", "✔️  PASSED: No IP addresses found", Time.utc)
         end
         resp
       else
         Dir.cd(cdir)
-        resp = upsert_passed_task("ip_addresses", "✔️  PASSED: No IP addresses found")
+        resp = upsert_passed_task("ip_addresses", "✔️  PASSED: No IP addresses found", Time.utc)
       end
     end
     yaml = File.open("#{CNFManager::Points::Results.file}") do |file|
@@ -174,9 +174,9 @@ describe "Utils" do
       LOGGING.debug "violator list: #{violation_list.flatten}"
       emoji_security=""
       if resource_response 
-        resp = upsert_passed_task("privileged", "✔️  PASSED: No privileged containers")
+        resp = upsert_passed_task("privileged", "✔️  PASSED: No privileged containers", Time.utc)
       else
-        resp = upsert_failed_task("privileged", "✖️  FAILED: Found #{violation_list.size} privileged containers: #{violation_list.inspect}")
+        resp = upsert_failed_task("privileged", "✖️  FAILED: Found #{violation_list.size} privileged containers: #{violation_list.inspect}", Time.utc)
       end
       resp
     end

--- a/src/tasks/platform/hardware_and_scheduling.cr
+++ b/src/tasks/platform/hardware_and_scheduling.cr
@@ -25,10 +25,10 @@ namespace "platform" do
       LOGGING.info "all_oci_runtimes: #{all_oci_runtimes}"
       if all_oci_runtimes 
         emoji_chaos_oci_compliant="📶☠️"
-        upsert_passed_task("oci_compliant","✔️  PASSED: Your platform is using the following runtimes: [#{KubectlClient::Get.container_runtimes.join(",")}] which are OCI compliant runtimes #{emoji_chaos_oci_compliant}")
+        upsert_passed_task("oci_compliant","✔️  PASSED: Your platform is using the following runtimes: [#{KubectlClient::Get.container_runtimes.join(",")}] which are OCI compliant runtimes #{emoji_chaos_oci_compliant}", Time.utc)
       else
         emoji_chaos_oci_compliant="📶☠️"
-        upsert_failed_task("oci_compliant", "✖️  FAILED: Platform has at least one node that uses a non OCI compliant runtime #{emoji_chaos_oci_compliant}")
+        upsert_failed_task("oci_compliant", "✖️  FAILED: Platform has at least one node that uses a non OCI compliant runtime #{emoji_chaos_oci_compliant}", Time.utc)
       end
     end
   end

--- a/src/tasks/platform/observability.cr
+++ b/src/tasks/platform/observability.cr
@@ -32,10 +32,10 @@ namespace "platform" do
 
     if found
       emoji_kube_state_metrics="📶☠️"
-      upsert_passed_task("kube_state_metrics","✔️  PASSED: Your platform is using the release for kube state metrics #{emoji_kube_state_metrics}")
+      upsert_passed_task("kube_state_metrics","✔️  PASSED: Your platform is using the release for kube state metrics #{emoji_kube_state_metrics}", Time.utc)
     else
       emoji_kube_state_metrics="📶☠️"
-      upsert_failed_task("kube_state_metrics", "✖️  FAILED: Your platform does not have kube state metrics installed #{emoji_kube_state_metrics}")
+      upsert_failed_task("kube_state_metrics", "✖️  FAILED: Your platform does not have kube state metrics installed #{emoji_kube_state_metrics}", Time.utc)
     end
   end
 
@@ -57,10 +57,10 @@ namespace "platform" do
     Log.info { "Found Process: #{found}" }
     if found
       emoji_node_exporter="📶☠️"
-      upsert_passed_task("node_exporter","✔️  PASSED: Your platform is using the node exporter #{emoji_node_exporter}")
+      upsert_passed_task("node_exporter","✔️  PASSED: Your platform is using the node exporter #{emoji_node_exporter}", Time.utc)
     else
       emoji_node_exporter="📶☠️"
-      upsert_failed_task("node_exporter", "✖️  FAILED: Your platform does not have the node exporter installed #{emoji_node_exporter}")
+      upsert_failed_task("node_exporter", "✖️  FAILED: Your platform does not have the node exporter installed #{emoji_node_exporter}", Time.utc)
     end
   end
 
@@ -83,10 +83,10 @@ namespace "platform" do
 
     if found
       emoji_prometheus_adapter="📶☠️"
-      upsert_passed_task("prometheus_adapter","✔️  PASSED: Your platform is using the prometheus adapter #{emoji_prometheus_adapter}")
+      upsert_passed_task("prometheus_adapter","✔️  PASSED: Your platform is using the prometheus adapter #{emoji_prometheus_adapter}", Time.utc)
     else
       emoji_prometheus_adapter="📶☠️"
-      upsert_failed_task("prometheus_adapter", "✖️  FAILED: Your platform does not have the prometheus adapter installed #{emoji_prometheus_adapter}")
+      upsert_failed_task("prometheus_adapter", "✖️  FAILED: Your platform does not have the prometheus adapter installed #{emoji_prometheus_adapter}", Time.utc)
     end
   end
 
@@ -108,10 +108,10 @@ namespace "platform" do
       found = KernelIntrospection::K8s.find_first_process(CloudNativeIntrospection::METRICS_SERVER)
       if found
         emoji_metrics_server="📶☠️"
-        upsert_passed_task("metrics_server","✔️  PASSED: Your platform is using the metrics server #{emoji_metrics_server}")
+        upsert_passed_task("metrics_server","✔️  PASSED: Your platform is using the metrics server #{emoji_metrics_server}", Time.utc)
       else
         emoji_metrics_server="📶☠️"
-        upsert_failed_task("metrics_server", "✖️  FAILED: Your platform does not have the metrics server installed #{emoji_metrics_server}")
+        upsert_failed_task("metrics_server", "✖️  FAILED: Your platform does not have the metrics server installed #{emoji_metrics_server}", Time.utc)
       end
     end
   end

--- a/src/tasks/platform/platform.cr
+++ b/src/tasks/platform/platform.cr
@@ -70,10 +70,10 @@ task "k8s_conformance" do |_, args|
 
     failed_count = ((results.match(/Failed: (.*)/)).try &.[1]) 
     if failed_count.to_s.to_i > 0 
-      upsert_failed_task("k8s_conformance", "✖️  FAILED: K8s conformance test has #{failed_count} failure(s)!")
+      upsert_failed_task("k8s_conformance", "✖️  FAILED: K8s conformance test has #{failed_count} failure(s)!", Time.utc)
 
     else
-      upsert_passed_task("k8s_conformance", "✔️  PASSED: K8s conformance test has no failures")
+      upsert_passed_task("k8s_conformance", "✔️  PASSED: K8s conformance test has no failures", Time.utc)
     end
   rescue ex
     Log.error { ex.message }
@@ -134,9 +134,9 @@ task "clusterapi_enabled" do |_, args|
     emoji_control="✨"
 
     if clusterapi_namespaces_json["items"]? && clusterapi_namespaces_json["items"].as_a.size > 0 && clusterapi_control_planes_json["items"]? && clusterapi_control_planes_json["items"].as_a.size > 0
-      resp = upsert_passed_task("clusterapi_enabled", "✔️ Cluster API is enabled #{emoji_control}")
+      resp = upsert_passed_task("clusterapi_enabled", "✔️ Cluster API is enabled #{emoji_control}", Time.utc)
     else
-      resp = upsert_failed_task("clusterapi_enabled", "✖️ Cluster API NOT enabled #{emoji_control}")
+      resp = upsert_failed_task("clusterapi_enabled", "✖️ Cluster API NOT enabled #{emoji_control}", Time.utc)
     end
 
     resp

--- a/src/tasks/platform/resilience.cr
+++ b/src/tasks/platform/resilience.cr
@@ -43,7 +43,7 @@ namespace "platform" do
           pod_ready = KubectlClient::Get.pod_status("reboot", "--field-selector spec.nodeName=#{worker_node}").split(",")[2]
           pod_ready_timeout = pod_ready_timeout - 1
           if pod_ready_timeout == 0
-            upsert_failed_task("worker_reboot_recovery", "✖️  FAILED: Failed to install reboot daemon")
+            upsert_failed_task("worker_reboot_recovery", "✖️  FAILED: Failed to install reboot daemon", Time.utc)
             exit 1
           end
           sleep 1
@@ -67,7 +67,7 @@ namespace "platform" do
           Log.info { "Node Ready Status: #{node_ready}" }
           node_failure_timeout = node_failure_timeout - 1
           if node_failure_timeout == 0
-            upsert_failed_task("worker_reboot_recovery", "✖️  FAILED: Node failed to go offline")
+            upsert_failed_task("worker_reboot_recovery", "✖️  FAILED: Node failed to go offline", Time.utc)
             exit 1
           end
           sleep 1
@@ -85,14 +85,14 @@ namespace "platform" do
           Log.info { "Node Ready Status: #{node_ready}" }
           node_online_timeout = node_online_timeout - 1
           if node_online_timeout == 0
-            upsert_failed_task("worker_reboot_recovery", "✖️  FAILED: Node failed to come back online")
+            upsert_failed_task("worker_reboot_recovery", "✖️  FAILED: Node failed to come back online", Time.utc)
             exit 1
           end
           sleep 1
         end
 
         emoji_worker_reboot_recovery=""
-        resp = upsert_passed_task("worker_reboot_recovery","✔️  PASSED: Node came back online #{emoji_worker_reboot_recovery}")
+        resp = upsert_passed_task("worker_reboot_recovery","✔️  PASSED: Node came back online #{emoji_worker_reboot_recovery}", Time.utc)
 
 
       ensure

--- a/src/tasks/platform/security.cr
+++ b/src/tasks/platform/security.cr
@@ -20,9 +20,9 @@ namespace "platform" do
 
       emoji_security="🔓🔑"
       if test_report.failed_resources.size == 0
-        upsert_passed_task("control_plane_hardening", "✔️  PASSED: Control plane hardened #{emoji_security}")
+        upsert_passed_task("control_plane_hardening", "✔️  PASSED: Control plane hardened #{emoji_security}", Time.utc)
       else
-        resp = upsert_failed_task("control_plane_hardening", "✖️  FAILED: Control plane not hardened #{emoji_security}")
+        resp = upsert_failed_task("control_plane_hardening", "✖️  FAILED: Control plane not hardened #{emoji_security}", Time.utc)
         test_report.failed_resources.map {|r| stdout_failure(r.alert_message) }
         stdout_failure("Remediation: #{test_report.remediation}")
         resp
@@ -41,9 +41,9 @@ namespace "platform" do
 
       emoji_security="🔓🔑"
       if test_report.failed_resources.size == 0
-        upsert_passed_task("cluster_admin", "✔️  PASSED: No users with cluster admin role found #{emoji_security}")
+        upsert_passed_task("cluster_admin", "✔️  PASSED: No users with cluster admin role found #{emoji_security}", Time.utc)
       else
-        resp = upsert_failed_task("cluster_admin", "✖️  FAILED: Users with cluster admin role found #{emoji_security}")
+        resp = upsert_failed_task("cluster_admin", "✖️  FAILED: Users with cluster admin role found #{emoji_security}", Time.utc)
         test_report.failed_resources.map {|r| stdout_failure(r.alert_message) }
         stdout_failure("Remediation: #{test_report.remediation}")
         resp
@@ -63,9 +63,9 @@ namespace "platform" do
 
       emoji_security = "🔓🔑"
       if test_report.failed_resources.size == 0
-        upsert_passed_task("exposed_dashboard", "✔️  PASSED: No exposed dashboard found in the cluster #{emoji_security}")
+        upsert_passed_task("exposed_dashboard", "✔️  PASSED: No exposed dashboard found in the cluster #{emoji_security}", Time.utc)
       else
-        resp = upsert_failed_task("exposed_dashboard", "✖️  FAILED: Found exposed dashboard in the cluster #{emoji_security}")
+        resp = upsert_failed_task("exposed_dashboard", "✖️  FAILED: Found exposed dashboard in the cluster #{emoji_security}", Time.utc)
         test_report.failed_resources.map {|r| stdout_failure(r.alert_message) }
         stdout_failure("Remediation: #{test_report.remediation}")
         resp
@@ -84,9 +84,9 @@ namespace "platform" do
       failures = Kyverno::PolicyAudit.run(policy_path, EXCLUDE_NAMESPACES)
 
       if failures.size == 0
-        resp = upsert_passed_task("helm_tiller", "✔️  PASSED: No Helm Tiller containers are running #{emoji_security}")
+        resp = upsert_passed_task("helm_tiller", "✔️  PASSED: No Helm Tiller containers are running #{emoji_security}", Time.utc)
       else
-        resp = upsert_failed_task("helm_tiller", "✖️  FAILED: Containers with the Helm Tiller image are running #{emoji_security}")
+        resp = upsert_failed_task("helm_tiller", "✖️  FAILED: Containers with the Helm Tiller image are running #{emoji_security}", Time.utc)
         failures.each do |failure|
           failure.resources.each do |resource|
             puts "#{resource.kind} #{resource.name} in #{resource.namespace} namespace failed. #{failure.message}".colorize(:red)

--- a/src/tasks/utils/points.cr
+++ b/src/tasks/utils/points.cr
@@ -403,12 +403,15 @@ module CNFManager
         name: task,
         status: status,
         type: task_type_by_task(task),
-        points: points,
-        start_time: start_time,
-        end_time: end_time,
-        task_runtime_milliseconds: task_runtime
-      }.to_yaml
-      result_items << YAML.parse(task_result_info)
+        points: points
+      }
+
+      if ENV.has_key?("TASK_TIMESTAMPS")
+        task_result_info[:start_time] = start_time
+        task_result_info[:end_time] = end_time
+        task_result_info[:task_runtime_milliseconds] = task_runtime
+      end
+      result_items << YAML.parse(task_result_info.to_yaml)
       File.open("#{Results.file}", "w") do |f|
         YAML.dump({name: results["name"],
                    # testsuite_version: CnfTestSuite::VERSION,

--- a/src/tasks/utils/points.cr
+++ b/src/tasks/utils/points.cr
@@ -396,7 +396,16 @@ module CNFManager
       Log.info {"cmd: #{cmd}"}
       end_time = Time.utc
       task_runtime = (end_time - start_time).seconds
-      result_items << YAML.parse "{name: #{task}, status: #{status}, type: #{task_type_by_task(task)}, points: #{points}}"
+      task_result_info = {
+        name: task,
+        status: status,
+        type: task_type_by_task(task),
+        points: points,
+        start_time: start_time,
+        end_time: end_time,
+        task_runtime_seconds: task_runtime
+      }
+      result_items << task_result_info
       File.open("#{Results.file}", "w") do |f|
         YAML.dump({name: results["name"],
                    # testsuite_version: CnfTestSuite::VERSION,
@@ -405,9 +414,6 @@ module CNFManager
                    command: cmd,
                    points: results["points"],
                    exit_code: results["exit_code"],
-                   start_time: start_time,
-                   end_time: end_time,
-                   task_runtime_seconds: task_runtime,
                    items: result_items}, f)
       end
       Log.info { "upsert_task: task: #{task} has status: #{status} and is awarded: #{points} points. Runtime: #{task_runtime} seconds" }

--- a/src/tasks/utils/points.cr
+++ b/src/tasks/utils/points.cr
@@ -399,19 +399,29 @@ module CNFManager
 
       # The task result info has to be appeneded to an array of YAML::Any
       # So encode it into YAML and parse it back again to assign it.
-      task_result_info = {
-        name: task,
-        status: status,
-        type: task_type_by_task(task),
-        points: points
-      }
-
+      #
+      # Only add task timestamps if the env var is set.
       if ENV.has_key?("TASK_TIMESTAMPS")
-        task_result_info[:start_time] = start_time
-        task_result_info[:end_time] = end_time
-        task_result_info[:task_runtime_milliseconds] = task_runtime
+        task_result_info = {
+          name: task,
+          status: status,
+          type: task_type_by_task(task),
+          points: points,
+          start_time: start_time,
+          end_time: end_time,
+          task_runtime_milliseconds: task_runtime
+        }
+        result_items << YAML.parse(task_result_info.to_yaml)
+      else
+        task_result_info = {
+          name: task,
+          status: status,
+          type: task_type_by_task(task),
+          points: points
+        }
+        result_items << YAML.parse(task_result_info.to_yaml)
       end
-      result_items << YAML.parse(task_result_info.to_yaml)
+
       File.open("#{Results.file}", "w") do |f|
         YAML.dump({name: results["name"],
                    # testsuite_version: CnfTestSuite::VERSION,

--- a/src/tasks/utils/points.cr
+++ b/src/tasks/utils/points.cr
@@ -396,6 +396,9 @@ module CNFManager
       Log.info {"cmd: #{cmd}"}
       end_time = Time.utc
       task_runtime = (end_time - start_time).seconds
+
+      # The task result info has to be appeneded to an array of YAML::Any
+      # So encode it into YAML and parse it back again to assign it.
       task_result_info = {
         name: task,
         status: status,
@@ -404,8 +407,8 @@ module CNFManager
         start_time: start_time,
         end_time: end_time,
         task_runtime_seconds: task_runtime
-      }
-      result_items << task_result_info
+      }.to_yaml
+      result_items << YAML.parse(task_result_info)
       File.open("#{Results.file}", "w") do |f|
         YAML.dump({name: results["name"],
                    # testsuite_version: CnfTestSuite::VERSION,

--- a/src/tasks/utils/points.cr
+++ b/src/tasks/utils/points.cr
@@ -395,7 +395,7 @@ module CNFManager
       cmd = "#{Process.executable_path} #{ARGV.join(" ")}"
       Log.info {"cmd: #{cmd}"}
       end_time = Time.utc
-      task_runtime = (end_time - start_time).seconds
+      task_runtime = (end_time - start_time).milliseconds
 
       # The task result info has to be appeneded to an array of YAML::Any
       # So encode it into YAML and parse it back again to assign it.
@@ -406,7 +406,7 @@ module CNFManager
         points: points,
         start_time: start_time,
         end_time: end_time,
-        task_runtime_seconds: task_runtime
+        task_runtime_milliseconds: task_runtime
       }.to_yaml
       result_items << YAML.parse(task_result_info)
       File.open("#{Results.file}", "w") do |f|

--- a/src/tasks/utils/utils.cr
+++ b/src/tasks/utils/utils.cr
@@ -289,32 +289,32 @@ def update_yml(yml_file, top_level_key, value)
   end
 end
 
-def upsert_failed_task(task, message)
- CNFManager::Points.upsert_task(task, FAILED, CNFManager::Points.task_points(task, false))
+def upsert_failed_task(task, message, start_time)
+ CNFManager::Points.upsert_task(task, FAILED, CNFManager::Points.task_points(task, false), start_time)
   stdout_failure message
   message
 end
 
-def upsert_passed_task(task, message)
- CNFManager::Points.upsert_task(task, PASSED, CNFManager::Points.task_points(task))
+def upsert_passed_task(task, message, start_time)
+ CNFManager::Points.upsert_task(task, PASSED, CNFManager::Points.task_points(task), start_time)
   stdout_success message
   message
 end
 
-def upsert_skipped_task(task, message)
- CNFManager::Points.upsert_task(task, SKIPPED, CNFManager::Points.task_points(task, CNFManager::Points::Results::ResultStatus::Skipped))
+def upsert_skipped_task(task, message, start_time)
+ CNFManager::Points.upsert_task(task, SKIPPED, CNFManager::Points.task_points(task, CNFManager::Points::Results::ResultStatus::Skipped), start_time)
   stdout_warning message
   message
 end
 
-def upsert_na_task(task, message)
- CNFManager::Points.upsert_task(task, NA, CNFManager::Points.task_points(task, CNFManager::Points::Results::ResultStatus::NA))
+def upsert_na_task(task, message, start_time)
+ CNFManager::Points.upsert_task(task, NA, CNFManager::Points.task_points(task, CNFManager::Points::Results::ResultStatus::NA), start_time)
   stdout_warning message
   message
 end
 
-def upsert_dynamic_task(task, status : CNFManager::Points::Results::ResultStatus, message)
-  CNFManager::Points.upsert_task(task, status.to_s.downcase, CNFManager::Points.task_points(task, status))
+def upsert_dynamic_task(task, status : CNFManager::Points::Results::ResultStatus, message, start_time)
+  CNFManager::Points.upsert_task(task, status.to_s.downcase, CNFManager::Points.task_points(task, status), start_time)
   case status.to_s.downcase 
   when /pass/
     stdout_success message

--- a/src/tasks/workload/compatibility.cr
+++ b/src/tasks/workload/compatibility.cr
@@ -83,9 +83,9 @@ rolling_version_change_test_names.each do |tn|
       end
       VERBOSE_LOGGING.debug "#{tn}: task_response=#{task_response}" if check_verbose(args)
       if task_response
-        resp = upsert_passed_task("#{tn}","✔️  PASSED: CNF for #{pretty_test_name_capitalized} Passed" )
+        resp = upsert_passed_task("#{tn}","✔️  PASSED: CNF for #{pretty_test_name_capitalized} Passed", Time.utc)
       else
-        resp = upsert_failed_task("#{tn}", "✖️  FAILED: CNF for #{pretty_test_name_capitalized} Failed")
+        resp = upsert_failed_task("#{tn}", "✖️  FAILED: CNF for #{pretty_test_name_capitalized} Failed", Time.utc)
       end
       resp
       # TODO should we roll the image back to original version in an ensure?
@@ -172,9 +172,9 @@ task "rollback" do |_, args|
 
 
     if task_response && version_change_applied && rollout_status && rollback_status
-      upsert_passed_task("rollback","✔️  PASSED: CNF Rollback Passed" )
+      upsert_passed_task("rollback","✔️  PASSED: CNF Rollback Passed", Time.utc)
     else
-      upsert_failed_task("rollback", "✖️  FAILED: CNF Rollback Failed")
+      upsert_failed_task("rollback", "✖️  FAILED: CNF Rollback Failed", Time.utc)
     end
   end
 end
@@ -219,9 +219,9 @@ task "increase_decrease_capacity" do |t, args|
 
     if increase_task_response.none?(false) && decrease_task_response.none?(false)
       pass_msg = "✔️  🏆 PASSED: Replicas increased to #{increase_test_target_replicas} and decreased to #{decrease_test_target_replicas} #{emoji_capacity}"
-      upsert_passed_task("increase_decrease_capacity", pass_msg)
+      upsert_passed_task("increase_decrease_capacity", pass_msg, Time.utc)
     else
-      upsert_failed_task("increase_decrease_capacity", "✖️  FAILURE: Capacity change failed #{emoji_capacity}")
+      upsert_failed_task("increase_decrease_capacity", "✖️  FAILURE: Capacity change failed #{emoji_capacity}", Time.utc)
 
       # If increased capacity failed
       if increase_task_response.any?(false)
@@ -430,13 +430,13 @@ task "helm_deploy" do |_, args|
       helm_used = configmap["data"].as_h["helm_used"].as_s
 
       if helm_used == "true"
-        upsert_passed_task("helm_deploy", "✔️  PASSED: Helm deploy successful #{emoji_helm_deploy}")
+        upsert_passed_task("helm_deploy", "✔️  PASSED: Helm deploy successful #{emoji_helm_deploy}", Time.utc)
       else
-        upsert_failed_task("helm_deploy", "✖️  FAILED: Helm deploy failed #{emoji_helm_deploy}")
+        upsert_failed_task("helm_deploy", "✖️  FAILED: Helm deploy failed #{emoji_helm_deploy}", Time.utc)
       end
     end
   else
-    upsert_failed_task("helm_deploy", "✖️  FAILED: No cnf_testsuite.yml found! Did you run the setup task?")
+    upsert_failed_task("helm_deploy", "✖️  FAILED: No cnf_testsuite.yml found! Did you run the setup task?", Time.utc)
   end
 end
 
@@ -470,15 +470,15 @@ task "helm_chart_published", ["helm_local_install"] do |_, args|
         helm_search = helm_search_stdout.to_s
         Log.for("verbose").debug { "#{helm_search}" } if check_verbose(args)
         unless helm_search =~ /No results found/
-          upsert_passed_task("helm_chart_published", "✔️  PASSED: Published Helm Chart Found #{emoji_published_helm_chart}")
+          upsert_passed_task("helm_chart_published", "✔️  PASSED: Published Helm Chart Found #{emoji_published_helm_chart}", Time.utc)
         else
-          upsert_failed_task("helm_chart_published", "✖️  FAILED: Published Helm Chart Not Found #{emoji_published_helm_chart}")
+          upsert_failed_task("helm_chart_published", "✖️  FAILED: Published Helm Chart Not Found #{emoji_published_helm_chart}", Time.utc)
         end
       else
-        upsert_failed_task("helm_chart_published", "✖️  FAILED: Published Helm Chart Not Found #{emoji_published_helm_chart}")
+        upsert_failed_task("helm_chart_published", "✖️  FAILED: Published Helm Chart Not Found #{emoji_published_helm_chart}", Time.utc)
       end
     else
-      upsert_failed_task("helm_chart_published", "✖️  FAILED: Published Helm Chart Not Found #{emoji_published_helm_chart}")
+      upsert_failed_task("helm_chart_published", "✖️  FAILED: Published Helm Chart Not Found #{emoji_published_helm_chart}", Time.utc)
     end
   end
 end
@@ -526,9 +526,9 @@ task "helm_chart_valid", ["helm_local_install"] do |_, args|
     Log.for("verbose").debug { "helm_lint: #{helm_lint}" } if check_verbose(args)
 
     if helm_lint_status.success?
-      upsert_passed_task("helm_chart_valid", "✔️  PASSED: Helm Chart #{working_chart_directory} Lint Passed #{emoji_helm_lint}")
+      upsert_passed_task("helm_chart_valid", "✔️  PASSED: Helm Chart #{working_chart_directory} Lint Passed #{emoji_helm_lint}", Time.utc)
     else
-      upsert_failed_task("helm_chart_valid", "✖️  FAILED: Helm Chart #{working_chart_directory} Lint Failed #{emoji_helm_lint}")
+      upsert_failed_task("helm_chart_valid", "✖️  FAILED: Helm Chart #{working_chart_directory} Lint Failed #{emoji_helm_lint}", Time.utc)
     end
   end
 end
@@ -650,9 +650,9 @@ task "cni_compatible" do |_, args|
         puts "CNF failed to install on Cilium CNI cluster".colorize(:red) unless cilium_cnf_passed
 
         if calico_cnf_passed && cilium_cnf_passed
-          upsert_passed_task("cni_compatible", "✔️  PASSED: CNF compatible with both Calico and Cilium #{emoji_security}")
+          upsert_passed_task("cni_compatible", "✔️  PASSED: CNF compatible with both Calico and Cilium #{emoji_security}", Time.utc)
         else
-          upsert_failed_task("cni_compatible", "✖️  FAILED: CNF not compatible with either Calico or Cillium #{emoji_security}")
+          upsert_failed_task("cni_compatible", "✖️  FAILED: CNF not compatible with either Calico or Cillium #{emoji_security}", Time.utc)
         end
       ensure
         kind_manager = KindManager.new
@@ -661,7 +661,7 @@ task "cni_compatible" do |_, args|
         ENV["KUBECONFIG"]="#{kubeconfig_orig}"
       end
     else
-      upsert_skipped_task("cni_compatible", "✖️  SKIPPED: Docker not installed #{emoji_security}")
+      upsert_skipped_task("cni_compatible", "✖️  SKIPPED: Docker not installed #{emoji_security}", Time.utc)
     end
   end
 end

--- a/src/tasks/workload/configuration.cr
+++ b/src/tasks/workload/configuration.cr
@@ -45,9 +45,9 @@ task "require_labels" do |_, args|
     failures = Kyverno.filter_failures_for_cnf_resources(resource_keys, failures)
 
     if failures.size == 0
-      resp = upsert_passed_task("require_labels", "✔️  PASSED: Pods have the app.kubernetes.io/name label #{emoji_passed}")
+      resp = upsert_passed_task("require_labels", "✔️  PASSED: Pods have the app.kubernetes.io/name label #{emoji_passed}", Time.utc)
     else
-      resp = upsert_failed_task("require_labels", "✖️  FAILED: Pods should have the app.kubernetes.io/name label. #{emoji_failed}")
+      resp = upsert_failed_task("require_labels", "✖️  FAILED: Pods should have the app.kubernetes.io/name label. #{emoji_failed}", Time.utc)
       failures.each do |failure|
         failure.resources.each do |resource|
           puts "#{resource.kind} #{resource.name} in #{resource.namespace} namespace failed. #{failure.message}".colorize(:red)
@@ -71,9 +71,9 @@ task "default_namespace" do |_, args|
     failures = Kyverno.filter_failures_for_cnf_resources(resource_keys, failures)
 
     if failures.size == 0
-      resp = upsert_passed_task("default_namespace", "✔️  PASSED: default namespace is not being used #{emoji_passed}")
+      resp = upsert_passed_task("default_namespace", "✔️  PASSED: default namespace is not being used #{emoji_passed}", Time.utc)
     else
-      resp = upsert_failed_task("default_namespace", "✖️  FAILED: Resources are created in the default namespace #{emoji_failed}")
+      resp = upsert_failed_task("default_namespace", "✖️  FAILED: Resources are created in the default namespace #{emoji_failed}", Time.utc)
       failures.each do |failure|
         failure.resources.each do |resource|
           puts "#{resource.kind} #{resource.name} in #{resource.namespace} namespace failed. #{failure.message}".colorize(:red)
@@ -98,9 +98,9 @@ task "latest_tag" do |_, args|
     failures = Kyverno.filter_failures_for_cnf_resources(resource_keys, failures)
 
     if failures.size == 0
-      resp = upsert_passed_task("latest_tag", "✔️  🏆 PASSED: Container images are not using the latest tag #{emoji_passed}")
+      resp = upsert_passed_task("latest_tag", "✔️  🏆 PASSED: Container images are not using the latest tag #{emoji_passed}", Time.utc)
     else
-      resp = upsert_failed_task("latest_tag", "✖️  🏆 FAILED: Container images are using the latest tag #{emoji_failed}")
+      resp = upsert_failed_task("latest_tag", "✖️  🏆 FAILED: Container images are using the latest tag #{emoji_failed}", Time.utc)
       failures.each do |failure|
         failure.resources.each do |resource|
           puts "#{resource.kind} #{resource.name} in #{resource.namespace} namespace failed. #{failure.message}".colorize(:red)
@@ -143,16 +143,16 @@ task "ip_addresses" do |_, args|
           matching_line = line_parts.join(":").strip()
           stdout_failure("  * In file #{file_name}: #{matching_line}")
         end
-        resp = upsert_failed_task("ip_addresses","✖️  FAILED: IP addresses found")
+        resp = upsert_failed_task("ip_addresses","✖️  FAILED: IP addresses found", Time.utc)
       else
-        resp = upsert_passed_task("ip_addresses", "✔️  PASSED: No IP addresses found")
+        resp = upsert_passed_task("ip_addresses", "✔️  PASSED: No IP addresses found", Time.utc)
       end
       resp
     else
       # TODO If no helm chart directory, exit with 0 points
       # ADD SKIPPED tag for points.yml to allow for 0 points
       Dir.cd(cdir)
-      resp = upsert_passed_task("ip_addresses", "✔️  PASSED: No IP addresses found")
+      resp = upsert_passed_task("ip_addresses", "✔️  PASSED: No IP addresses found", Time.utc)
     end
   end
 end
@@ -204,9 +204,9 @@ task "versioned_tag", ["install_opa"] do |_, args|
     emoji_non_versioned_tag="🏷️❌"
 
     if task_response
-      upsert_passed_task("versioned_tag", "✔️  PASSED: Container images use versioned tags #{emoji_versioned_tag}")
+      upsert_passed_task("versioned_tag", "✔️  PASSED: Container images use versioned tags #{emoji_versioned_tag}", Time.utc)
     else
-      upsert_failed_task("versioned_tag", "✖️  FAILED: Container images do not use versioned tags #{emoji_non_versioned_tag}")
+      upsert_failed_task("versioned_tag", "✖️  FAILED: Container images do not use versioned tags #{emoji_non_versioned_tag}", Time.utc)
       fail_msgs.each do |msg|
         stdout_failure(msg)
       end
@@ -242,9 +242,9 @@ task "nodeport_not_used" do |_, args|
       end
     end
     if task_response
-      upsert_passed_task("nodeport_not_used", "✔️  PASSED: NodePort is not used")
+      upsert_passed_task("nodeport_not_used", "✔️  PASSED: NodePort is not used", Time.utc)
     else
-      upsert_failed_task("nodeport_not_used", "✖️  FAILED: NodePort is being used")
+      upsert_failed_task("nodeport_not_used", "✖️  FAILED: NodePort is being used", Time.utc)
     end
   end
 end
@@ -289,9 +289,9 @@ task "hostport_not_used" do |_, args|
       test_passed
     end
     if task_response
-      upsert_passed_task("hostport_not_used", "✔️  🏆 PASSED: HostPort is not used")
+      upsert_passed_task("hostport_not_used", "✔️  🏆 PASSED: HostPort is not used", Time.utc)
     else
-      upsert_failed_task("hostport_not_used", "✖️  🏆 FAILED: HostPort is being used")
+      upsert_failed_task("hostport_not_used", "✖️  🏆 FAILED: HostPort is being used", Time.utc)
     end
   end
 end
@@ -330,12 +330,12 @@ task "hardcoded_ip_addresses_in_k8s_runtime_configuration" do |_, args|
     VERBOSE_LOGGING.info "IPs: #{ip_search}" if check_verbose(args)
 
     if ip_search.empty?
-      upsert_passed_task("hardcoded_ip_addresses_in_k8s_runtime_configuration", "✔️  🏆 PASSED: No hard-coded IP addresses found in the runtime K8s configuration")
+      upsert_passed_task("hardcoded_ip_addresses_in_k8s_runtime_configuration", "✔️  🏆 PASSED: No hard-coded IP addresses found in the runtime K8s configuration", Time.utc)
     else
-      upsert_failed_task("hardcoded_ip_addresses_in_k8s_runtime_configuration", "✖️  🏆 FAILED: Hard-coded IP addresses found in the runtime K8s configuration")
+      upsert_failed_task("hardcoded_ip_addresses_in_k8s_runtime_configuration", "✖️  🏆 FAILED: Hard-coded IP addresses found in the runtime K8s configuration", Time.utc)
     end
   rescue
-    upsert_skipped_task("hardcoded_ip_addresses_in_k8s_runtime_configuration", "⏭️  🏆 SKIPPED: unknown exception")
+    upsert_skipped_task("hardcoded_ip_addresses_in_k8s_runtime_configuration", "⏭️  🏆 SKIPPED: unknown exception", Time.utc)
   ensure
     KubectlClient::Delete.command("namespace hardcoded-ip-test --force --grace-period 0")
   end
@@ -432,9 +432,9 @@ task "secrets_used" do |_, args|
       test_passed
     end
     if task_response
-      resp = upsert_passed_task("secrets_used","✔️  ✨PASSED: Secrets defined and used #{emoji_probe}")
+      resp = upsert_passed_task("secrets_used","✔️  ✨PASSED: Secrets defined and used #{emoji_probe}", Time.utc)
     else
-      resp = upsert_skipped_task("secrets_used","⏭  ✨#{secrets_used_skipped_msg(emoji_probe)}")
+      resp = upsert_skipped_task("secrets_used","⏭  ✨#{secrets_used_skipped_msg(emoji_probe)}", Time.utc)
     end
     resp
   end
@@ -583,10 +583,10 @@ task "immutable_configmap" do |_, args|
       k8s_ver = KubectlClient.server_version
       if version_less_than(k8s_ver, "1.19.0")
         resp = " ⏭️  SKIPPED: immmutable configmaps are not supported in this k8s cluster.".colorize(:yellow)
-        upsert_skipped_task("immutable_configmap", resp)
+        upsert_skipped_task("immutable_configmap", resp, Time.utc)
       else
         resp = "✖️  FAILED: immmutable configmaps are not enabled in this k8s cluster.".colorize(:red)
-        upsert_failed_task("immutable_configmap", resp)
+        upsert_failed_task("immutable_configmap", resp, Time.utc)
       end
     else
 
@@ -620,10 +620,10 @@ task "immutable_configmap" do |_, args|
 
       if cnf_manager_workload_resource_task_response
         resp = "✔️  ✨PASSED: All volume or container mounted configmaps immutable #{emoji_probe}".colorize(:green)
-        upsert_passed_task("immutable_configmap", resp)
+        upsert_passed_task("immutable_configmap", resp, Time.utc)
       elsif immutable_configmap_supported
         resp = "✖️  ✨FAILED: Found mutable configmap(s) #{emoji_probe}".colorize(:red)
-        upsert_failed_task("immutable_configmap", resp)
+        upsert_failed_task("immutable_configmap", resp, Time.utc)
 
         # Print out any mutable configmaps mounted as volumes
         volumes_test_results.each do |result|
@@ -663,7 +663,7 @@ task "alpha_k8s_apis" do |_, args|
 
     # No offline support for this task for now
     if args.named["offline"]? && args.named["offline"]? != "false"
-      upsert_skipped_task("alpha_k8s_apis","⏭️  SKIPPED: alpha_k8s_apis chaos test skipped #{emoji}")
+      upsert_skipped_task("alpha_k8s_apis","⏭️  SKIPPED: alpha_k8s_apis chaos test skipped #{emoji}", Time.utc)
       next
     end
 
@@ -687,7 +687,7 @@ task "alpha_k8s_apis" do |_, args|
     # CNF setup failed on kind cluster. Inform in test output.
     unless cnf_setup_complete
       puts "CNF failed to install on apisnoop cluster".colorize(:red)
-      upsert_failed_task("alpha_k8s_apis", "✖️  FAILED: Could not check CNF for usage of Kubernetes alpha APIs #{emoji}")
+      upsert_failed_task("alpha_k8s_apis", "✖️  FAILED: Could not check CNF for usage of Kubernetes alpha APIs #{emoji}", Time.utc)
       next
     end
 
@@ -704,9 +704,9 @@ task "alpha_k8s_apis" do |_, args|
     api_count = result[:output].split("\n")[2].to_i
 
     if api_count == 0
-      upsert_passed_task("alpha_k8s_apis", "✔️  PASSED: CNF does not use Kubernetes alpha APIs #{emoji}")
+      upsert_passed_task("alpha_k8s_apis", "✔️  PASSED: CNF does not use Kubernetes alpha APIs #{emoji}", Time.utc)
     else
-      upsert_failed_task("alpha_k8s_apis", "✖️  FAILED: CNF uses Kubernetes alpha APIs #{emoji}")
+      upsert_failed_task("alpha_k8s_apis", "✖️  FAILED: CNF uses Kubernetes alpha APIs #{emoji}", Time.utc)
     end
   ensure
     if cluster_name != nil
@@ -783,9 +783,9 @@ task "operator_installed" do |_, args|
     emoji_big="🦖"
 
     if test_passed
-      upsert_passed_task("operator_installed", "✔️  PASSED: Operator is installed: #{emoji_small} #{emoji_image_size}")
+      upsert_passed_task("operator_installed", "✔️  PASSED: Operator is installed: #{emoji_small} #{emoji_image_size}", Time.utc)
     else
-      upsert_na_task("operator_installed", "✖️  NA: No Operators Found #{emoji_big} #{emoji_image_size}")
+      upsert_na_task("operator_installed", "✖️  NA: No Operators Found #{emoji_big} #{emoji_image_size}", Time.utc)
     end
   end
 end

--- a/src/tasks/workload/microservice.cr
+++ b/src/tasks/workload/microservice.cr
@@ -30,7 +30,7 @@ task "shared_database", ["install_cluster_tools"] do |_, args|
     db_match = Netstat::Mariadb.match
     
     if db_match[:found] == false
-      upsert_na_task("shared_database", "⏭️  N/A: [shared_database] No MariaDB containers were found")
+      upsert_na_task("shared_database", "⏭️  N/A: [shared_database] No MariaDB containers were found", Time.utc)
       next
     end
 
@@ -98,9 +98,9 @@ task "shared_database", ["install_cluster_tools"] do |_, args|
     failed_emoji = "(ভ_ভ) ރ 💾"
     passed_emoji = "🖥️  💾"
     if integrated_database_found 
-      upsert_failed_task("shared_database", "✖️  FAILED: Found a shared database #{failed_emoji}")
+      upsert_failed_task("shared_database", "✖️  FAILED: Found a shared database #{failed_emoji}", Time.utc)
     else
-      upsert_passed_task("shared_database", "✔️  PASSED: No shared database found #{passed_emoji}")
+      upsert_passed_task("shared_database", "✔️  PASSED: No shared database found #{passed_emoji}", Time.utc)
     end
   end
 end
@@ -181,9 +181,9 @@ task "reasonable_startup_time" do |_, args|
     Log.info { "startup_time: #{startup_time.to_i}" }
 
     if startup_time.to_i <= startup_time_limit
-      upsert_passed_task("reasonable_startup_time", "✔️  PASSED: CNF had a reasonable startup time #{emoji_fast}")
+      upsert_passed_task("reasonable_startup_time", "✔️  PASSED: CNF had a reasonable startup time #{emoji_fast}", Time.utc)
     else
-      upsert_failed_task("reasonable_startup_time", "✖️  FAILED: CNF had a startup time of #{startup_time} seconds #{emoji_slow}")
+      upsert_failed_task("reasonable_startup_time", "✖️  FAILED: CNF had a startup time of #{startup_time} seconds #{emoji_slow}", Time.utc)
     end
 
   end
@@ -204,7 +204,7 @@ task "reasonable_image_size" do |_, args|
       docker_insecure_registries = config.cnf_config[:docker_insecure_registries].not_nil!
     end
     unless Dockerd.install(docker_insecure_registries)
-      upsert_skipped_task("reasonable_image_size", "⏭️  SKIPPED: Skipping reasonable_image_size: Dockerd tool failed to install")
+      upsert_skipped_task("reasonable_image_size", "⏭️  SKIPPED: Skipping reasonable_image_size: Dockerd tool failed to install", Time.utc)
       next
     end
     Log.for("verbose").info { "reasonable_image_size" } if check_verbose(args)
@@ -298,9 +298,9 @@ task "reasonable_image_size" do |_, args|
     emoji_big="🦖"
 
     if task_response
-      upsert_passed_task("reasonable_image_size", "✔️  PASSED: Image size is good #{emoji_small} #{emoji_image_size}")
+      upsert_passed_task("reasonable_image_size", "✔️  PASSED: Image size is good #{emoji_small} #{emoji_image_size}", Time.utc)
     else
-      upsert_failed_task("reasonable_image_size", "✖️  FAILED: Image size too large #{emoji_big} #{emoji_image_size}")
+      upsert_failed_task("reasonable_image_size", "✖️  FAILED: Image size too large #{emoji_big} #{emoji_image_size}", Time.utc)
     end
   end
 end
@@ -412,9 +412,9 @@ task "single_process_type" do |_, args|
     emoji_big="🦖"
 
     if task_response
-      upsert_passed_task("single_process_type", "✔️  🏆 PASSED: Only one process type used #{emoji_small} #{emoji_image_size}")
+      upsert_passed_task("single_process_type", "✔️  🏆 PASSED: Only one process type used #{emoji_small} #{emoji_image_size}", Time.utc)
     else
-      upsert_failed_task("single_process_type", "✖️  🏆 FAILED: More than one process type used #{emoji_big} #{emoji_image_size}")
+      upsert_failed_task("single_process_type", "✖️  🏆 FAILED: More than one process type used #{emoji_big} #{emoji_image_size}", Time.utc)
     end
   end
 end
@@ -470,9 +470,9 @@ task "zombie_handled" do |_, args|
     emoji_big="🦖"
 
     if task_response
-      upsert_passed_task("zombie_handled", "✔️  🏆 PASSED: Zombie handled #{emoji_small} #{emoji_image_size}")
+      upsert_passed_task("zombie_handled", "✔️  🏆 PASSED: Zombie handled #{emoji_small} #{emoji_image_size}", Time.utc)
     else
-      upsert_failed_task("zombie_handled", "✖️  🏆 FAILED: Zombie not handled #{emoji_big} #{emoji_image_size}")
+      upsert_failed_task("zombie_handled", "✖️  🏆 FAILED: Zombie not handled #{emoji_big} #{emoji_image_size}", Time.utc)
     end
   end
 
@@ -646,9 +646,9 @@ task "sig_term_handled" do |_, args|
     emoji_big="🦖"
 
     if task_response
-      upsert_passed_task("sig_term_handled", "✔️  🏆 PASSED: Sig Term handled #{emoji_small} #{emoji_image_size}")
+      upsert_passed_task("sig_term_handled", "✔️  🏆 PASSED: Sig Term handled #{emoji_small} #{emoji_image_size}", Time.utc)
     else
-      upsert_failed_task("sig_term_handled", "✖️  🏆 FAILED: Sig Term not handled #{emoji_big} #{emoji_image_size}")
+      upsert_failed_task("sig_term_handled", "✖️  🏆 FAILED: Sig Term not handled #{emoji_big} #{emoji_image_size}", Time.utc)
     end
   end
 end
@@ -703,9 +703,9 @@ task "service_discovery" do |_, args|
     emoji_big="🦖"
 
     if test_passed
-      upsert_passed_task("service_discovery", "✔️  ✨PASSED: Some containers exposed as a service #{emoji_small} #{emoji_image_size}")
+      upsert_passed_task("service_discovery", "✔️  ✨PASSED: Some containers exposed as a service #{emoji_small} #{emoji_image_size}", Time.utc)
     else
-      upsert_failed_task("service_discovery", "✖️  ✨FAILED: No containers exposed as a service #{emoji_big} #{emoji_image_size}")
+      upsert_failed_task("service_discovery", "✖️  ✨FAILED: No containers exposed as a service #{emoji_big} #{emoji_image_size}", Time.utc)
     end
   end
 end
@@ -737,12 +737,12 @@ task "specialized_init_system", ["install_cluster_tools"] do |_, args|
     passed_emoji = "🖥️  🚀"
 
     if failed_cnf_resources.size > 0
-      upsert_failed_task(test_name, "✖️  FAILED: Containers do not use specialized init systems #{failed_emoji}")
+      upsert_failed_task(test_name, "✖️  FAILED: Containers do not use specialized init systems #{failed_emoji}", Time.utc)
       failed_cnf_resources.each do |init_info|
         stdout_failure "#{init_info.kind}/#{init_info.name} has container '#{init_info.container}' with #{init_info.init_cmd} as init process"
       end
     else
-      upsert_passed_task(test_name, "✔️  PASSED: Containers use specialized init systems #{passed_emoji}")
+      upsert_passed_task(test_name, "✔️  PASSED: Containers use specialized init systems #{passed_emoji}", Time.utc)
     end
 
   end

--- a/src/tasks/workload/observability.cr
+++ b/src/tasks/workload/observability.cr
@@ -38,9 +38,9 @@ task "log_output" do |_, args|
     emoji_observability="📶☠️"
 
     if task_response
-      upsert_passed_task("log_output", "✔️  🏆 PASSED: Resources output logs to stdout and stderr #{emoji_observability}")
+      upsert_passed_task("log_output", "✔️  🏆 PASSED: Resources output logs to stdout and stderr #{emoji_observability}", Time.utc)
     else
-      upsert_failed_task("log_output", "✖️  🏆 FAILED: Resources do not output logs to stdout and stderr #{emoji_observability}")
+      upsert_failed_task("log_output", "✖️  🏆 FAILED: Resources do not output logs to stdout and stderr #{emoji_observability}", Time.utc)
     end
   end
 end
@@ -157,12 +157,12 @@ task "prometheus_traffic" do |_, args|
       #  -- match ip address to cnf ip addresses
       # todo check if scrape_url is not an ip, assume it is a service, then do task (2)
       if prom_cnf_match
-        upsert_passed_task("prometheus_traffic","✔️  ✨PASSED: Your cnf is sending prometheus traffic #{emoji_observability}")
+        upsert_passed_task("prometheus_traffic","✔️  ✨PASSED: Your cnf is sending prometheus traffic #{emoji_observability}", Time.utc)
       else
-        upsert_failed_task("prometheus_traffic", "✖️  ✨FAILED: Your cnf is not sending prometheus traffic #{emoji_observability}")
+        upsert_failed_task("prometheus_traffic", "✖️  ✨FAILED: Your cnf is not sending prometheus traffic #{emoji_observability}", Time.utc)
       end
     else
-      upsert_skipped_task("prometheus_traffic", "⏭️  ✨SKIPPED: Prometheus server not found #{emoji_observability}")
+      upsert_skipped_task("prometheus_traffic", "⏭️  ✨SKIPPED: Prometheus server not found #{emoji_observability}", Time.utc)
     end
   end
 end
@@ -179,14 +179,14 @@ task "open_metrics", ["prometheus_traffic"] do |_, args|
       open_metrics_validated = configmap["data"].as_h["open_metrics_validated"].as_s
 
       if open_metrics_validated == "true"
-        upsert_passed_task("open_metrics","✔️  ✨PASSED: Your cnf's metrics traffic is OpenMetrics compatible #{emoji_observability}")
+        upsert_passed_task("open_metrics","✔️  ✨PASSED: Your cnf's metrics traffic is OpenMetrics compatible #{emoji_observability}", Time.utc)
       else
         open_metrics_response = configmap["data"].as_h["open_metrics_response"].as_s
         puts "OpenMetrics Failed: #{open_metrics_response}".colorize(:red)
-        upsert_failed_task("open_metrics", "✖️  ✨FAILED: Your cnf's metrics traffic is not OpenMetrics compatible #{emoji_observability}")
+        upsert_failed_task("open_metrics", "✖️  ✨FAILED: Your cnf's metrics traffic is not OpenMetrics compatible #{emoji_observability}", Time.utc)
       end
     else
-      upsert_skipped_task("open_metrics", "⏭️  ✨SKIPPED: Prometheus traffic not configured #{emoji_observability}")
+      upsert_skipped_task("open_metrics", "⏭️  ✨SKIPPED: Prometheus traffic not configured #{emoji_observability}", Time.utc)
     end
   end
 end
@@ -221,12 +221,12 @@ task "routed_logs", ["install_cluster_tools"] do |_, args|
         end
         Log.info { "all_resourced_logged: #{all_resourced_logged}" }
         if all_resourced_logged 
-          upsert_passed_task("routed_logs","✔️  ✨PASSED: Your cnf's logs are being captured #{emoji_observability}")
+          upsert_passed_task("routed_logs","✔️  ✨PASSED: Your cnf's logs are being captured #{emoji_observability}", Time.utc)
         else
-          upsert_failed_task("routed_logs", "✖️  ✨FAILED: Your cnf's logs are not being captured #{emoji_observability}")
+          upsert_failed_task("routed_logs", "✖️  ✨FAILED: Your cnf's logs are not being captured #{emoji_observability}", Time.utc)
         end
     else
-      upsert_skipped_task("routed_logs", "⏭️  ✨SKIPPED: Fluentd or FluentBit not configured #{emoji_observability}")
+      upsert_skipped_task("routed_logs", "⏭️  ✨SKIPPED: Fluentd or FluentBit not configured #{emoji_observability}", Time.utc)
     end
   end
 end
@@ -252,16 +252,16 @@ task "tracing" do |_, args|
         tracing_used = configmap["data"].as_h["tracing_used"].as_s
 
         if tracing_used == "true" 
-          upsert_passed_task("tracing", "✔️  ✨PASSED: Tracing used #{emoji_tracing_deploy}")
+          upsert_passed_task("tracing", "✔️  ✨PASSED: Tracing used #{emoji_tracing_deploy}", Time.utc)
         else
-          upsert_failed_task("tracing", "✖️  ✨FAILED: Tracing not used #{emoji_tracing_deploy}")
+          upsert_failed_task("tracing", "✖️  ✨FAILED: Tracing not used #{emoji_tracing_deploy}", Time.utc)
         end
       else
-        upsert_skipped_task("tracing", "⏭️  ✨SKIPPED: Jaeger not configured #{emoji_tracing_deploy}")
+        upsert_skipped_task("tracing", "⏭️  ✨SKIPPED: Jaeger not configured #{emoji_tracing_deploy}", Time.utc)
       end
     end
   else
-    upsert_failed_task("tracing", "✖️  ✨FAILED: No cnf_testsuite.yml found! Did you run the setup task?")
+    upsert_failed_task("tracing", "✖️  ✨FAILED: No cnf_testsuite.yml found! Did you run the setup task?", Time.utc)
   end
 end
 

--- a/src/tasks/workload/reliability.cr
+++ b/src/tasks/workload/reliability.cr
@@ -50,9 +50,9 @@ task "liveness" do |_, args|
     end
     Log.for("liveness").info { "Workload resource task response: #{task_response}" }
     if task_response
-      resp = upsert_passed_task("liveness","✔️  🏆 PASSED: Helm liveness probe found #{emoji_probe}")
+      resp = upsert_passed_task("liveness","✔️  🏆 PASSED: Helm liveness probe found #{emoji_probe}", Time.utc)
 		else
-			resp = upsert_failed_task("liveness","✖️  🏆 FAILED: No livenessProbe found #{emoji_probe}")
+			resp = upsert_failed_task("liveness","✖️  🏆 FAILED: No livenessProbe found #{emoji_probe}", Time.utc)
     end
     resp
   end
@@ -81,9 +81,9 @@ task "readiness" do |_, args|
     end
     Log.for("readiness").info { "Workload resource task response: #{task_response}" }
     if task_response
-      resp = upsert_passed_task("readiness","✔️  🏆 PASSED: Helm readiness probe found #{emoji_probe}")
+      resp = upsert_passed_task("readiness","✔️  🏆 PASSED: Helm readiness probe found #{emoji_probe}", Time.utc)
 		else
-      resp = upsert_failed_task("readiness","✖️  🏆 FAILED: No readinessProbe found #{emoji_probe}")
+      resp = upsert_failed_task("readiness","✖️  🏆 FAILED: No readinessProbe found #{emoji_probe}", Time.utc)
     end
     resp
   end
@@ -151,9 +151,9 @@ task "pod_network_latency", ["install_litmus"] do |_, args|
       end
     end
     if task_response
-      resp = upsert_passed_task("pod_network_latency","✔️  ✨PASSED: pod_network_latency chaos test passed 🗡️💀♻️")
+      resp = upsert_passed_task("pod_network_latency","✔️  ✨PASSED: pod_network_latency chaos test passed 🗡️💀♻️", Time.utc)
     else
-      resp = upsert_failed_task("pod_network_latency","✖️  ✨FAILED: pod_network_latency chaos test failed 🗡️💀♻️")
+      resp = upsert_failed_task("pod_network_latency","✖️  ✨FAILED: pod_network_latency chaos test failed 🗡️💀♻️", Time.utc)
     end
   end
 end
@@ -218,9 +218,9 @@ task "pod_network_corruption", ["install_litmus"] do |_, args|
       end
     end
     if task_response
-      resp = upsert_passed_task("pod_network_corruption","✔️  ✨PASSED: pod_network_corruption chaos test passed 🗡️💀♻️")
+      resp = upsert_passed_task("pod_network_corruption","✔️  ✨PASSED: pod_network_corruption chaos test passed 🗡️💀♻️", Time.utc)
     else
-      resp = upsert_failed_task("pod_network_corruption","✖️  ✨FAILED: pod_network_corruption chaos test failed 🗡️💀♻️")
+      resp = upsert_failed_task("pod_network_corruption","✖️  ✨FAILED: pod_network_corruption chaos test failed 🗡️💀♻️", Time.utc)
     end
   end
 end
@@ -285,9 +285,9 @@ task "pod_network_duplication", ["install_litmus"] do |_, args|
       end
     end
     if task_response
-      resp = upsert_passed_task("pod_network_duplication","✔️  ✨PASSED: pod_network_duplication chaos test passed 🗡️💀♻️")
+      resp = upsert_passed_task("pod_network_duplication","✔️  ✨PASSED: pod_network_duplication chaos test passed 🗡️💀♻️", Time.utc)
     else
-      resp = upsert_failed_task("pod_network_duplication","✖️  ✨FAILED: pod_network_duplication chaos test failed 🗡️💀♻️")
+      resp = upsert_failed_task("pod_network_duplication","✖️  ✨FAILED: pod_network_duplication chaos test failed 🗡️💀♻️", Time.utc)
     end
   end
 end
@@ -352,9 +352,9 @@ task "disk_fill", ["install_litmus"] do |_, args|
       test_passed
     end
     if task_response 
-      resp = upsert_passed_task("disk_fill","✔️  PASSED: disk_fill chaos test passed 🗡️💀♻️")
+      resp = upsert_passed_task("disk_fill","✔️  PASSED: disk_fill chaos test passed 🗡️💀♻️", Time.utc)
     else
-      resp = upsert_failed_task("disk_fill","✖️  FAILED: disk_fill chaos test failed 🗡️💀♻️")
+      resp = upsert_failed_task("disk_fill","✖️  FAILED: disk_fill chaos test failed 🗡️💀♻️", Time.utc)
     end
   end
 end
@@ -420,9 +420,9 @@ task "pod_delete", ["install_litmus"] do |_, args|
       test_passed=LitmusManager.check_chaos_verdict(chaos_result_name,chaos_experiment_name,args, namespace: app_namespace)
     end
     if task_response
-      resp = upsert_passed_task("pod_delete","✔️  PASSED: pod_delete chaos test passed 🗡️💀♻️")
+      resp = upsert_passed_task("pod_delete","✔️  PASSED: pod_delete chaos test passed 🗡️💀♻️", Time.utc)
     else
-      resp = upsert_failed_task("pod_delete","✖️  FAILED: pod_delete chaos test failed 🗡️💀♻️")
+      resp = upsert_failed_task("pod_delete","✖️  FAILED: pod_delete chaos test failed 🗡️💀♻️", Time.utc)
     end
   end
 end
@@ -489,9 +489,9 @@ task "pod_memory_hog", ["install_litmus"] do |_, args|
       test_passed
     end
     if task_response
-      resp = upsert_passed_task("pod_memory_hog","✔️  PASSED: pod_memory_hog chaos test passed 🗡️💀♻️")
+      resp = upsert_passed_task("pod_memory_hog","✔️  PASSED: pod_memory_hog chaos test passed 🗡️💀♻️", Time.utc)
     else
-      resp = upsert_failed_task("pod_memory_hog","✖️  FAILED: pod_memory_hog chaos test failed 🗡️💀♻️")
+      resp = upsert_failed_task("pod_memory_hog","✖️  FAILED: pod_memory_hog chaos test failed 🗡️💀♻️", Time.utc)
     end
   end
 end
@@ -557,9 +557,9 @@ task "pod_io_stress", ["install_litmus"] do |_, args|
       end
     end
     if task_response
-      resp = upsert_passed_task(test_name,"✔️  ✨PASSED: #{test_name} chaos test passed 🗡️💀♻️")
+      resp = upsert_passed_task(test_name,"✔️  ✨PASSED: #{test_name} chaos test passed 🗡️💀♻️", Time.utc)
     else
-      resp = upsert_failed_task(test_name,"✖️  ✨FAILED: #{test_name} chaos test failed 🗡️💀♻️")
+      resp = upsert_failed_task(test_name,"✖️  ✨FAILED: #{test_name} chaos test failed 🗡️💀♻️", Time.utc)
     end
   end
 ensure
@@ -632,12 +632,12 @@ task "pod_dns_error", ["install_litmus"] do |_, args|
         end
       end
       if task_response
-        resp = upsert_passed_task("pod_dns_error","✔️  ✨PASSED: pod_dns_error chaos test passed 🗡️💀♻️")
+        resp = upsert_passed_task("pod_dns_error","✔️  ✨PASSED: pod_dns_error chaos test passed 🗡️💀♻️", Time.utc)
       else
-        resp = upsert_failed_task("pod_dns_error","✖️  ✨FAILED: pod_dns_error chaos test failed 🗡️💀♻️")
+        resp = upsert_failed_task("pod_dns_error","✖️  ✨FAILED: pod_dns_error chaos test failed 🗡️💀♻️", Time.utc)
       end
     else
-      resp = upsert_skipped_task("pod_dns_error","⏭️   ✨SKIPPED: pod_dns_error docker runtime not found 🗡️💀♻️")
+      resp = upsert_skipped_task("pod_dns_error","⏭️   ✨SKIPPED: pod_dns_error docker runtime not found 🗡️💀♻️", Time.utc)
     end
   end
 end

--- a/src/tasks/workload/security.cr
+++ b/src/tasks/workload/security.cr
@@ -48,9 +48,9 @@ task "sysctls" do |_, args|
     failures = Kyverno.filter_failures_for_cnf_resources(resource_keys, failures)
 
     if failures.size == 0
-      resp = upsert_passed_task("sysctls", "✔️  PASSED: No restricted values found for sysctls #{emoji_security}")
+      resp = upsert_passed_task("sysctls", "✔️  PASSED: No restricted values found for sysctls #{emoji_security}", Time.utc)
     else
-      resp = upsert_failed_task("sysctls", "✖️  FAILED: Restricted values for are being used for sysctls #{emoji_security}")
+      resp = upsert_failed_task("sysctls", "✖️  FAILED: Restricted values for are being used for sysctls #{emoji_security}", Time.utc)
       failures.each do |failure|
         failure.resources.each do |resource|
           puts "#{resource.kind} #{resource.name} in #{resource.namespace} namespace failed. #{failure.message}".colorize(:red)
@@ -73,9 +73,9 @@ task "external_ips" do |_, args|
     failures = Kyverno.filter_failures_for_cnf_resources(resource_keys, failures)
     
     if failures.size == 0
-      resp = upsert_passed_task("external_ips", "✔️  PASSED: Services are not using external IPs #{emoji_security}")
+      resp = upsert_passed_task("external_ips", "✔️  PASSED: Services are not using external IPs #{emoji_security}", Time.utc)
     else
-      resp = upsert_failed_task("external_ips", "✖️  FAILED: Services are using external IPs #{emoji_security}")
+      resp = upsert_failed_task("external_ips", "✖️  FAILED: Services are using external IPs #{emoji_security}", Time.utc)
       failures.each do |failure|
         failure.resources.each do |resource|
           puts "#{resource.kind} #{resource.name} in #{resource.namespace} namespace failed. #{failure.message}".colorize(:red)
@@ -106,15 +106,15 @@ task "selinux_options" do |_, args|
     check_failures = Kyverno.filter_failures_for_cnf_resources(resource_keys, check_failures)
 
     if check_failures.size == 0
-      # upsert_skipped_task("selinux_options", "⏭️  🏆 SKIPPED: Pods are not using SELinux options #{emoji_security}")
-      upsert_na_task("selinux_options", "⏭️  🏆 N/A: Pods are not using SELinux #{emoji_security}")
+      # upsert_skipped_task("selinux_options", "⏭️  🏆 SKIPPED: Pods are not using SELinux options #{emoji_security}", Time.utc)
+      upsert_na_task("selinux_options", "⏭️  🏆 N/A: Pods are not using SELinux #{emoji_security}", Time.utc)
     else
       failures = Kyverno.filter_failures_for_cnf_resources(resource_keys, disallow_failures)
 
       if failures.size == 0
-        resp = upsert_passed_task("selinux_options", "✔️  🏆 PASSED: Pods are not using custom SELinux options that can be used for privilege escalations #{emoji_security}")
+        resp = upsert_passed_task("selinux_options", "✔️  🏆 PASSED: Pods are not using custom SELinux options that can be used for privilege escalations #{emoji_security}", Time.utc)
       else
-        resp = upsert_failed_task("selinux_options", "✖️  🏆 FAILED: Pods are using custom SELinux options that can be used for privilege escalations #{emoji_security}")
+        resp = upsert_failed_task("selinux_options", "✖️  🏆 FAILED: Pods are using custom SELinux options that can be used for privilege escalations #{emoji_security}", Time.utc)
         failures.each do |failure|
           failure.resources.each do |resource|
             puts "#{resource.kind} #{resource.name} in #{resource.namespace} namespace failed. #{failure.message}".colorize(:red)
@@ -137,9 +137,9 @@ task "container_sock_mounts" do |_, args|
     failures = Kyverno::PolicyAudit.run(policy_path, EXCLUDE_NAMESPACES)
 
     if failures.size == 0
-      resp = upsert_passed_task("container_sock_mounts", "✔️  🏆 PASSED: Container engine daemon sockets are not mounted as volumes #{emoji_security}")
+      resp = upsert_passed_task("container_sock_mounts", "✔️  🏆 PASSED: Container engine daemon sockets are not mounted as volumes #{emoji_security}", Time.utc)
     else
-      resp = upsert_failed_task("container_sock_mounts", "✖️  🏆 FAILED: Container engine daemon sockets are mounted as volumes #{emoji_security}")
+      resp = upsert_failed_task("container_sock_mounts", "✖️  🏆 FAILED: Container engine daemon sockets are mounted as volumes #{emoji_security}", Time.utc)
       failures.each do |failure|
         failure.resources.each do |resource|
           puts "#{resource.kind} #{resource.name} in #{resource.namespace} namespace failed. #{failure.message}".colorize(:red)
@@ -155,7 +155,7 @@ task "non_root_user", ["install_falco"] do |_, args|
 
      unless KubectlClient::Get.resource_wait_for_install("Daemonset", "falco", namespace: TESTSUITE_NAMESPACE)
        Log.info { "Falco Failed to Start" }
-       upsert_skipped_task("non_root_user", "⏭️  SKIPPED: Skipping non_root_user: Falco failed to install. Check Kernel Headers are installed on the Host Systems(K8s).")
+       upsert_skipped_task("non_root_user", "⏭️  SKIPPED: Skipping non_root_user: Falco failed to install. Check Kernel Headers are installed on the Host Systems(K8s).", Time.utc)
        node_pods = KubectlClient::Get.pods_by_nodes(KubectlClient::Get.schedulable_nodes_list)
        pods = KubectlClient::Get.pods_by_label(node_pods, "app", "falco")
 
@@ -201,9 +201,9 @@ task "non_root_user", ["install_falco"] do |_, args|
      emoji_root="√"
 
      if task_response
-       upsert_passed_task("non_root_user", "✔️  PASSED: Root user not found #{emoji_no_root}")
+       upsert_passed_task("non_root_user", "✔️  PASSED: Root user not found #{emoji_no_root}", Time.utc)
      else
-       upsert_failed_task("non_root_user", "✖️  FAILED: Root user found #{emoji_root}")
+       upsert_failed_task("non_root_user", "✖️  FAILED: Root user found #{emoji_root}", Time.utc)
      end
    end
 end
@@ -232,9 +232,9 @@ task "privileged" do |_, args|
     LOGGING.debug "violator list: #{violation_list.flatten}"
     emoji_security="🔓🔑"
     if task_response 
-      upsert_passed_task("privileged", "✔️  PASSED: No privileged containers #{emoji_security}")
+      upsert_passed_task("privileged", "✔️  PASSED: No privileged containers #{emoji_security}", Time.utc)
     else
-      upsert_failed_task("privileged", "✖️  FAILED: Found #{violation_list.size} privileged containers #{emoji_security}")
+      upsert_failed_task("privileged", "✖️  FAILED: Found #{violation_list.size} privileged containers #{emoji_security}", Time.utc)
       violation_list.each do |violation|
         stdout_failure("Privileged container #{violation[:container]} in #{violation[:kind]}/#{violation[:name]} in the #{violation[:namespace]} namespace")
       end
@@ -254,9 +254,9 @@ task "privilege_escalation", ["kubescape_scan"] do |_, args|
 
     emoji_security="🔓🔑"
     if test_report.failed_resources.size == 0 
-      upsert_passed_task("privilege_escalation", "✔️  PASSED: No containers that allow privilege escalation were found #{emoji_security}")
+      upsert_passed_task("privilege_escalation", "✔️  PASSED: No containers that allow privilege escalation were found #{emoji_security}", Time.utc)
     else
-      resp = upsert_failed_task("privilege_escalation", "✖️  FAILED: Found containers that allow privilege escalation #{emoji_security}")
+      resp = upsert_failed_task("privilege_escalation", "✖️  FAILED: Found containers that allow privilege escalation #{emoji_security}", Time.utc)
       test_report.failed_resources.map {|r| stdout_failure(r.alert_message) }
       stdout_failure("Remediation: #{test_report.remediation}")
       resp
@@ -276,9 +276,9 @@ task "symlink_file_system", ["kubescape_scan"] do |_, args|
 
     emoji_security="🔓🔑"
     if test_report.failed_resources.size == 0
-      upsert_passed_task("symlink_file_system", "✔️  PASSED: No containers allow a symlink attack #{emoji_security}")
+      upsert_passed_task("symlink_file_system", "✔️  PASSED: No containers allow a symlink attack #{emoji_security}", Time.utc)
     else
-      resp = upsert_failed_task("symlink_file_system", "✖️  FAILED: Found containers that allow a symlink attack #{emoji_security}")
+      resp = upsert_failed_task("symlink_file_system", "✖️  FAILED: Found containers that allow a symlink attack #{emoji_security}", Time.utc)
       test_report.failed_resources.map {|r| stdout_failure(r.alert_message) }
       stdout_failure("Remediation: #{test_report.remediation}")
       resp
@@ -298,9 +298,9 @@ task "application_credentials", ["kubescape_scan"] do |_, args|
 
     emoji_security="🔓🔑"
     if test_report.failed_resources.size == 0
-      upsert_passed_task("application_credentials", "✔️  PASSED: No applications credentials in configuration files #{emoji_security}")
+      upsert_passed_task("application_credentials", "✔️  PASSED: No applications credentials in configuration files #{emoji_security}", Time.utc)
     else
-      resp = upsert_failed_task("application_credentials", "✖️  FAILED: Found applications credentials in configuration files #{emoji_security}")
+      resp = upsert_failed_task("application_credentials", "✖️  FAILED: Found applications credentials in configuration files #{emoji_security}", Time.utc)
       test_report.failed_resources.map {|r| stdout_failure(r.alert_message) }
       stdout_failure("Remediation: #{test_report.remediation}")
       resp
@@ -320,9 +320,9 @@ task "host_network", ["kubescape_scan"] do |_, args|
 
     emoji_security="🔓🔑"
     if test_report.failed_resources.size == 0
-      upsert_passed_task("host_network", "✔️  PASSED: No host network attached to pod #{emoji_security}")
+      upsert_passed_task("host_network", "✔️  PASSED: No host network attached to pod #{emoji_security}", Time.utc)
     else
-      resp = upsert_failed_task("host_network", "✖️  FAILED: Found host network attached to pod #{emoji_security}")
+      resp = upsert_failed_task("host_network", "✖️  FAILED: Found host network attached to pod #{emoji_security}", Time.utc)
       test_report.failed_resources.map {|r| stdout_failure(r.alert_message) }
       stdout_failure("Remediation: #{test_report.remediation}")
       resp
@@ -342,9 +342,9 @@ task "service_account_mapping", ["kubescape_scan"] do |_, args|
 
     emoji_security="🔓🔑"
     if test_report.failed_resources.size == 0 
-      upsert_passed_task("service_account_mapping", "✔️  PASSED: No service accounts automatically mapped #{emoji_security}")
+      upsert_passed_task("service_account_mapping", "✔️  PASSED: No service accounts automatically mapped #{emoji_security}", Time.utc)
     else
-      resp = upsert_failed_task("service_account_mapping", "✖️  FAILED: Service accounts automatically mapped #{emoji_security}")
+      resp = upsert_failed_task("service_account_mapping", "✖️  FAILED: Service accounts automatically mapped #{emoji_security}", Time.utc)
       test_report.failed_resources.map {|r| stdout_failure(r.alert_message) }
       stdout_failure("Remediation: #{test_report.remediation}")
       resp
@@ -366,9 +366,9 @@ task "linux_hardening", ["kubescape_scan"] do |_, args|
 
     emoji_security = "🔓🔑"
     if test_report.failed_resources.size == 0
-      upsert_passed_task("linux_hardening", "✔️  ✨PASSED: Security services are being used to harden applications #{emoji_security}")
+      upsert_passed_task("linux_hardening", "✔️  ✨PASSED: Security services are being used to harden applications #{emoji_security}", Time.utc)
     else
-      resp = upsert_failed_task("linux_hardening", "✖️  ✨FAILED: Found resources that do not use security services #{emoji_security}")
+      resp = upsert_failed_task("linux_hardening", "✖️  ✨FAILED: Found resources that do not use security services #{emoji_security}", Time.utc)
         test_report.failed_resources.map {|r| stdout_failure(r.alert_message) }
         stdout_failure("Remediation: #{test_report.remediation}")
       resp
@@ -390,9 +390,9 @@ task "insecure_capabilities", ["kubescape_scan"] do |_, args|
 
     emoji_security = "🔓🔑"
     if test_report.failed_resources.size == 0
-      upsert_passed_task("insecure_capabilities", "✔️  PASSED: Containers with insecure capabilities were not found #{emoji_security}")
+      upsert_passed_task("insecure_capabilities", "✔️  PASSED: Containers with insecure capabilities were not found #{emoji_security}", Time.utc)
     else
-      resp = upsert_failed_task("insecure_capabilities", "✖️  FAILED: Found containers with insecure capabilities #{emoji_security}")
+      resp = upsert_failed_task("insecure_capabilities", "✖️  FAILED: Found containers with insecure capabilities #{emoji_security}", Time.utc)
       test_report.failed_resources.map {|r| stdout_failure(r.alert_message) }
       stdout_failure("Remediation: #{test_report.remediation}")
       resp
@@ -414,9 +414,9 @@ task "resource_policies", ["kubescape_scan"] do |_, args|
 
     emoji_security = "🔓🔑"
     if test_report.failed_resources.size == 0
-      upsert_passed_task("resource_policies", "✔️  🏆 PASSED: Containers have resource limits defined #{emoji_security}")
+      upsert_passed_task("resource_policies", "✔️  🏆 PASSED: Containers have resource limits defined #{emoji_security}", Time.utc)
     else
-      resp = upsert_failed_task("resource_policies", "✖️  🏆 FAILED: Found containers without resource limits defined #{emoji_security}")
+      resp = upsert_failed_task("resource_policies", "✖️  🏆 FAILED: Found containers without resource limits defined #{emoji_security}", Time.utc)
       test_report.failed_resources.map {|r| stdout_failure(r.alert_message) }
       stdout_failure("Remediation: #{test_report.remediation}")
       resp
@@ -438,9 +438,9 @@ task "ingress_egress_blocked", ["kubescape_scan"] do |_, args|
 
     emoji_security = "🔓🔑"
     if test_report.failed_resources.size == 0
-      upsert_passed_task("ingress_egress_blocked", "✔️  ✨PASSED: Ingress and Egress traffic blocked on pods #{emoji_security}")
+      upsert_passed_task("ingress_egress_blocked", "✔️  ✨PASSED: Ingress and Egress traffic blocked on pods #{emoji_security}", Time.utc)
     else
-      resp = upsert_failed_task("ingress_egress_blocked", "✖️  ✨FAILED: Ingress and Egress traffic not blocked on pods #{emoji_security}")
+      resp = upsert_failed_task("ingress_egress_blocked", "✖️  ✨FAILED: Ingress and Egress traffic not blocked on pods #{emoji_security}", Time.utc)
       test_report.failed_resources.map {|r| stdout_failure(r.alert_message) }
       stdout_failure("Remediation: #{test_report.remediation}")
       resp
@@ -462,9 +462,9 @@ task "host_pid_ipc_privileges", ["kubescape_scan"] do |_, args|
 
     emoji_security = "🔓🔑"
     if test_report.failed_resources.size == 0
-      upsert_passed_task("host_pid_ipc_privileges", "✔️  PASSED: No containers with hostPID and hostIPC privileges #{emoji_security}")
+      upsert_passed_task("host_pid_ipc_privileges", "✔️  PASSED: No containers with hostPID and hostIPC privileges #{emoji_security}", Time.utc)
     else
-      resp = upsert_failed_task("host_pid_ipc_privileges", "✖️  FAILED: Found containers with hostPID and hostIPC privileges #{emoji_security}")
+      resp = upsert_failed_task("host_pid_ipc_privileges", "✖️  FAILED: Found containers with hostPID and hostIPC privileges #{emoji_security}", Time.utc)
       test_report.failed_resources.map {|r| stdout_failure(r.alert_message) }
       stdout_failure("Remediation: #{test_report.remediation}")
       resp
@@ -486,9 +486,9 @@ task "non_root_containers", ["kubescape_scan"] do |_, args|
 
     emoji_security = "🔓🔑"
     if test_report.failed_resources.size == 0
-      upsert_passed_task("non_root_containers", "✔️  🏆 PASSED: Containers are running with non-root user with non-root group membership #{emoji_security}")
+      upsert_passed_task("non_root_containers", "✔️  🏆 PASSED: Containers are running with non-root user with non-root group membership #{emoji_security}", Time.utc)
     else
-      resp = upsert_failed_task("non_root_containers", "✖️  🏆 FAILED: Found containers running with root user or user with root group membership #{emoji_security}")
+      resp = upsert_failed_task("non_root_containers", "✖️  🏆 FAILED: Found containers running with root user or user with root group membership #{emoji_security}", Time.utc)
       test_report.failed_resources.map {|r| stdout_failure(r.alert_message) }
       stdout_failure("Remediation: #{test_report.remediation}")
       resp
@@ -511,9 +511,9 @@ task "privileged_containers", ["kubescape_scan" ] do |_, args|
     emoji_security = "🔓🔑"
     #todo whitelist
     if test_report.failed_resources.size == 0
-      upsert_passed_task("privileged_containers", "✔️  🏆 PASSED: No privileged containers were found #{emoji_security}")
+      upsert_passed_task("privileged_containers", "✔️  🏆 PASSED: No privileged containers were found #{emoji_security}", Time.utc)
     else
-      resp = upsert_failed_task("privileged_containers", "✖️  🏆 FAILED: Found privileged containers #{emoji_security}")
+      resp = upsert_failed_task("privileged_containers", "✖️  🏆 FAILED: Found privileged containers #{emoji_security}", Time.utc)
       test_report.failed_resources.map {|r| stdout_failure(r.alert_message) }
       stdout_failure("Remediation: #{test_report.remediation}")
       resp
@@ -535,9 +535,9 @@ task "immutable_file_systems", ["kubescape_scan"] do |_, args|
 
     emoji_security = "🔓🔑"
     if test_report.failed_resources.size == 0
-      upsert_passed_task("immutable_file_systems", "✔️  ✨PASSED: Containers have immutable file systems #{emoji_security}")
+      upsert_passed_task("immutable_file_systems", "✔️  ✨PASSED: Containers have immutable file systems #{emoji_security}", Time.utc)
     else
-      resp = upsert_failed_task("immutable_file_systems", "✖️  ✨FAILED: Found containers with mutable file systems #{emoji_security}")
+      resp = upsert_failed_task("immutable_file_systems", "✖️  ✨FAILED: Found containers with mutable file systems #{emoji_security}", Time.utc)
       test_report.failed_resources.map {|r| stdout_failure(r.alert_message) }
       stdout_failure("Remediation: #{test_report.remediation}")
       resp
@@ -559,9 +559,9 @@ task "hostpath_mounts", ["kubescape_scan"] do |_, args|
 
     emoji_security = "🔓🔑"
     if test_report.failed_resources.size == 0
-      upsert_passed_task("hostpath_mounts", "✔️  PASSED: Containers do not have hostPath mounts #{emoji_security}")
+      upsert_passed_task("hostpath_mounts", "✔️  PASSED: Containers do not have hostPath mounts #{emoji_security}", Time.utc)
     else
-      resp = upsert_failed_task("hostpath_mounts", "✖️  FAILED: Found containers with hostPath mounts #{emoji_security}")
+      resp = upsert_failed_task("hostpath_mounts", "✖️  FAILED: Found containers with hostPath mounts #{emoji_security}", Time.utc)
       test_report.failed_resources.map {|r| stdout_failure(r.alert_message) }
       stdout_failure("Remediation: #{test_report.remediation}")
       resp

--- a/src/tasks/workload/state.cr
+++ b/src/tasks/workload/state.cr
@@ -329,11 +329,11 @@ task "node_drain", ["install_litmus"] do |t, args|
     end
     if skipped
       Log.for("verbose").warn{"The node_drain test needs minimum 2 schedulable nodes, current number of nodes: #{KubectlClient::Get.schedulable_nodes_list.size}"} if check_verbose(args)
-      resp = upsert_skipped_task("node_drain","⏭️  🏆 SKIPPED: node_drain chaos test requires the cluster to have atleast two schedulable nodes 🗡️💀♻️")
+      resp = upsert_skipped_task("node_drain","⏭️  🏆 SKIPPED: node_drain chaos test requires the cluster to have atleast two schedulable nodes 🗡️💀♻️", Time.utc)
     elsif task_response
-      resp = upsert_passed_task("node_drain","✔️  🏆 PASSED: node_drain chaos test passed 🗡️💀♻️")
+      resp = upsert_passed_task("node_drain","✔️  🏆 PASSED: node_drain chaos test passed 🗡️💀♻️", Time.utc)
     else
-      resp = upsert_failed_task("node_drain","✖️  🏆 FAILED: node_drain chaos test failed 🗡️💀♻️")
+      resp = upsert_failed_task("node_drain","✖️  🏆 FAILED: node_drain chaos test failed 🗡️💀♻️", Time.utc)
     end
   end
 end
@@ -367,11 +367,11 @@ task "elastic_volumes" do |_, args|
 
     Log.for("elastic_volumes:result").info { "Volumes used: #{volumes_used}; Elastic?: #{elastic_volumes_used}" }
     if volumes_used == false
-      resp = upsert_skipped_task("elastic_volumes","⏭️  ✨SKIPPED: No volumes used #{emoji_probe}")
+      resp = upsert_skipped_task("elastic_volumes","⏭️  ✨SKIPPED: No volumes used #{emoji_probe}", Time.utc)
     elsif elastic_volumes_used
-      resp = upsert_passed_task("elastic_volumes","✔️  ✨PASSED: Elastic Volumes Used #{emoji_probe}")
+      resp = upsert_passed_task("elastic_volumes","✔️  ✨PASSED: Elastic Volumes Used #{emoji_probe}", Time.utc)
     else
-      resp = upsert_failed_task("elastic_volumes","✔️  ✨FAILED: Volumes used are not elastic volumes #{emoji_probe}")
+      resp = upsert_failed_task("elastic_volumes","✔️  ✨FAILED: Volumes used are not elastic volumes #{emoji_probe}", Time.utc)
     end
     resp
   end
@@ -426,17 +426,17 @@ task "database_persistence" do |_, args|
       end
       failed_emoji = "(ভ_ভ) ރ 💾"
       if elastic_statefulset
-        resp = upsert_dynamic_task("database_persistence",CNFManager::Points::Results::ResultStatus::Pass5, "✔️  PASSED: Elastic Volumes and Statefulsets Used #{emoji_probe}")
+        resp = upsert_dynamic_task("database_persistence",CNFManager::Points::Results::ResultStatus::Pass5, "✔️  PASSED: Elastic Volumes and Statefulsets Used #{emoji_probe}", Time.utc)
       elsif elastic_volume_used 
-        resp = upsert_dynamic_task("database_persistence",CNFManager::Points::Results::ResultStatus::Pass3,"✔️  PASSED: Elastic Volumes Used #{emoji_probe}")
+        resp = upsert_dynamic_task("database_persistence",CNFManager::Points::Results::ResultStatus::Pass3,"✔️  PASSED: Elastic Volumes Used #{emoji_probe}", Time.utc)
       elsif statefulset_exists
-        resp = upsert_dynamic_task("database_persistence",CNFManager::Points::Results::ResultStatus::Neutral, "✖️  FAILED: Statefulset used without an elastic volume #{failed_emoji}")
+        resp = upsert_dynamic_task("database_persistence",CNFManager::Points::Results::ResultStatus::Neutral, "✖️  FAILED: Statefulset used without an elastic volume #{failed_emoji}", Time.utc)
       else
-        resp = upsert_failed_task("database_persistence","✖️  FAILED: Elastic Volumes Not Used #{failed_emoji}")
+        resp = upsert_failed_task("database_persistence","✖️  FAILED: Elastic Volumes Not Used #{failed_emoji}", Time.utc)
       end
 
     else
-      resp = upsert_skipped_task("database_persistence", "⏭️  SKIPPED: Mysql not installed #{emoji_probe}")
+      resp = upsert_skipped_task("database_persistence", "⏭️  SKIPPED: Mysql not installed #{emoji_probe}", Time.utc)
     end
     resp
   end
@@ -482,9 +482,9 @@ task "volume_hostpath_not_found" do |_, args|
     end
 
     if task_response.any?(false)
-      upsert_failed_task("volume_hostpath_not_found","✖️  FAILED: hostPath volumes found #{failed_emoji}")
+      upsert_failed_task("volume_hostpath_not_found","✖️  FAILED: hostPath volumes found #{failed_emoji}", Time.utc)
     else
-      upsert_passed_task("volume_hostpath_not_found","✔️  PASSED: hostPath volumes not found #{passed_emoji}")
+      upsert_passed_task("volume_hostpath_not_found","✔️  PASSED: hostPath volumes not found #{passed_emoji}", Time.utc)
     end
   end
 end
@@ -546,9 +546,9 @@ task "no_local_volume_configuration" do |_, args|
     end
 
     if task_response.any?(false) 
-      upsert_failed_task("no_local_volume_configuration","✖️  ✨FAILED: local storage configuration volumes found #{failed_emoji}")
+      upsert_failed_task("no_local_volume_configuration","✖️  ✨FAILED: local storage configuration volumes found #{failed_emoji}", Time.utc)
     else
-      upsert_passed_task("no_local_volume_configuration","✔️  ✨PASSED: local storage configuration volumes not found #{passed_emoji}")
+      upsert_passed_task("no_local_volume_configuration","✔️  ✨PASSED: local storage configuration volumes not found #{passed_emoji}", Time.utc)
     end
   end
 end


### PR DESCRIPTION
## Issues
Refs: #1807

## Description

When `TASK_TIMESTAMPS` env var is set when running any tests, the following fields are added to every test in the results file:

* `start_time` - Timestamp in UTC when the task was started
* `end_time` - Timestamp in UTC when the task was completed (ended)
* `task_runtime_milliseconds` - Time required for this task to run in milliseconds.

### Screenshot of results file when `TASK_TIMESTAMPS` env is set

```
TASK_TIMESTAMPS=true ./cnf-testsuite cert
```

<img width="565" alt="CleanShot 2023-07-28 at 11 11 56@2x" src="https://github.com/cncf/cnf-testsuite/assets/84005/104f7098-a732-4577-b0cf-75e5283b9088">


## How has this been tested:
 - [x] Covered by existing integration testing
 - [ ] Added integration testing to cover
 - [ ] Verified all A/C passes
     * [ ] develop
     * [ ] master
     * [ ] tag/other branch
 - [ ] Test environment
    * [ ] Shared Packet K8s cluster
    * [ ] New Packet K8s cluster
    * [ ] Kind cluster
 - [ ] Have not tested

## Types of changes:
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [x] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [ ] Documentation update

## Checklist:
**Documentation**
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] No updates required.

**Code Review**
- [ ] Does the test handle fatal exceptions, ie. rescue block

**Issue**
- [ ] Tasks in issue are checked off
