### PR TITLE
[1809] Fix kind install step in GitHub Actions workflow

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -113,9 +113,8 @@ jobs:
         KIND_VERSION: v0.17.0
         KIND_URL: https://kind.sigs.k8s.io/dl
       run: |
-        kind --version
-        which kind
-        sudo rm $(which kind)
+        echo "Existing kind binary path: $(which kind)"
+        if [[ -s $(which kind) ]]; then sudo rm $(which kind); fi
         wget -O kind "$KIND_URL/$KIND_VERSION/kind-linux-amd64" --progress=dot:giga; 
         chmod +x ./kind
         sudo mv ./kind /usr/local/bin/kind
@@ -222,9 +221,8 @@ jobs:
         KIND_VERSION: v0.17.0
         KIND_URL: https://kind.sigs.k8s.io/dl
       run: |
-        kind --version
-        which kind
-        sudo rm $(which kind)
+        echo "Existing kind binary path: $(which kind)"
+        if [[ -s $(which kind) ]]; then sudo rm $(which kind); fi
         wget -O kind "$KIND_URL/$KIND_VERSION/kind-linux-amd64" --progress=dot:giga; 
         chmod +x ./kind
         sudo mv ./kind /usr/local/bin/kind
@@ -794,9 +792,8 @@ jobs:
         KIND_VERSION: v0.17.0
         KIND_URL: https://kind.sigs.k8s.io/dl
       run: |
-        kind --version
-        which kind
-        sudo rm $(which kind)
+        echo "Existing kind binary path: $(which kind)"
+        if [[ -s $(which kind) ]]; then sudo rm $(which kind); fi
         wget -O kind "$KIND_URL/$KIND_VERSION/kind-linux-amd64" --progress=dot:giga; 
         chmod +x ./kind
         sudo mv ./kind /usr/local/bin/kind
@@ -875,9 +872,8 @@ jobs:
         KIND_VERSION: v0.17.0
         KIND_URL: https://kind.sigs.k8s.io/dl
       run: |
-        kind --version
-        which kind
-        sudo rm $(which kind)
+        echo "Existing kind binary path: $(which kind)"
+        if [[ -s $(which kind) ]]; then sudo rm $(which kind); fi
         wget -O kind "$KIND_URL/$KIND_VERSION/kind-linux-amd64" --progress=dot:giga; 
         chmod +x ./kind
         sudo mv ./kind /usr/local/bin/kind
@@ -946,9 +942,8 @@ jobs:
         KIND_VERSION: v0.17.0
         KIND_URL: https://kind.sigs.k8s.io/dl
       run: |
-        kind --version
-        which kind
-        sudo rm $(which kind)
+        echo "Existing kind binary path: $(which kind)"
+        if [[ -s $(which kind) ]]; then sudo rm $(which kind); fi
         wget -O kind "$KIND_URL/$KIND_VERSION/kind-linux-amd64" --progress=dot:giga; 
         chmod +x ./kind
         sudo mv ./kind /usr/local/bin/kind


### PR DESCRIPTION
## Description
This update only attempts to delete kind binary if kind exists.

## Issues:
Refs: #1809

## How has this been tested:
 - [x] Covered by existing integration testing
 - [ ] Added integration testing to cover
 - [ ] Verified all A/C passes
     * [ ] develop
     * [ ] master
     * [ ] tag/other branch
 - [ ] Test environment
    * [ ] Shared Packet K8s cluster
    * [ ] New Packet K8s cluster
    * [ ] Kind cluster
 - [ ] Have not tested

## Types of changes:
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [ ] Documentation update

## Checklist:
**Documentation**
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] No updates required.

**Code Review**
- [ ] Does the test handle fatal exceptions, ie. rescue block

**Issue**
- [ ] Tasks in issue are checked off
