### PR TITLE
[1798] Remove shard.override.yml for kubectl_client

### DIFF
--- a/shard.override.yml
+++ b/shard.override.yml
@@ -1,5 +1,0 @@
-dependencies:
-  kubectl_client:
-    github: 'cnf-testsuite/kubectl_client'
-    branch: 'kubectl-detection'
-


### PR DESCRIPTION
## Issues: #1798

## Description
This PR removes the shard.override.yml that was created to override kubectl_client to a branch with fixes.

## How has this been tested:
 - [x] Covered by existing integration testing
 - [ ] Added integration testing to cover
 - [ ] Verified all A/C passes
     * [ ] develop
     * [ ] master
     * [ ] tag/other branch
 - [ ] Test environment
    * [ ] Shared Packet K8s cluster
    * [ ] New Packet K8s cluster
    * [ ] Kind cluster
 - [ ] Have not tested

## Types of changes:
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [ ] Documentation update

## Checklist:
**Documentation**
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] No updates required.

**Code Review**
- [ ] Does the test handle fatal exceptions, ie. rescue block

**Issue**
- [x] Tasks in issue are checked off
