### PR TITLE
[1822] Update kubectl_client to 1.0.2 to support kubectl v1.28

### DIFF
--- a/shard.lock
+++ b/shard.lock
@@ -54,7 +54,7 @@ shards:
 
   kubectl_client:
     git: https://github.com/cnf-testsuite/kubectl_client.git
-    version: 1.0.1
+    version: 1.0.2
 
   popcorn:
     git: https://github.com/icyleaf/popcorn.git

--- a/shard.yml
+++ b/shard.yml
@@ -49,7 +49,7 @@ dependencies:
     version: ~> 1.0.0
   kubectl_client:
     github: cnf-testsuite/kubectl_client
-    version: ~> 1.0.1
+    version: ~> 1.0.2
   cluster_tools:
     github: cnf-testsuite/cluster_tools
     version: ~> 1.0.0


### PR DESCRIPTION
## Issues: #1822

## Description
* Added support for kubectl v1.28 in kubectl_client 1.0.2
* Updated the shard.yml in the project to point to kubectl_client 1.0.2

## How has this been tested:
 - [x] Covered by existing integration testing
 - [ ] Added integration testing to cover
 - [ ] Verified all A/C passes
     * [ ] develop
     * [ ] master
     * [ ] tag/other branch
 - [ ] Test environment
    * [ ] Shared Packet K8s cluster
    * [ ] New Packet K8s cluster
    * [ ] Kind cluster
 - [ ] Have not tested

## Types of changes:
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [x] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [ ] Documentation update

## Checklist:
**Documentation**
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] No updates required.

**Code Review**
- [ ] Does the test handle fatal exceptions, ie. rescue block

**Issue**
- [x] Tasks in issue are checked off
