### PR TITLE
[bug/1311] Do not create results file if not running any test

### DIFF
--- a/spec/utils/cnf_manager_spec.cr
+++ b/spec/utils/cnf_manager_spec.cr
@@ -12,6 +12,9 @@ describe "SampleUtils" do
     $?.success?.should be_true
     `./cnf-testsuite cleanup`
     $?.success?.should be_true
+
+    # Ensure a results file is present to test different scenarios
+    CNFManager::Points::Results.ensure_results_file!
   end
 
    # after_all do
@@ -494,6 +497,3 @@ describe "SampleUtils" do
   end
 
 end
-
-
-

--- a/spec/utils/utils_spec.cr
+++ b/spec/utils/utils_spec.cr
@@ -256,11 +256,16 @@ describe "Utils" do
   end
 
   it "'logger' or verbose output should be shown when verbose flag is set", tags: ["logger"] do
-    response_s = `./cnf-testsuite -l info helm_deploy verbose`
-    LOGGING.info response_s
-    puts response_s
-    $?.success?.should be_true
-    (/helm_deploy args/ =~ response_s).should_not be_nil
+    begin
+      `./cnf-testsuite cnf_setup cnf-path=sample-cnfs/sample-coredns-cnf`
+      response_s = `./cnf-testsuite -l info helm_deploy verbose`
+      Log.info { response_s }
+      puts response_s
+      $?.success?.should be_true
+      (/helm_deploy args/ =~ response_s).should_not be_nil
+    ensure
+      CNFManager.sample_cleanup(config_file: "sample-cnfs/sample-coredns-cnf", verbose: true)
+    end
   end
 
   it "'#update_yml' should update the value for a key in a yml file", tags: ["logger"]  do

--- a/spec/utils/utils_spec.cr
+++ b/spec/utils/utils_spec.cr
@@ -256,16 +256,14 @@ describe "Utils" do
   end
 
   it "'logger' or verbose output should be shown when verbose flag is set", tags: ["logger"] do
-    begin
-      `./cnf-testsuite cnf_setup cnf-path=sample-cnfs/sample-coredns-cnf`
-      response_s = `./cnf-testsuite -l info helm_deploy verbose`
-      Log.info { response_s }
-      puts response_s
-      $?.success?.should be_true
-      (/helm_deploy args/ =~ response_s).should_not be_nil
-    ensure
-      CNFManager.sample_cleanup(config_file: "sample-cnfs/sample-coredns-cnf", verbose: true)
-    end
+    `./cnf-testsuite cnf_setup cnf-path=sample-cnfs/sample-coredns-cnf`
+    response_s = `./cnf-testsuite -l info helm_deploy verbose`
+    Log.info { response_s }
+    puts response_s
+    $?.success?.should be_true
+    (/helm_deploy args/ =~ response_s).should_not be_nil
+  ensure
+    CNFManager.sample_cleanup(config_file: "sample-cnfs/sample-coredns-cnf", verbose: true)
   end
 
   it "'#update_yml' should update the value for a key in a yml file", tags: ["logger"]  do

--- a/spec/utils/utils_spec.cr
+++ b/spec/utils/utils_spec.cr
@@ -10,6 +10,9 @@ describe "Utils" do
   before_all do
     `./cnf-testsuite setup`
     $?.success?.should be_true
+
+    # Ensure a results file is present to test different scenarios
+    CNFManager::Points::Results.ensure_results_file!
   end
 
   before_each do
@@ -284,4 +287,3 @@ describe "Utils" do
   end
 
 end
-

--- a/src/cnf-testsuite.cr
+++ b/src/cnf-testsuite.cr
@@ -130,15 +130,18 @@ begin
   puts `#{PROGRAM_NAME} help` if ARGV.empty?
   # See issue #426 for exit code requirement
   Sam.process_tasks(ARGV.clone)
-  yaml = File.open("#{CNFManager::Points::Results.file}") do |file|
-    YAML.parse(file)
-  end
-  Log.info { "results yaml: #{yaml}" }
-  case (yaml["exit_code"])
-  when 1
-    exit 1
-  when 2
-    exit 2
+
+  if File.exists?("#{CNFManager::Points::Results.file}")
+    yaml = File.open("#{CNFManager::Points::Results.file}") do |file|
+      YAML.parse(file)
+    end
+    Log.info { "results yaml: #{yaml}" }
+    case (yaml["exit_code"])
+    when 1
+      exit 1
+    when 2
+      exit 2
+    end
   end
 rescue e : Sam::NotFound
   puts e.message

--- a/src/tasks/utils/points.cr
+++ b/src/tasks/utils/points.cr
@@ -371,6 +371,10 @@ module CNFManager
 
 
     def self.upsert_task(task, status, points, start_time)
+      # In certain cases the results file might not exist.
+      # So create one.
+      CNFManager::Points::Results.ensure_results_file!
+
       results = File.open("#{Results.file}") do |f|
         YAML.parse(f)
       end

--- a/src/tasks/utils/points.cr
+++ b/src/tasks/utils/points.cr
@@ -21,30 +21,18 @@ module CNFManager
 
       @@file : String
       @@file = CNFManager::Points.create_final_results_yml_name
-      Log.debug { "Results.file" }
-      continue = false
-      # LOGGING.info "file exists?:#{File.exists?(@@file)}"
-      if File.exists?("#{@@file}")
-        stdout_info "Do you wish to overwrite the #{@@file} file? If so, your previous results.yml will be lost."
-        print "(Y/N) (Default N): > "
-        if ENV["CRYSTAL_ENV"]? == "TEST"
-          continue = true
-        else
-          user_input = gets
-          if user_input == "Y" || user_input == "y"
-            continue = true
-          end
-        end
-      else
-        continue = true
-      end
-      if continue
-        File.open("#{@@file}", "w") do |f|
-          YAML.dump(CNFManager::Points.template_results_yml, f)
-        end
-      end
+      Log.debug { "Results.file: #{Results.file}" }
+
       def self.file
         @@file
+      end
+
+      def self.ensure_results_file!
+        return true if File.exists?("#{file}")
+
+        File.open("#{file}", "w") do |f|
+          YAML.dump(CNFManager::Points.template_results_yml, f)
+        end
       end
     end
 

--- a/src/tasks/utils/task.cr
+++ b/src/tasks/utils/task.cr
@@ -26,6 +26,8 @@ module CNFManager
     def self.task_runner(args, check_cnf_installed=true, &block : Sam::Args, CNFManager::Config -> String | Colorize::Object(String) | Nil)
       LOGGING.info("task_runner args: #{args.inspect}")
 
+      CNFManager::Points::Results.ensure_results_file!
+
       if check_cnf_installed
         ensure_cnf_installed!
       end


### PR DESCRIPTION
## Issues: #1311, #1310

## Description

* Running commands like `setup` or `version` that is not a test or group of tests will not create any results files.
* Fixed some tests that were supposed to be failing before but were still passing.

## How has this been tested:
 - [x] Covered by existing integration testing
 - [ ] Added integration testing to cover
 - [ ] Verified all A/C passes
     * [ ] develop
     * [ ] master
     * [ ] tag/other branch
 - [ ] Test environment
    * [ ] Shared Packet K8s cluster
    * [ ] New Packet K8s cluster
    * [ ] Kind cluster
 - [ ] Have not tested

## Types of changes:
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [ ] Documentation update

## Checklist:
**Documentation**
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] No updates required.

**Code Review**
- [ ] Does the test handle fatal exceptions, ie. rescue block

**Issue**
- [ ] Tasks in issue are checked off
