### PR TITLE
[bug/1834] Uncordon node after running `node_drain` test for a CNF

### DIFF
--- a/sample-cnfs/sample-coredns-cnf2/README.md
+++ b/sample-cnfs/sample-coredns-cnf2/README.md
@@ -1,0 +1,39 @@
+# Set up Sample CoreDNS CNF
+./sample-cnfs/sample-coredns-cnf/readme.md
+# Prerequistes
+### Install helm
+```
+curl -fsSL -o get_helm.sh https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3
+chmod 700 get_helm.sh
+./get_helm.sh
+```
+### Optional: Use a helm version manager
+https://github.com/yuya-takeyama/helmenv
+Check out helmenv into any path (here is ${HOME}/.helmenv)
+```
+${HOME}/.helmenv)
+$ git clone https://github.com/yuya-takeyama/helmenv.git ~/.helmenv
+```
+Add ~/.helmenv/bin to your $PATH any way you like
+```
+$ echo 'export PATH="$HOME/.helmenv/bin:$PATH"' >> ~/.bash_profile
+```
+```
+helmenv versions 
+helmenv install <version 3.1?>
+```
+
+### core-dns installation
+```
+helm install coredns stable/coredns
+```
+### Pull down the helm chart code, untar it, and put it in the cnfs/coredns directory
+```
+helm pull stable/coredns
+```
+### Example cnf-testsuite config file for sample-core-dns-cnf
+In ./cnfs/sample-core-dns-cnf/cnf-testsuite.yml
+```
+---
+container_names: [coredns-coredns] 
+```

--- a/sample-cnfs/sample-coredns-cnf2/cnf-testsuite.yml
+++ b/sample-cnfs/sample-coredns-cnf2/cnf-testsuite.yml
@@ -1,0 +1,9 @@
+---
+release_name: coredns2
+service_name: coredns-coredns 
+helm_repository:
+  name: stable 
+  repo_url: https://cncf.gitlab.io/stable
+helm_chart: stable/coredns
+helm_install_namespace: cnfspace2
+allowlist_helm_chart_container_names: [falco, node-cache, nginx, coredns, calico-node, kube-proxy, nginx-proxy]

--- a/shard.lock
+++ b/shard.lock
@@ -1,3 +1,4 @@
+# NOTICE: This lockfile contains some overrides from shard.override.yml
 version: 2.0
 shards:
   airgap:
@@ -52,9 +53,9 @@ shards:
     git: https://github.com/cnf-testsuite/kernel_introspection.git
     version: 0.1.0
 
-  kubectl_client:
+  kubectl_client: # Overridden
     git: https://github.com/cnf-testsuite/kubectl_client.git
-    version: 1.0.3
+    version: 1.0.4+git.commit.aa28eec2d33a11bf1185e75155eb9b34afa08fe8
 
   popcorn:
     git: https://github.com/icyleaf/popcorn.git

--- a/shard.lock
+++ b/shard.lock
@@ -1,4 +1,3 @@
-# NOTICE: This lockfile contains some overrides from shard.override.yml
 version: 2.0
 shards:
   airgap:
@@ -53,9 +52,9 @@ shards:
     git: https://github.com/cnf-testsuite/kernel_introspection.git
     version: 0.1.0
 
-  kubectl_client: # Overridden
+  kubectl_client:
     git: https://github.com/cnf-testsuite/kubectl_client.git
-    version: 1.0.4+git.commit.aa28eec2d33a11bf1185e75155eb9b34afa08fe8
+    version: 1.0.4
 
   popcorn:
     git: https://github.com/icyleaf/popcorn.git

--- a/shard.override.yml
+++ b/shard.override.yml
@@ -1,4 +1,0 @@
-dependencies:
-  kubectl_client:
-    github: cnf-testsuite/kubectl_client
-    branch: "bug/1834"

--- a/shard.override.yml
+++ b/shard.override.yml
@@ -1,0 +1,4 @@
+dependencies:
+  kubectl_client:
+    github: cnf-testsuite/kubectl_client
+    branch: "bug/1834"

--- a/shard.yml
+++ b/shard.yml
@@ -49,7 +49,7 @@ dependencies:
     version: ~> 1.0.0
   kubectl_client:
     github: cnf-testsuite/kubectl_client
-    version: ~> 1.0.3
+    version: ~> 1.0.4
   cluster_tools:
     github: cnf-testsuite/cluster_tools
     version: ~> 1.0.0

--- a/src/tasks/litmus_setup.cr
+++ b/src/tasks/litmus_setup.cr
@@ -76,15 +76,12 @@ module LitmusManager
     File.write(MODIFIED_LITMUS_FILE, output_file) unless output_file == nil
   end
 
-  def self.cordon_target_node(deployment_label, deployment_value, namespace)
+  def self.get_target_node_to_cordon(deployment_label, deployment_value, namespace)
     app_nodeName_cmd = "kubectl get pods -l #{deployment_label}=#{deployment_value} -n #{namespace} -o=jsonpath='{.items[0].spec.nodeName}'"
     Log.info { "Getting the operator node name: #{app_nodeName_cmd}" }
     status_code = Process.run("#{app_nodeName_cmd}", shell: true, output: appNodeName_response = IO::Memory.new, error: stderr = IO::Memory.new).exit_status
     Log.for("verbose").info { "status_code: #{status_code}" } 
-    app_nodeName = appNodeName_response.to_s 
-    status_code = KubectlClient::Cordon.command("#{app_nodeName}")
-    Log.for("verbose").info { "status_code: #{status_code}" }
-    Log.info { "The target node has been cordoned sucessfully" }
+    appNodeName_response.to_s
   end
 
   ## wait_for_test will wait for the completion of litmus test

--- a/src/tasks/workload/state.cr
+++ b/src/tasks/workload/state.cr
@@ -347,17 +347,17 @@ task "node_drain", ["install_litmus"] do |t, args|
           LitmusManager.wait_for_test(test_name,chaos_experiment_name,total_chaos_duration,args, namespace: app_namespace)
           test_passed = LitmusManager.check_chaos_verdict(chaos_result_name,chaos_experiment_name,args, namespace: app_namespace)
         end
-      end
 
-      # Uncordon the node.
-      result = KubectlClient::Uncordon.command("#{cordon_target_node_name}")
+        # Uncordon the node.
+        result = KubectlClient::Uncordon.command("#{cordon_target_node_name}")
 
-      # If uncordoning fails, log the error.
-      if result[:status].success?
-        Log.info { "Uncordoned node #{cordon_target_node_name} successfully." }
-      else
-        Log.error { "Uncordoning node #{cordon_target_node_name} failed." }
-        skipped = true
+        # If uncordoning fails, log the error.
+        if result[:status].success?
+          Log.info { "Uncordoned node #{cordon_target_node_name} successfully." }
+        else
+          Log.error { "Uncordoning node #{cordon_target_node_name} failed." }
+          skipped = true
+        end
       end
 
       test_passed


### PR DESCRIPTION
## Issues: #1834

## Description
* Uncordon node after running `node_drain` for an app.
* Update `kubectl_client` to `1.0.4`.
* Added sample coredns CNF with different release name and namespace to help with testing the changes.

## Testing

### Create a 3-node cluster using the below kind config

```yaml
kind: Cluster
apiVersion: kind.x-k8s.io/v1alpha4
nodes:
- role: control-plane
- role: worker
- role: worker
containerdConfigPatches:
- |-
  [plugins."io.containerd.grpc.v1.cri".registry.mirrors."docker.io"]
    endpoint = ["http://139.178.70.81:80"]
  [plugins."io.containerd.grpc.v1.cri".registry.mirrors."registry:5000"]
    endpoint = ["http://localhost:5000"]
  [plugins."io.containerd.grpc.v1.cri".registry.mirrors."registry.default.svc.cluster.local:5000"]
    endpoint = ["http://localhost:5000"]
```

### Setup CNF and run tests

```shell
# Create kind cluster
export KIND_CLUSTER_NAME="1834-3node"
export KUBECONFIG="${PWD}/${KIND_CLUSTER_NAME}.kubeconfig"
kind create cluster --name $KIND_CLUSTER_NAME \
--kubeconfig $KUBECONFIG \
--config kind-3node.yml

# Setup cluster for testsuite
./cnf-testsuite setup

# Check kind cluster nodes
kubectl get nodes

# Setup two CNFs
./cnf-testsuite cnf_setup cnf-path=sample-cnfs/sample-coredns-cnf
./cnf-testsuite cnf_setup cnf-path=sample-cnfs/sample-coredns-cnf2

# Run node drain test
./cnf-testsuite node_drain

# Check kind nodes again to ensure all nodes are scheduleable.
# No nodes should be cordoned.
kubectl get nodes
```

![image](https://github.com/cncf/cnf-testsuite/assets/84005/5dc3ed6e-f44e-4c3c-80ee-6414e286214e)


## How has this been tested:
 - [x] Covered by existing integration testing
 - [ ] Added integration testing to cover
 - [ ] Verified all A/C passes
     * [ ] develop
     * [ ] master
     * [ ] tag/other branch
 - [ ] Test environment
    * [ ] Shared Packet K8s cluster
    * [ ] New Packet K8s cluster
    * [ ] Kind cluster
 - [ ] Have not tested

## Types of changes:
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [ ] Documentation update

## Checklist:
**Documentation**
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] No updates required.

**Code Review**
- [ ] Does the test handle fatal exceptions, ie. rescue block

**Issue**
- [ ] Tasks in issue are checked off
