### PR TITLE
[maintain/1841] Add log lines and organize log messages in tests

### DIFF
--- a/src/tasks/platform/hardware_and_scheduling.cr
+++ b/src/tasks/platform/hardware_and_scheduling.cr
@@ -15,6 +15,10 @@ namespace "platform" do
   desc "Does the Platform use a runtime that is oci compliant"
   task "oci_compliant" do |_, args|
     task_response = CNFManager::Task.task_runner(args, check_cnf_installed=false) do |args|
+      task_start_time = Time.utc
+      testsuite_task = "oci_compliant"
+      Log.for(testsuite_task).info { "Starting test" }
+
       resp = KubectlClient::Get.container_runtimes
       all_oci_runtimes = true
       resp.each do |x|
@@ -25,10 +29,10 @@ namespace "platform" do
       LOGGING.info "all_oci_runtimes: #{all_oci_runtimes}"
       if all_oci_runtimes 
         emoji_chaos_oci_compliant="📶☠️"
-        upsert_passed_task("oci_compliant","✔️  PASSED: Your platform is using the following runtimes: [#{KubectlClient::Get.container_runtimes.join(",")}] which are OCI compliant runtimes #{emoji_chaos_oci_compliant}", Time.utc)
+        upsert_passed_task(testsuite_task,"✔️  PASSED: Your platform is using the following runtimes: [#{KubectlClient::Get.container_runtimes.join(",")}] which are OCI compliant runtimes #{emoji_chaos_oci_compliant}", task_start_time)
       else
         emoji_chaos_oci_compliant="📶☠️"
-        upsert_failed_task("oci_compliant", "✖️  FAILED: Platform has at least one node that uses a non OCI compliant runtime #{emoji_chaos_oci_compliant}", Time.utc)
+        upsert_failed_task(testsuite_task, "✖️  FAILED: Platform has at least one node that uses a non OCI compliant runtime #{emoji_chaos_oci_compliant}", task_start_time)
       end
     end
   end

--- a/src/tasks/platform/observability.cr
+++ b/src/tasks/platform/observability.cr
@@ -16,6 +16,10 @@ namespace "platform" do
 
   desc "Does the Platform have Kube State Metrics installed"
   task "kube_state_metrics", ["install_cluster_tools"] do |_, args|
+    task_start_time = Time.utc
+    testsuite_task = "kube_state_metrics"
+    Log.for(testsuite_task).info { "Starting test" }
+
     unless check_poc(args)
       Log.info { "skipping kube_state_metrics: not in poc mode" }
       puts "SKIPPED: Kube State Metrics".colorize(:yellow)
@@ -32,15 +36,19 @@ namespace "platform" do
 
     if found
       emoji_kube_state_metrics="📶☠️"
-      upsert_passed_task("kube_state_metrics","✔️  PASSED: Your platform is using the release for kube state metrics #{emoji_kube_state_metrics}", Time.utc)
+      upsert_passed_task(testsuite_task,"✔️  PASSED: Your platform is using the release for kube state metrics #{emoji_kube_state_metrics}", task_start_time)
     else
       emoji_kube_state_metrics="📶☠️"
-      upsert_failed_task("kube_state_metrics", "✖️  FAILED: Your platform does not have kube state metrics installed #{emoji_kube_state_metrics}", Time.utc)
+      upsert_failed_task(testsuite_task, "✖️  FAILED: Your platform does not have kube state metrics installed #{emoji_kube_state_metrics}", task_start_time)
     end
   end
 
   desc "Does the Platform have a Node Exporter installed"
   task "node_exporter", ["install_cluster_tools"] do |_, args|
+    task_start_time = Time.utc
+    testsuite_task = "node_exporter"
+    Log.for(testsuite_task).info { "Starting test" }
+
     unless check_poc(args)
       Log.info { "skipping node_exporter: not in poc mode" }
       puts "SKIPPED: Node Exporter".colorize(:yellow)
@@ -57,16 +65,20 @@ namespace "platform" do
     Log.info { "Found Process: #{found}" }
     if found
       emoji_node_exporter="📶☠️"
-      upsert_passed_task("node_exporter","✔️  PASSED: Your platform is using the node exporter #{emoji_node_exporter}", Time.utc)
+      upsert_passed_task(testsuite_task,"✔️  PASSED: Your platform is using the node exporter #{emoji_node_exporter}", task_start_time)
     else
       emoji_node_exporter="📶☠️"
-      upsert_failed_task("node_exporter", "✖️  FAILED: Your platform does not have the node exporter installed #{emoji_node_exporter}", Time.utc)
+      upsert_failed_task(testsuite_task, "✖️  FAILED: Your platform does not have the node exporter installed #{emoji_node_exporter}", task_start_time)
     end
   end
 
 
   desc "Does the Platform have the prometheus adapter installed"
   task "prometheus_adapter", ["install_cluster_tools"] do |_, args|
+    task_start_time = Time.utc
+    testsuite_task = "prometheus_adapter"
+    Log.for(testsuite_task).info { "Starting test" }
+
     unless check_poc(args)
       Log.info { "skipping prometheus_adapter: not in poc mode" }
       puts "SKIPPED: Prometheus Adapter".colorize(:yellow)
@@ -83,15 +95,19 @@ namespace "platform" do
 
     if found
       emoji_prometheus_adapter="📶☠️"
-      upsert_passed_task("prometheus_adapter","✔️  PASSED: Your platform is using the prometheus adapter #{emoji_prometheus_adapter}", Time.utc)
+      upsert_passed_task(testsuite_task,"✔️  PASSED: Your platform is using the prometheus adapter #{emoji_prometheus_adapter}", task_start_time)
     else
       emoji_prometheus_adapter="📶☠️"
-      upsert_failed_task("prometheus_adapter", "✖️  FAILED: Your platform does not have the prometheus adapter installed #{emoji_prometheus_adapter}", Time.utc)
+      upsert_failed_task(testsuite_task, "✖️  FAILED: Your platform does not have the prometheus adapter installed #{emoji_prometheus_adapter}", task_start_time)
     end
   end
 
   desc "Does the Platform have the K8s Metrics Server installed"
   task "metrics_server", ["install_cluster_tools"] do |_, args|
+    task_start_time = Time.utc
+    testsuite_task = "metrics_server"
+    Log.for(testsuite_task).info { "Starting test" }
+
     unless check_poc(args)
       Log.info { "skipping metrics_server: not in poc mode" }
       puts "SKIPPED: Metrics Server".colorize(:yellow)
@@ -108,10 +124,10 @@ namespace "platform" do
       found = KernelIntrospection::K8s.find_first_process(CloudNativeIntrospection::METRICS_SERVER)
       if found
         emoji_metrics_server="📶☠️"
-        upsert_passed_task("metrics_server","✔️  PASSED: Your platform is using the metrics server #{emoji_metrics_server}", Time.utc)
+        upsert_passed_task(testsuite_task, "✔️  PASSED: Your platform is using the metrics server #{emoji_metrics_server}", task_start_time)
       else
         emoji_metrics_server="📶☠️"
-        upsert_failed_task("metrics_server", "✖️  FAILED: Your platform does not have the metrics server installed #{emoji_metrics_server}", Time.utc)
+        upsert_failed_task(testsuite_task, "✖️  FAILED: Your platform does not have the metrics server installed #{emoji_metrics_server}", task_start_time)
       end
     end
   end

--- a/src/tasks/platform/security.cr
+++ b/src/tasks/platform/security.cr
@@ -85,7 +85,10 @@ namespace "platform" do
   desc "Check if the CNF is running containers with name tiller in their image name?"
   task "helm_tiller" do |_, args|
     emoji_security="🔓🔑"
-    Log.for("verbose").info { "platform:helm_tiller" }
+    task_start_time = Time.utc
+    testsuite_task = "helm_tiller"
+    Log.for(testsuite_task).info { "Starting test" }
+
     Kyverno.install
 
     CNFManager::Task.task_runner(args, check_cnf_installed=false) do |args, config|
@@ -93,9 +96,9 @@ namespace "platform" do
       failures = Kyverno::PolicyAudit.run(policy_path, EXCLUDE_NAMESPACES)
 
       if failures.size == 0
-        resp = upsert_passed_task("helm_tiller", "✔️  PASSED: No Helm Tiller containers are running #{emoji_security}", Time.utc)
+        resp = upsert_passed_task(testsuite_task, "✔️  PASSED: No Helm Tiller containers are running #{emoji_security}", task_start_time)
       else
-        resp = upsert_failed_task("helm_tiller", "✖️  FAILED: Containers with the Helm Tiller image are running #{emoji_security}", Time.utc)
+        resp = upsert_failed_task(testsuite_task, "✖️  FAILED: Containers with the Helm Tiller image are running #{emoji_security}", task_start_time)
         failures.each do |failure|
           failure.resources.each do |resource|
             puts "#{resource.kind} #{resource.name} in #{resource.namespace} namespace failed. #{failure.message}".colorize(:red)

--- a/src/tasks/platform/security.cr
+++ b/src/tasks/platform/security.cr
@@ -13,16 +13,19 @@ namespace "platform" do
   desc "Is the platform control plane hardened"
   task "control_plane_hardening", ["kubescape_scan"] do |_, args|
     task_response = CNFManager::Task.task_runner(args, check_cnf_installed=false) do |args|
-      VERBOSE_LOGGING.info "control_plane_hardening" if check_verbose(args)
+      task_start_time = Time.utc
+      testsuite_task = "control_plane_hardening"
+      Log.for(testsuite_task).info { "Starting test" }
+
       results_json = Kubescape.parse
       test_json = Kubescape.test_by_test_name(results_json, "Control plane hardening")
       test_report = Kubescape.parse_test_report(test_json)
 
       emoji_security="🔓🔑"
       if test_report.failed_resources.size == 0
-        upsert_passed_task("control_plane_hardening", "✔️  PASSED: Control plane hardened #{emoji_security}", Time.utc)
+        upsert_passed_task(testsuite_task, "✔️  PASSED: Control plane hardened #{emoji_security}", task_start_time)
       else
-        resp = upsert_failed_task("control_plane_hardening", "✖️  FAILED: Control plane not hardened #{emoji_security}", Time.utc)
+        resp = upsert_failed_task(testsuite_task, "✖️  FAILED: Control plane not hardened #{emoji_security}", task_start_time)
         test_report.failed_resources.map {|r| stdout_failure(r.alert_message) }
         stdout_failure("Remediation: #{test_report.remediation}")
         resp
@@ -34,16 +37,19 @@ namespace "platform" do
   task "cluster_admin", ["kubescape_scan"] do |_, args|
     next if args.named["offline"]?
     CNFManager::Task.task_runner(args, check_cnf_installed=false) do |args, config|
-      VERBOSE_LOGGING.info "cluster_admin" if check_verbose(args)
+      task_start_time = Time.utc
+      testsuite_task = "cluster_admin"
+      Log.for(testsuite_task).info { "Starting test" }
+
       results_json = Kubescape.parse
       test_json = Kubescape.test_by_test_name(results_json, "Cluster-admin binding")
       test_report = Kubescape.parse_test_report(test_json)
 
       emoji_security="🔓🔑"
       if test_report.failed_resources.size == 0
-        upsert_passed_task("cluster_admin", "✔️  PASSED: No users with cluster admin role found #{emoji_security}", Time.utc)
+        upsert_passed_task(testsuite_task, "✔️  PASSED: No users with cluster admin role found #{emoji_security}", task_start_time)
       else
-        resp = upsert_failed_task("cluster_admin", "✖️  FAILED: Users with cluster admin role found #{emoji_security}", Time.utc)
+        resp = upsert_failed_task(testsuite_task, "✖️  FAILED: Users with cluster admin role found #{emoji_security}", task_start_time)
         test_report.failed_resources.map {|r| stdout_failure(r.alert_message) }
         stdout_failure("Remediation: #{test_report.remediation}")
         resp
@@ -56,16 +62,19 @@ namespace "platform" do
     next if args.named["offline"]?
 
     CNFManager::Task.task_runner(args, check_cnf_installed=false) do |args, config|
-      Log.for("verbose").info { "exposed_dashboard" } if check_verbose(args)
+      task_start_time = Time.utc
+      testsuite_task = "exposed_dashboard"
+      Log.for(testsuite_task).info { "Starting test" }
+
       results_json = Kubescape.parse
       test_json = Kubescape.test_by_test_name(results_json, "Exposed dashboard")
       test_report = Kubescape.parse_test_report(test_json)
 
       emoji_security = "🔓🔑"
       if test_report.failed_resources.size == 0
-        upsert_passed_task("exposed_dashboard", "✔️  PASSED: No exposed dashboard found in the cluster #{emoji_security}", Time.utc)
+        upsert_passed_task(testsuite_task, "✔️  PASSED: No exposed dashboard found in the cluster #{emoji_security}", task_start_time)
       else
-        resp = upsert_failed_task("exposed_dashboard", "✖️  FAILED: Found exposed dashboard in the cluster #{emoji_security}", Time.utc)
+        resp = upsert_failed_task(testsuite_task, "✖️  FAILED: Found exposed dashboard in the cluster #{emoji_security}", task_start_time)
         test_report.failed_resources.map {|r| stdout_failure(r.alert_message) }
         stdout_failure("Remediation: #{test_report.remediation}")
         resp

--- a/src/tasks/utils/points.cr
+++ b/src/tasks/utils/points.cr
@@ -389,7 +389,7 @@ module CNFManager
       end_time = Time.utc
       task_runtime = (end_time - start_time).milliseconds
 
-      Log.for(task).info { "task_runtime=#{task_runtime}; start_time=#{start_time}; end_time:#{end_time}" }
+      Log.for("#{task}").info { "task_runtime=#{task_runtime}; start_time=#{start_time}; end_time:#{end_time}" }
 
       # The task result info has to be appeneded to an array of YAML::Any
       # So encode it into YAML and parse it back again to assign it.

--- a/src/tasks/utils/points.cr
+++ b/src/tasks/utils/points.cr
@@ -389,6 +389,8 @@ module CNFManager
       end_time = Time.utc
       task_runtime = (end_time - start_time).milliseconds
 
+      Log.for(task).info { "task_runtime=#{task_runtime}; start_time=#{start_time}; end_time:#{end_time}" }
+
       # The task result info has to be appeneded to an array of YAML::Any
       # So encode it into YAML and parse it back again to assign it.
       #

--- a/src/tasks/workload/compatibility.cr
+++ b/src/tasks/workload/compatibility.cr
@@ -86,9 +86,9 @@ rolling_version_change_test_names.each do |tn|
       end
       VERBOSE_LOGGING.debug "#{tn}: task_response=#{task_response}" if check_verbose(args)
       if task_response
-        resp = upsert_passed_task("#{tn}","✔️  PASSED: CNF for #{pretty_test_name_capitalized} Passed", task_start_time)
+        resp = upsert_passed_task(testsuite_task, "✔️  PASSED: CNF for #{pretty_test_name_capitalized} Passed", task_start_time)
       else
-        resp = upsert_failed_task("#{tn}", "✖️  FAILED: CNF for #{pretty_test_name_capitalized} Failed", task_start_time)
+        resp = upsert_failed_task(testsuite_task, "✖️  FAILED: CNF for #{pretty_test_name_capitalized} Failed", task_start_time)
       end
       resp
       # TODO should we roll the image back to original version in an ensure?

--- a/src/tasks/workload/compatibility.cr
+++ b/src/tasks/workload/compatibility.cr
@@ -426,13 +426,13 @@ end
 
 desc "Will the CNF install using helm with helm_deploy?"
 task "helm_deploy" do |_, args|
+  task_start_time = Time.utc
   testsuite_task = "helm_deploy"
   Log.for(testsuite_task).info { "Running #{testsuite_task}" }
   Log.for(testsuite_task).info { "helm_deploy args: #{args.inspect}" } if check_verbose(args)
 
   if check_cnf_config(args) || CNFManager.destination_cnfs_exist?
     CNFManager::Task.task_runner(args) do |args, config|
-      task_start_time = Time.utc
       Log.for(testsuite_task).info { "Starting test" }
 
       emoji_helm_deploy="⎈🚀"

--- a/src/tasks/workload/configuration.cr
+++ b/src/tasks/workload/configuration.cr
@@ -358,7 +358,7 @@ task "hardcoded_ip_addresses_in_k8s_runtime_configuration" do |_, args|
       upsert_failed_task(testsuite_task, "✖️  🏆 FAILED: Hard-coded IP addresses found in the runtime K8s configuration", task_start_time)
     end
   rescue
-    upsert_skipped_task(testsuite_task, "⏭️  🏆 SKIPPED: unknown exception", task_start_time)
+    upsert_skipped_task(testsuite_task, "⏭️  🏆 SKIPPED: unknown exception", Time.utc)
   ensure
     KubectlClient::Delete.command("namespace hardcoded-ip-test --force --grace-period 0")
   end
@@ -595,7 +595,7 @@ task "immutable_configmap" do |_, args|
     # now we change then apply again
 
     template = ImmutableConfigMapTemplate.new("doesnt_matter_again").to_s
-    Log.for(testsuite_task)debug { "test immutable_configmap change template: #{template}" }
+    Log.for(testsuite_task).debug { "test immutable_configmap change template: #{template}" }
     File.write(test_config_map_filename, template)
 
     immutable_configmap_supported = true

--- a/src/tasks/workload/configuration.cr
+++ b/src/tasks/workload/configuration.cr
@@ -34,7 +34,10 @@ end
 desc "Check if the CNF is running containers with labels configured?"
 task "require_labels" do |_, args|
   CNFManager::Task.task_runner(args) do |args, config|
-    Log.for("verbose").info { "require-labels" }
+    task_start_time = Time.utc
+    testsuite_task = "require_labels"
+    Log.for(testsuite_task).info { "Starting test" }
+
     Kyverno.install
     emoji_passed = "🏷️✔️"
     emoji_failed = "🏷️❌"
@@ -45,9 +48,9 @@ task "require_labels" do |_, args|
     failures = Kyverno.filter_failures_for_cnf_resources(resource_keys, failures)
 
     if failures.size == 0
-      resp = upsert_passed_task("require_labels", "✔️  PASSED: Pods have the app.kubernetes.io/name label #{emoji_passed}", Time.utc)
+      resp = upsert_passed_task(testsuite_task, "✔️  PASSED: Pods have the app.kubernetes.io/name label #{emoji_passed}", task_start_time)
     else
-      resp = upsert_failed_task("require_labels", "✖️  FAILED: Pods should have the app.kubernetes.io/name label. #{emoji_failed}", Time.utc)
+      resp = upsert_failed_task(testsuite_task, "✖️  FAILED: Pods should have the app.kubernetes.io/name label. #{emoji_failed}", task_start_time)
       failures.each do |failure|
         failure.resources.each do |resource|
           puts "#{resource.kind} #{resource.name} in #{resource.namespace} namespace failed. #{failure.message}".colorize(:red)
@@ -60,7 +63,10 @@ end
 desc "Check if the CNF installs resources in the default namespace"
 task "default_namespace" do |_, args|
   CNFManager::Task.task_runner(args) do |args, config|
-    Log.for("verbose").info { "default_namespace" }
+    task_start_time = Time.utc
+    testsuite_task = "default_namespace"
+    Log.for(testsuite_task).info { "Starting test" }
+
     Kyverno.install
     emoji_passed = "🏷️✔️"
     emoji_failed = "🏷️❌"
@@ -71,9 +77,9 @@ task "default_namespace" do |_, args|
     failures = Kyverno.filter_failures_for_cnf_resources(resource_keys, failures)
 
     if failures.size == 0
-      resp = upsert_passed_task("default_namespace", "✔️  PASSED: default namespace is not being used #{emoji_passed}", Time.utc)
+      resp = upsert_passed_task(testsuite_task, "✔️  PASSED: default namespace is not being used #{emoji_passed}", task_start_time)
     else
-      resp = upsert_failed_task("default_namespace", "✖️  FAILED: Resources are created in the default namespace #{emoji_failed}", Time.utc)
+      resp = upsert_failed_task(testsuite_task, "✖️  FAILED: Resources are created in the default namespace #{emoji_failed}", task_start_time)
       failures.each do |failure|
         failure.resources.each do |resource|
           puts "#{resource.kind} #{resource.name} in #{resource.namespace} namespace failed. #{failure.message}".colorize(:red)
@@ -86,7 +92,10 @@ end
 desc "Check if the CNF uses container images with the latest tag"
 task "latest_tag" do |_, args|
   CNFManager::Task.task_runner(args) do |args, config|
-    Log.for("verbose").info { "latest_tag" }
+    task_start_time = Time.utc
+    testsuite_task = "latest_tag"
+    Log.for(testsuite_task).info { "Starting test" }
+
     Kyverno.install
 
     emoji_passed = "🏷️✔️"
@@ -98,9 +107,9 @@ task "latest_tag" do |_, args|
     failures = Kyverno.filter_failures_for_cnf_resources(resource_keys, failures)
 
     if failures.size == 0
-      resp = upsert_passed_task("latest_tag", "✔️  🏆 PASSED: Container images are not using the latest tag #{emoji_passed}", Time.utc)
+      resp = upsert_passed_task(testsuite_task, "✔️  🏆 PASSED: Container images are not using the latest tag #{emoji_passed}", task_start_time)
     else
-      resp = upsert_failed_task("latest_tag", "✖️  🏆 FAILED: Container images are using the latest tag #{emoji_failed}", Time.utc)
+      resp = upsert_failed_task(testsuite_task, "✖️  🏆 FAILED: Container images are using the latest tag #{emoji_failed}", task_start_time)
       failures.each do |failure|
         failure.resources.each do |resource|
           puts "#{resource.kind} #{resource.name} in #{resource.namespace} namespace failed. #{failure.message}".colorize(:red)
@@ -113,8 +122,10 @@ end
 desc "Does a search for IP addresses or subnets come back as negative?"
 task "ip_addresses" do |_, args|
   CNFManager::Task.task_runner(args) do |args, config|
-    VERBOSE_LOGGING.info "ip_addresses" if check_verbose(args)
-    LOGGING.info("ip_addresses args #{args.inspect}")
+    task_start_time = Time.utc
+    testsuite_task = "ip_addresses"
+    Log.for(testsuite_task).info { "Starting test" }
+
     cdir = FileUtils.pwd()
     response = String::Builder.new
     helm_directory = config.cnf_config[:helm_directory]
@@ -123,7 +134,7 @@ task "ip_addresses" do |_, args|
       # Switch to the helm chart directory
       Dir.cd(helm_chart_path)
       # Look for all ip addresses that are not comments
-      LOGGING.info "current directory: #{ FileUtils.pwd()}"
+      Log.for(testsuite_task).info { "current directory: #{ FileUtils.pwd()}" }
       # should catch comments (# // or /*) and ignore 0.0.0.0
       # note: grep wants * escaped twice
       Process.run("grep -r -P '^(?!.+0\.0\.0\.0)(?![[:space:]]*0\.0\.0\.0)(?!#)(?![[:space:]]*#)(?!\/\/)(?![[:space:]]*\/\/)(?!\/\\*)(?![[:space:]]*\/\\*)(.+([0-9]{1,3}[\.]){3}[0-9]{1,3})'  --exclude=*.txt", shell: true) do |proc|
@@ -143,16 +154,16 @@ task "ip_addresses" do |_, args|
           matching_line = line_parts.join(":").strip()
           stdout_failure("  * In file #{file_name}: #{matching_line}")
         end
-        resp = upsert_failed_task("ip_addresses","✖️  FAILED: IP addresses found", Time.utc)
+        resp = upsert_failed_task(testsuite_task,"✖️  FAILED: IP addresses found", task_start_time)
       else
-        resp = upsert_passed_task("ip_addresses", "✔️  PASSED: No IP addresses found", Time.utc)
+        resp = upsert_passed_task(testsuite_task, "✔️  PASSED: No IP addresses found", task_start_time)
       end
       resp
     else
       # TODO If no helm chart directory, exit with 0 points
       # ADD SKIPPED tag for points.yml to allow for 0 points
       Dir.cd(cdir)
-      resp = upsert_passed_task("ip_addresses", "✔️  PASSED: No IP addresses found", Time.utc)
+      resp = upsert_passed_task(testsuite_task, "✔️  PASSED: No IP addresses found", task_start_time)
     end
   end
 end
@@ -173,8 +184,11 @@ task "versioned_tag", ["install_opa"] do |_, args|
    # end
    #
   CNFManager::Task.task_runner(args) do |args,config|
-    VERBOSE_LOGGING.info "versioned_tag" if check_verbose(args)
-    LOGGING.debug "cnf_config: #{config}"
+    task_start_time = Time.utc
+    testsuite_task = "versioned_tag"
+    Log.for(testsuite_task).info { "Starting test" }
+
+    Log.for(testsuite_task).debug { "cnf_config: #{config}" }
     fail_msgs = [] of String
     task_response = CNFManager.workload_resource_test(args, config) do |resource, container, initialized|
       test_passed = true
@@ -204,9 +218,9 @@ task "versioned_tag", ["install_opa"] do |_, args|
     emoji_non_versioned_tag="🏷️❌"
 
     if task_response
-      upsert_passed_task("versioned_tag", "✔️  PASSED: Container images use versioned tags #{emoji_versioned_tag}", Time.utc)
+      upsert_passed_task(testsuite_task, "✔️  PASSED: Container images use versioned tags #{emoji_versioned_tag}", task_start_time)
     else
-      upsert_failed_task("versioned_tag", "✖️  FAILED: Container images do not use versioned tags #{emoji_non_versioned_tag}", Time.utc)
+      upsert_failed_task(testsuite_task, "✖️  FAILED: Container images do not use versioned tags #{emoji_non_versioned_tag}", task_start_time)
       fail_msgs.each do |msg|
         stdout_failure(msg)
       end
@@ -218,20 +232,23 @@ desc "Does the CNF use NodePort"
 task "nodeport_not_used" do |_, args|
   # TODO rename task_runner to multi_cnf_task_runner
   CNFManager::Task.task_runner(args) do |args, config|
-    VERBOSE_LOGGING.info "nodeport_not_used" if check_verbose(args)
-    LOGGING.debug "cnf_config: #{config}"
+    task_start_time = Time.utc
+    testsuite_task = "nodeport_not_used"
+    Log.for(testsuite_task).info { "Starting test" }
+
+    Log.for(testsuite_task).debug { "cnf_config: #{config}" }
+
     release_name = config.cnf_config[:release_name]
     service_name  = config.cnf_config[:service_name]
     destination_cnf_dir = config.cnf_config[:destination_cnf_dir]
     task_response = CNFManager.workload_resource_test(args, config, check_containers:false, check_service: true) do |resource, container, initialized|
-      LOGGING.info "nodeport_not_used resource: #{resource}"
+      Log.for(testsuite_task).info { "nodeport_not_used resource: #{resource}" }
       if resource["kind"].downcase == "service"
-        LOGGING.info "resource kind: #{resource}"
+        Log.for(testsuite_task).info { "resource kind: #{resource}" }
         service = KubectlClient::Get.resource(resource[:kind], resource[:name], resource[:namespace])
-        LOGGING.debug "service: #{service}"
+        Log.for(testsuite_task).debug { "service: #{service}" }
         service_type = service.dig?("spec", "type")
-        LOGGING.info "service_type: #{service_type}"
-        VERBOSE_LOGGING.debug service_type if check_verbose(args)
+        Log.for(testsuite_task).info { "service_type: #{service_type}" }
         if service_type == "NodePort"
           #TODO make a service selector and display the related resources
           # that are tied to this service
@@ -242,9 +259,9 @@ task "nodeport_not_used" do |_, args|
       end
     end
     if task_response
-      upsert_passed_task("nodeport_not_used", "✔️  PASSED: NodePort is not used", Time.utc)
+      upsert_passed_task(testsuite_task, "✔️  PASSED: NodePort is not used", task_start_time)
     else
-      upsert_failed_task("nodeport_not_used", "✖️  FAILED: NodePort is being used", Time.utc)
+      upsert_failed_task(testsuite_task, "✖️  FAILED: NodePort is being used", task_start_time)
     end
   end
 end
@@ -252,32 +269,35 @@ end
 desc "Does the CNF use HostPort"
 task "hostport_not_used" do |_, args|
   CNFManager::Task.task_runner(args) do |args, config|
-    VERBOSE_LOGGING.info "hostport_not_used" if check_verbose(args)
-    LOGGING.debug "cnf_config: #{config}"
+    task_start_time = Time.utc
+    testsuite_task = "hostport_not_used"
+    Log.for(testsuite_task).info { "Starting test" }
+
+    Log.for(testsuite_task).debug { "cnf_config: #{config}" }
     release_name = config.cnf_config[:release_name]
     service_name  = config.cnf_config[:service_name]
     destination_cnf_dir = config.cnf_config[:destination_cnf_dir]
 
     task_response = CNFManager.workload_resource_test(args, config, check_containers:false, check_service: true) do |resource, container, initialized|
-      LOGGING.info "hostport_not_used resource: #{resource}"
+      Log.for(testsuite_task).info { "hostport_not_used resource: #{resource}" }
       test_passed=true
-      LOGGING.info "resource kind: #{resource}"
+      Log.for(testsuite_task).info { "resource kind: #{resource}" }
       k8s_resource = KubectlClient::Get.resource(resource[:kind], resource[:name], resource[:namespace])
-      LOGGING.debug "resource: #{k8s_resource}"
+      Log.for(testsuite_task).debug { "resource: #{k8s_resource}" }
 
       # per examaple https://github.com/cncf/cnf-testsuite/issues/164#issuecomment-904890977
       containers = k8s_resource.dig?("spec", "template", "spec", "containers")
-      LOGGING.debug "containers: #{containers}"
+      Log.for(testsuite_task).debug { "containers: #{containers}" }
 
       containers && containers.as_a.each do |single_container|
         ports = single_container.dig?("ports")
 
         ports && ports.as_a.each do |single_port|
-          LOGGING.debug "single_port: #{single_port}"
+          Log.for(testsuite_task).debug { "single_port: #{single_port}" }
           
           hostport = single_port.dig?("hostPort")
 
-          LOGGING.debug "DAS hostPort: #{hostport}"
+          Log.for(testsuite_task).debug { "DAS hostPort: #{hostport}" }
 
           if hostport
             stdout_failure("Resource #{resource[:kind]}/#{resource[:name]} in #{resource[:namespace]} namespace is using a HostPort")
@@ -289,9 +309,9 @@ task "hostport_not_used" do |_, args|
       test_passed
     end
     if task_response
-      upsert_passed_task("hostport_not_used", "✔️  🏆 PASSED: HostPort is not used", Time.utc)
+      upsert_passed_task(testsuite_task, "✔️  🏆 PASSED: HostPort is not used", task_start_time)
     else
-      upsert_failed_task("hostport_not_used", "✖️  🏆 FAILED: HostPort is being used", Time.utc)
+      upsert_failed_task(testsuite_task, "✖️  🏆 FAILED: HostPort is being used", task_start_time)
     end
   end
 end
@@ -299,9 +319,10 @@ end
 desc "Does the CNF have hardcoded IPs in the K8s resource configuration"
 task "hardcoded_ip_addresses_in_k8s_runtime_configuration" do |_, args|
   task_response = CNFManager::Task.task_runner(args) do |args, config|
+    task_start_time = Time.utc
     testsuite_task = "hardcoded_ip_addresses_in_k8s_runtime_configuration"
     Log.for(testsuite_task).info { "Starting test" }
-    VERBOSE_LOGGING.info "Task Name: hardcoded_ip_addresses_in_k8s_runtime_configuration" if check_verbose(args)
+
     helm_chart = config.cnf_config[:helm_chart]
     helm_directory = config.cnf_config[:helm_directory]
     release_name = config.cnf_config[:release_name]
@@ -314,7 +335,7 @@ task "hardcoded_ip_addresses_in_k8s_runtime_configuration" do |_, args|
     unless helm_chart.empty?
       if args.named["offline"]?
         info = AirGap.tar_info_by_config_src(helm_chart)
-        LOGGING.info  "hardcoded_ip_addresses_in_k8s_runtime_configuration airgapped mode info: #{info}"
+        Log.for(testsuite_task).info { "airgapped mode info: #{info}" }
         helm_chart = info[:tar_name]
       end
       helm_install = Helm.install("--namespace hardcoded-ip-test hardcoded-ip-test #{helm_chart} --dry-run --debug > #{destination_cnf_dir}/helm_chart.yml")
@@ -332,12 +353,12 @@ task "hardcoded_ip_addresses_in_k8s_runtime_configuration" do |_, args|
     VERBOSE_LOGGING.info "IPs: #{ip_search}" if check_verbose(args)
 
     if ip_search.empty?
-      upsert_passed_task(testsuite_task, "✔️  🏆 PASSED: No hard-coded IP addresses found in the runtime K8s configuration", Time.utc)
+      upsert_passed_task(testsuite_task, "✔️  🏆 PASSED: No hard-coded IP addresses found in the runtime K8s configuration", task_start_time)
     else
-      upsert_failed_task(testsuite_task, "✖️  🏆 FAILED: Hard-coded IP addresses found in the runtime K8s configuration", Time.utc)
+      upsert_failed_task(testsuite_task, "✖️  🏆 FAILED: Hard-coded IP addresses found in the runtime K8s configuration", task_start_time)
     end
   rescue
-    upsert_skipped_task(testsuite_task, "⏭️  🏆 SKIPPED: unknown exception", Time.utc)
+    upsert_skipped_task(testsuite_task, "⏭️  🏆 SKIPPED: unknown exception", task_start_time)
   ensure
     KubectlClient::Delete.command("namespace hardcoded-ip-test --force --grace-period 0")
   end
@@ -346,29 +367,33 @@ end
 desc "Does the CNF use K8s Secrets?"
 task "secrets_used" do |_, args|
   CNFManager::Task.task_runner(args) do |args, config|
-    Log.debug { "cnf_config: #{config}" }
-    Log.for("verbose").info { "secrets_used" } if check_verbose(args)
+    task_start_time = Time.utc
+    testsuite_task = "secrets_used"
+    Log.for(testsuite_task).info { "Starting test" }
+
+    Log.for(testsuite_task).debug { "cnf_config: #{config}" }
+
     # Parse the cnf-testsuite.yml
     resp = ""
     emoji_probe="🧫"
     task_response = CNFManager.workload_resource_test(args, config, check_containers=false) do |resource, containers, volumes, initialized|
-      Log.info { "resource: #{resource}" }
-      Log.info { "volumes: #{volumes}" }
+      Log.for(testsuite_task).info { "resource: #{resource}" }
+      Log.for(testsuite_task).info { "volumes: #{volumes}" }
 
       volume_test_passed = false
       container_secret_mounted = false
       # Check to see any volume secrets are actually used
       volumes.as_a.each do |secret_volume|
         if secret_volume["secret"]?
-          LOGGING.info "secret_volume: #{secret_volume["name"]}"
+          Log.for(testsuite_task).info { "secret_volume: #{secret_volume["name"]}" }
           container_secret_mounted = false
           containers.as_a.each do |container|
             if container["volumeMounts"]?
                 vmount = container["volumeMounts"].as_a
-              LOGGING.info "vmount: #{vmount}"
-              LOGGING.debug "container[env]: #{container["env"]}"
+              Log.for(testsuite_task).info { "vmount: #{vmount}" }
+              Log.for(testsuite_task).debug { "container[env]: #{container["env"]}" }
               if (vmount.find { |x| x["name"] == secret_volume["name"]? })
-                LOGGING.debug secret_volume["name"]
+                Log.for(testsuite_task).debug { secret_volume["name"] }
                 container_secret_mounted = true
                 volume_test_passed = true
               end
@@ -393,26 +418,26 @@ task "secrets_used" do |_, args|
         s_name = s["metadata"]["name"]
         s_type = s["type"]
         s_namespace = s.dig("metadata", "namespace")
-        Log.for("verbose").info {"secret name: #{s_name}, type: #{s_type}, namespace: #{s_namespace}"} if check_verbose(args)
+        Log.for(testsuite_task).info {"secret name: #{s_name}, type: #{s_type}, namespace: #{s_namespace}"} if check_verbose(args)
       end
       secret_keyref_found_and_not_ignored = false
       containers.as_a.each do |container|
         c_name = container["name"]
-        Log.for("verbose").info { "container: #{c_name} envs #{container["env"]?}" } if check_verbose(args)
+        Log.for(testsuite_task).info { "container: #{c_name} envs #{container["env"]?}" } if check_verbose(args)
         if container["env"]?
           Log.for("container_info").info { container["env"] }
           container["env"].as_a.find do |env|
-            Log.for("verbose").debug { "checking container: #{c_name}" } if check_verbose(args)
+            Log.for(testsuite_task).debug { "checking container: #{c_name}" } if check_verbose(args)
             secret_keyref_found_and_not_ignored = secrets["items"].as_a.find do |s|
               s_name = s["metadata"]["name"]
               if IGNORED_SECRET_TYPES.includes?(s["type"])
                 Log.for("verbose").info { "container: #{c_name} ignored secret: #{s_name}" } if check_verbose(args)
                 next
               end
-              Log.for("checking_secret").info { s_name }
+              Log.for(testsuite_task).info { "Checking secret: #{s_name}" }
               found = (s_name == env.dig?("valueFrom", "secretKeyRef", "name"))
               if found
-                Log.for("secret_reference_found").info { "container: #{c_name} found secret reference: #{s_name}" }
+                Log.for(testsuite_task).info { "secret_reference_found. container: #{c_name} found secret reference: #{s_name}" }
               end
               found
             end
@@ -434,9 +459,9 @@ task "secrets_used" do |_, args|
       test_passed
     end
     if task_response
-      resp = upsert_passed_task("secrets_used","✔️  ✨PASSED: Secrets defined and used #{emoji_probe}", Time.utc)
+      resp = upsert_passed_task(testsuite_task, "✔️  ✨PASSED: Secrets defined and used #{emoji_probe}", task_start_time)
     else
-      resp = upsert_skipped_task("secrets_used","⏭  ✨#{secrets_used_skipped_msg(emoji_probe)}", Time.utc)
+      resp = upsert_skipped_task(testsuite_task, "⏭  ✨#{secrets_used_skipped_msg(emoji_probe)}", task_start_time)
     end
     resp
   end
@@ -547,8 +572,11 @@ task "immutable_configmap" do |_, args|
   emoji_probe="⚖️"
 
   task_response = CNFManager::Task.task_runner(args) do |args, config|
-    VERBOSE_LOGGING.info "immutable_configmap" if check_verbose(args)
-    LOGGING.debug "cnf_config: #{config}"
+    task_start_time = Time.utc
+    testsuite_task = "immutable_configmap"
+    Log.for(testsuite_task).info { "Starting test" }
+
+    Log.for(testsuite_task).debug { "cnf_config: #{config}" }
 
     destination_cnf_dir = config.cnf_config[:destination_cnf_dir]
 
@@ -560,14 +588,14 @@ task "immutable_configmap" do |_, args|
     test_config_map_filename = "#{destination_cnf_dir}/config_maps/test_config_map.yml";
 
     template = ImmutableConfigMapTemplate.new("doesnt_matter").to_s
-    Log.debug { "test immutable_configmap template: #{template}" }
+    Log.for(testsuite_task).debug { "test immutable_configmap template: #{template}" }
     File.write(test_config_map_filename, template)
     KubectlClient::Apply.file(test_config_map_filename)
 
     # now we change then apply again
 
     template = ImmutableConfigMapTemplate.new("doesnt_matter_again").to_s
-    Log.debug { "test immutable_configmap change template: #{template}" }
+    Log.for(testsuite_task)debug { "test immutable_configmap change template: #{template}" }
     File.write(test_config_map_filename, template)
 
     immutable_configmap_supported = true
@@ -581,14 +609,14 @@ task "immutable_configmap" do |_, args|
     KubectlClient::Delete.file(test_config_map_filename)
 
     if apply_result[:status].success?
-      Log.info { "kubectl apply on immutable configmap succeeded for: #{test_config_map_filename}" }
+      Log.for(testsuite_task).info { "kubectl apply on immutable configmap succeeded for: #{test_config_map_filename}" }
       k8s_ver = KubectlClient.server_version
       if version_less_than(k8s_ver, "1.19.0")
         resp = " ⏭️  SKIPPED: immmutable configmaps are not supported in this k8s cluster.".colorize(:yellow)
-        upsert_skipped_task("immutable_configmap", resp, Time.utc)
+        upsert_skipped_task(testsuite_task, resp, task_start_time)
       else
         resp = "✖️  FAILED: immmutable configmaps are not enabled in this k8s cluster.".colorize(:red)
-        upsert_failed_task("immutable_configmap", resp, Time.utc)
+        upsert_failed_task(testsuite_task, resp, task_start_time)
       end
     else
 
@@ -596,8 +624,8 @@ task "immutable_configmap" do |_, args|
       envs_with_mutable_configmap = [] of MutableConfigMapsInEnvResult
 
       cnf_manager_workload_resource_task_response = CNFManager.workload_resource_test(args, config, check_containers=false, check_service=true) do |resource, containers, volumes, initialized|
-        Log.info { "resource: #{resource}" }
-        Log.info { "volumes: #{volumes}" }
+        Log.for(testsuite_task).info { "resource: #{resource}" }
+        Log.for(testsuite_task).info { "volumes: #{volumes}" }
 
         # If the install type is manifest, the namesapce would be in the manifest.
         # Else rely on config for helm-based install
@@ -622,10 +650,10 @@ task "immutable_configmap" do |_, args|
 
       if cnf_manager_workload_resource_task_response
         resp = "✔️  ✨PASSED: All volume or container mounted configmaps immutable #{emoji_probe}".colorize(:green)
-        upsert_passed_task("immutable_configmap", resp, Time.utc)
+        upsert_passed_task(testsuite_task, resp, task_start_time)
       elsif immutable_configmap_supported
         resp = "✖️  ✨FAILED: Found mutable configmap(s) #{emoji_probe}".colorize(:red)
-        upsert_failed_task("immutable_configmap", resp, Time.utc)
+        upsert_failed_task(testsuite_task, resp, task_start_time)
 
         # Print out any mutable configmaps mounted as volumes
         volumes_test_results.each do |result|
@@ -651,7 +679,9 @@ end
 desc "Check if CNF uses Kubernetes alpha APIs"
 task "alpha_k8s_apis" do |_, args|
   CNFManager::Task.task_runner(args) do |args, config|
-    Log.for("verbose").info { "alpha_k8s_apis" } if check_verbose(args)
+    task_start_time = Time.utc
+    testsuite_task = "alpha_k8s_apis"
+    Log.for(testsuite_task).info { "Starting test" }
 
     unless check_poc(args)
       Log.info { "Skipping alpha_k8s_apis: not in poc mode" }
@@ -665,7 +695,7 @@ task "alpha_k8s_apis" do |_, args|
 
     # No offline support for this task for now
     if args.named["offline"]? && args.named["offline"]? != "false"
-      upsert_skipped_task("alpha_k8s_apis","⏭️  SKIPPED: alpha_k8s_apis chaos test skipped #{emoji}", Time.utc)
+      upsert_skipped_task(testsuite_task, "⏭️  SKIPPED: alpha_k8s_apis chaos test skipped #{emoji}", task_start_time)
       next
     end
 
@@ -689,7 +719,7 @@ task "alpha_k8s_apis" do |_, args|
     # CNF setup failed on kind cluster. Inform in test output.
     unless cnf_setup_complete
       puts "CNF failed to install on apisnoop cluster".colorize(:red)
-      upsert_failed_task("alpha_k8s_apis", "✖️  FAILED: Could not check CNF for usage of Kubernetes alpha APIs #{emoji}", Time.utc)
+      upsert_failed_task(testsuite_task, "✖️  FAILED: Could not check CNF for usage of Kubernetes alpha APIs #{emoji}", task_start_time)
       next
     end
 
@@ -706,9 +736,9 @@ task "alpha_k8s_apis" do |_, args|
     api_count = result[:output].split("\n")[2].to_i
 
     if api_count == 0
-      upsert_passed_task("alpha_k8s_apis", "✔️  PASSED: CNF does not use Kubernetes alpha APIs #{emoji}", Time.utc)
+      upsert_passed_task(testsuite_task, "✔️  PASSED: CNF does not use Kubernetes alpha APIs #{emoji}", task_start_time)
     else
-      upsert_failed_task("alpha_k8s_apis", "✖️  FAILED: CNF uses Kubernetes alpha APIs #{emoji}", Time.utc)
+      upsert_failed_task(testsuite_task, "✖️  FAILED: CNF uses Kubernetes alpha APIs #{emoji}", task_start_time)
     end
   ensure
     if cluster_name != nil
@@ -731,8 +761,11 @@ end
 desc "Does the CNF install an Operator with OLM?"
 task "operator_installed" do |_, args|
   CNFManager::Task.task_runner(args) do |args,config|
-    Log.for("verbose").info { "operator_installed" } if check_verbose(args)
-    Log.debug { "cnf_config: #{config}" }
+    task_start_time = Time.utc
+    testsuite_task = "operator_installed"
+    Log.for(testsuite_task).info { "Starting test" }
+
+    Log.for(testsuite_task).debug { "cnf_config: #{config}" }
 
     subscription_names = CNFManager.cnf_resources(args, config) do |resource|
       kind = resource.dig("kind").as_s
@@ -741,7 +774,7 @@ task "operator_installed" do |_, args|
       end
     end.compact
 
-    Log.info { "Subscription Names: #{subscription_names}" }
+    Log.for(testsuite_task).info { "Subscription Names: #{subscription_names}" }
 
 
     #TODO Warn if csv is not found for a subscription.
@@ -759,7 +792,7 @@ task "operator_installed" do |_, args|
       end
     end.compact
 
-    Log.info { "CSV Names: #{csv_names}" }
+    Log.for(testsuite_task).info { "CSV Names: #{csv_names}" }
 
 
     succeeded = csv_names.map do |csv| 
@@ -769,12 +802,12 @@ task "operator_installed" do |_, args|
       csv_succeeded
     end
 
-    Log.info { "Succeeded CSV Names: #{succeeded}" }
+    Log.for(testsuite_task).info { "Succeeded CSV Names: #{succeeded}" }
 
     test_passed = false
 
     if succeeded.size > 0 && succeeded.all?(true)
-      Log.info { "Succeeded All True?" }
+      Log.for(testsuite_task).info { "Succeeded All True?" }
       test_passed = true
     end
 
@@ -785,9 +818,9 @@ task "operator_installed" do |_, args|
     emoji_big="🦖"
 
     if test_passed
-      upsert_passed_task("operator_installed", "✔️  PASSED: Operator is installed: #{emoji_small} #{emoji_image_size}", Time.utc)
+      upsert_passed_task(testsuite_task, "✔️  PASSED: Operator is installed: #{emoji_small} #{emoji_image_size}", task_start_time)
     else
-      upsert_na_task("operator_installed", "✖️  NA: No Operators Found #{emoji_big} #{emoji_image_size}", Time.utc)
+      upsert_na_task(testsuite_task, "✖️  NA: No Operators Found #{emoji_big} #{emoji_image_size}", task_start_time)
     end
   end
 end

--- a/src/tasks/workload/configuration.cr
+++ b/src/tasks/workload/configuration.cr
@@ -299,6 +299,8 @@ end
 desc "Does the CNF have hardcoded IPs in the K8s resource configuration"
 task "hardcoded_ip_addresses_in_k8s_runtime_configuration" do |_, args|
   task_response = CNFManager::Task.task_runner(args) do |args, config|
+    testsuite_task = "hardcoded_ip_addresses_in_k8s_runtime_configuration"
+    Log.for(testsuite_task).info { "Starting test" }
     VERBOSE_LOGGING.info "Task Name: hardcoded_ip_addresses_in_k8s_runtime_configuration" if check_verbose(args)
     helm_chart = config.cnf_config[:helm_chart]
     helm_directory = config.cnf_config[:helm_directory]
@@ -330,12 +332,12 @@ task "hardcoded_ip_addresses_in_k8s_runtime_configuration" do |_, args|
     VERBOSE_LOGGING.info "IPs: #{ip_search}" if check_verbose(args)
 
     if ip_search.empty?
-      upsert_passed_task("hardcoded_ip_addresses_in_k8s_runtime_configuration", "✔️  🏆 PASSED: No hard-coded IP addresses found in the runtime K8s configuration", Time.utc)
+      upsert_passed_task(testsuite_task, "✔️  🏆 PASSED: No hard-coded IP addresses found in the runtime K8s configuration", Time.utc)
     else
-      upsert_failed_task("hardcoded_ip_addresses_in_k8s_runtime_configuration", "✖️  🏆 FAILED: Hard-coded IP addresses found in the runtime K8s configuration", Time.utc)
+      upsert_failed_task(testsuite_task, "✖️  🏆 FAILED: Hard-coded IP addresses found in the runtime K8s configuration", Time.utc)
     end
   rescue
-    upsert_skipped_task("hardcoded_ip_addresses_in_k8s_runtime_configuration", "⏭️  🏆 SKIPPED: unknown exception", Time.utc)
+    upsert_skipped_task(testsuite_task, "⏭️  🏆 SKIPPED: unknown exception", Time.utc)
   ensure
     KubectlClient::Delete.command("namespace hardcoded-ip-test --force --grace-period 0")
   end

--- a/src/tasks/workload/observability.cr
+++ b/src/tasks/workload/observability.cr
@@ -252,16 +252,17 @@ end
 
 desc "Does the CNF install use tracing?"
 task "tracing" do |_, args|
-  Log.for("verbose").info { "tracing" } if check_verbose(args)
-  Log.info { "tracing args: #{args.inspect}" }
+  testsuite_task = "tracing"
+  Log.for(testsuite_task).info { "Running test" }
+  Log.for(testsuite_task).info { "tracing args: #{args.inspect}" }
+
   next if args.named["offline"]?
-   emoji_tracing_deploy="⎈🚀"
+  emoji_tracing_deploy="⎈🚀"
 
   if check_cnf_config(args) || CNFManager.destination_cnfs_exist?
     CNFManager::Task.task_runner(args) do |args, config|
       task_start_time = Time.utc
-      testsuite_task = "tracing"
-      Log.for(testsuite_task).info { "Starting test" }
+      Log.for(testsuite_task).info { "Starting test for CNF" }
 
       match = JaegerManager.match()
       Log.info { "jaeger match: #{match}" }

--- a/src/tasks/workload/observability.cr
+++ b/src/tasks/workload/observability.cr
@@ -285,7 +285,7 @@ task "tracing" do |_, args|
       end
     end
   else
-    upsert_failed_task(testsuite_task, "✖️  ✨FAILED: No cnf_testsuite.yml found! Did you run the setup task?", task_start_time)
+    upsert_failed_task(testsuite_task, "✖️  ✨FAILED: No cnf_testsuite.yml found! Did you run the setup task?", Time.utc)
   end
 end
 

--- a/src/tasks/workload/observability.cr
+++ b/src/tasks/workload/observability.cr
@@ -19,7 +19,9 @@ end
 desc "Check if the CNF outputs logs to stdout or stderr"
 task "log_output" do |_, args|
   CNFManager::Task.task_runner(args) do |args,config|
-    Log.for("verbose").info { "log_output" } if check_verbose(args)
+    task_start_time = Time.utc
+    testsuite_task = "log_output"
+    Log.for(testsuite_task).info { "Starting test" }
 
     task_response = CNFManager.workload_resource_test(args, config) do |resource, container, initialized|
       test_passed = false
@@ -38,9 +40,9 @@ task "log_output" do |_, args|
     emoji_observability="📶☠️"
 
     if task_response
-      upsert_passed_task("log_output", "✔️  🏆 PASSED: Resources output logs to stdout and stderr #{emoji_observability}", Time.utc)
+      upsert_passed_task(testsuite_task, "✔️  🏆 PASSED: Resources output logs to stdout and stderr #{emoji_observability}", task_start_time)
     else
-      upsert_failed_task("log_output", "✖️  🏆 FAILED: Resources do not output logs to stdout and stderr #{emoji_observability}", Time.utc)
+      upsert_failed_task(testsuite_task, "✖️  🏆 FAILED: Resources do not output logs to stdout and stderr #{emoji_observability}", task_start_time)
     end
   end
 end
@@ -50,6 +52,9 @@ task "prometheus_traffic" do |_, args|
   Log.info { "Running: prometheus_traffic" }
   next if args.named["offline"]?
   task_response = CNFManager::Task.task_runner(args) do |args, config|
+    task_start_time = Time.utc
+    testsuite_task = "prometheus_traffic"
+    Log.for(testsuite_task).info { "Starting test" }
 
     release_name = config.cnf_config[:release_name]
     destination_cnf_dir = config.cnf_config[:destination_cnf_dir] 
@@ -157,12 +162,12 @@ task "prometheus_traffic" do |_, args|
       #  -- match ip address to cnf ip addresses
       # todo check if scrape_url is not an ip, assume it is a service, then do task (2)
       if prom_cnf_match
-        upsert_passed_task("prometheus_traffic","✔️  ✨PASSED: Your cnf is sending prometheus traffic #{emoji_observability}", Time.utc)
+        upsert_passed_task(testsuite_task,"✔️  ✨PASSED: Your cnf is sending prometheus traffic #{emoji_observability}", task_start_time)
       else
-        upsert_failed_task("prometheus_traffic", "✖️  ✨FAILED: Your cnf is not sending prometheus traffic #{emoji_observability}", Time.utc)
+        upsert_failed_task(testsuite_task, "✖️  ✨FAILED: Your cnf is not sending prometheus traffic #{emoji_observability}", task_start_time)
       end
     else
-      upsert_skipped_task("prometheus_traffic", "⏭️  ✨SKIPPED: Prometheus server not found #{emoji_observability}", Time.utc)
+      upsert_skipped_task(testsuite_task, "⏭️  ✨SKIPPED: Prometheus server not found #{emoji_observability}", task_start_time)
     end
   end
 end
@@ -172,6 +177,10 @@ task "open_metrics", ["prometheus_traffic"] do |_, args|
   Log.info { "Running: open_metrics" }
   next if args.named["offline"]?
   task_response = CNFManager::Task.task_runner(args) do |args, config|
+    task_start_time = Time.utc
+    testsuite_task = "open_metrics"
+    Log.for(testsuite_task).info { "Starting test" }
+
     release_name = config.cnf_config[:release_name]
     configmap = KubectlClient::Get.configmap("cnf-testsuite-#{release_name}-open-metrics")
     emoji_observability="📶☠️"
@@ -179,14 +188,14 @@ task "open_metrics", ["prometheus_traffic"] do |_, args|
       open_metrics_validated = configmap["data"].as_h["open_metrics_validated"].as_s
 
       if open_metrics_validated == "true"
-        upsert_passed_task("open_metrics","✔️  ✨PASSED: Your cnf's metrics traffic is OpenMetrics compatible #{emoji_observability}", Time.utc)
+        upsert_passed_task(testsuite_task,"✔️  ✨PASSED: Your cnf's metrics traffic is OpenMetrics compatible #{emoji_observability}", task_start_time)
       else
         open_metrics_response = configmap["data"].as_h["open_metrics_response"].as_s
         puts "OpenMetrics Failed: #{open_metrics_response}".colorize(:red)
-        upsert_failed_task("open_metrics", "✖️  ✨FAILED: Your cnf's metrics traffic is not OpenMetrics compatible #{emoji_observability}", Time.utc)
+        upsert_failed_task(testsuite_task, "✖️  ✨FAILED: Your cnf's metrics traffic is not OpenMetrics compatible #{emoji_observability}", task_start_time)
       end
     else
-      upsert_skipped_task("open_metrics", "⏭️  ✨SKIPPED: Prometheus traffic not configured #{emoji_observability}", Time.utc)
+      upsert_skipped_task(testsuite_task, "⏭️  ✨SKIPPED: Prometheus traffic not configured #{emoji_observability}", task_start_time)
     end
   end
 end
@@ -197,6 +206,10 @@ task "routed_logs", ["install_cluster_tools"] do |_, args|
   next if args.named["offline"]?
     emoji_observability="📶☠️"
   task_response = CNFManager::Task.task_runner(args) do |args, config|
+    task_start_time = Time.utc
+    testsuite_task = "routed_logs"
+    Log.for(testsuite_task).info { "Starting test" }
+
     fluentd_match = FluentD.match()
     fluentbit_match = FluentBit.match()
     fluentbitBitnami_match = FluentDBitnami.match()
@@ -227,12 +240,12 @@ task "routed_logs", ["install_cluster_tools"] do |_, args|
         end
         Log.info { "all_resourced_logged: #{all_resourced_logged}" }
         if all_resourced_logged 
-          upsert_passed_task("routed_logs","✔️  ✨PASSED: Your cnf's logs are being captured #{emoji_observability}", Time.utc)
+          upsert_passed_task(testsuite_task,"✔️  ✨PASSED: Your cnf's logs are being captured #{emoji_observability}", task_start_time)
         else
-          upsert_failed_task("routed_logs", "✖️  ✨FAILED: Your cnf's logs are not being captured #{emoji_observability}", Time.utc)
+          upsert_failed_task(testsuite_task, "✖️  ✨FAILED: Your cnf's logs are not being captured #{emoji_observability}", task_start_time)
         end
     else
-      upsert_skipped_task("routed_logs", "⏭️  ✨SKIPPED: Fluentd or FluentBit not configured #{emoji_observability}", Time.utc)
+      upsert_skipped_task(testsuite_task, "⏭️  ✨SKIPPED: Fluentd or FluentBit not configured #{emoji_observability}", task_start_time)
     end
   end
 end
@@ -246,6 +259,10 @@ task "tracing" do |_, args|
 
   if check_cnf_config(args) || CNFManager.destination_cnfs_exist?
     CNFManager::Task.task_runner(args) do |args, config|
+      task_start_time = Time.utc
+      testsuite_task = "tracing"
+      Log.for(testsuite_task).info { "Starting test" }
+
       match = JaegerManager.match()
       Log.info { "jaeger match: #{match}" }
       if match[:found]
@@ -258,16 +275,16 @@ task "tracing" do |_, args|
         tracing_used = configmap["data"].as_h["tracing_used"].as_s
 
         if tracing_used == "true" 
-          upsert_passed_task("tracing", "✔️  ✨PASSED: Tracing used #{emoji_tracing_deploy}", Time.utc)
+          upsert_passed_task(testsuite_task, "✔️  ✨PASSED: Tracing used #{emoji_tracing_deploy}", task_start_time)
         else
-          upsert_failed_task("tracing", "✖️  ✨FAILED: Tracing not used #{emoji_tracing_deploy}", Time.utc)
+          upsert_failed_task(testsuite_task, "✖️  ✨FAILED: Tracing not used #{emoji_tracing_deploy}", task_start_time)
         end
       else
-        upsert_skipped_task("tracing", "⏭️  ✨SKIPPED: Jaeger not configured #{emoji_tracing_deploy}", Time.utc)
+        upsert_skipped_task(testsuite_task, "⏭️  ✨SKIPPED: Jaeger not configured #{emoji_tracing_deploy}", task_start_time)
       end
     end
   else
-    upsert_failed_task("tracing", "✖️  ✨FAILED: No cnf_testsuite.yml found! Did you run the setup task?", Time.utc)
+    upsert_failed_task(testsuite_task, "✖️  ✨FAILED: No cnf_testsuite.yml found! Did you run the setup task?", task_start_time)
   end
 end
 

--- a/src/tasks/workload/ran.cr
+++ b/src/tasks/workload/ran.cr
@@ -8,7 +8,10 @@ require "../utils/utils.cr"
 desc "Test if a 5G core supports SUCI Concealment"
 task "suci_enabled" do |_, args|
   CNFManager::Task.task_runner(args) do |args, config|
-    Log.info { "Running suci_enabled test" }
+    task_start_time = Time.utc
+    testsuite_task = "suci_enabled"
+    Log.for(testsuite_task).info { "Starting test" }
+
     Log.debug { "cnf_config: #{config}" }
     suci_found : Bool | Nil
     core = config.cnf_config[:core_label]? 
@@ -52,9 +55,9 @@ task "suci_enabled" do |_, args|
 
 
     if suci_found 
-      resp = upsert_passed_task("suci_enabled","✔️  PASSED: Core uses SUCI 5g authentication", Time.utc)
+      resp = upsert_passed_task(testsuite_task,"✔️  PASSED: Core uses SUCI 5g authentication", task_start_time)
     else
-      resp = upsert_failed_task("suci_enabled", "✖️  FAILED: Core does not use SUCI 5g authentication", Time.utc)
+      resp = upsert_failed_task(testsuite_task, "✖️  FAILED: Core does not use SUCI 5g authentication", task_start_time)
     end
     resp
   ensure
@@ -68,7 +71,10 @@ end
 desc "Test if RAN uses the ORAN e2 interface"
 task "oran_e2_connection" do |_, args|
   CNFManager::Task.task_runner(args) do |args, config|
-    Log.info { "Running oran_e2_connection test" }
+    task_start_time = Time.utc
+    testsuite_task = "oran_e2_connection"
+    Log.for(testsuite_task).info { "Starting test" }
+
     Log.debug { "cnf_config: #{config}" }
     release_name = config.cnf_config[:release_name]
     if ORANMonitor.isCNFaRIC?(config.cnf_config) 
@@ -77,13 +83,13 @@ task "oran_e2_connection" do |_, args|
 
 
       if e2_found  == "true"
-        resp = upsert_passed_task("oran_e2_connection","✔️  PASSED: RAN connects to a RIC using the e2 standard interface", Time.utc)
+        resp = upsert_passed_task(testsuite_task,"✔️  PASSED: RAN connects to a RIC using the e2 standard interface", task_start_time)
       else
-        resp = upsert_failed_task("e2_established", "✖️  FAILED: RAN does not connect to a RIC using the e2 standard interface", Time.utc)
+        resp = upsert_failed_task(testsuite_task, "✖️  FAILED: RAN does not connect to a RIC using the e2 standard interface", task_start_time)
       end
       resp
     else
-      upsert_na_task("oran_e2_connection", "⏭️  N/A: [oran_e2_connection] No ric designated in cnf_testsuite.yml", Time.utc)
+      upsert_na_task(testsuite_task, "⏭️  N/A: [oran_e2_connection] No ric designated in cnf_testsuite.yml", task_start_time)
       next
     end
   end

--- a/src/tasks/workload/security.cr
+++ b/src/tasks/workload/security.cr
@@ -65,7 +65,10 @@ end
 desc "Check if the CNF has services with external IPs configured"
 task "external_ips" do |_, args|
   CNFManager::Task.task_runner(args) do |args, config|
-    Log.for("verbose").info { "external_ips" }
+    task_start_time = Time.utc
+    testsuite_task = "external_ips"
+    Log.for(testsuite_task).info { "Starting test" }
+
     Kyverno.install
     emoji_security = "🔓🔑"
     policy_path = Kyverno.best_practice_policy("restrict-service-external-ips/restrict-service-external-ips.yaml")
@@ -75,9 +78,9 @@ task "external_ips" do |_, args|
     failures = Kyverno.filter_failures_for_cnf_resources(resource_keys, failures)
     
     if failures.size == 0
-      resp = upsert_passed_task("external_ips", "✔️  PASSED: Services are not using external IPs #{emoji_security}", Time.utc)
+      resp = upsert_passed_task(testsuite_task, "✔️  PASSED: Services are not using external IPs #{emoji_security}", task_start_time)
     else
-      resp = upsert_failed_task("external_ips", "✖️  FAILED: Services are using external IPs #{emoji_security}", Time.utc)
+      resp = upsert_failed_task(testsuite_task, "✖️  FAILED: Services are using external IPs #{emoji_security}", task_start_time)
       failures.each do |failure|
         failure.resources.each do |resource|
           puts "#{resource.kind} #{resource.name} in #{resource.namespace} namespace failed. #{failure.message}".colorize(:red)

--- a/src/tasks/workload/security.cr
+++ b/src/tasks/workload/security.cr
@@ -93,7 +93,10 @@ end
 desc "Check if the CNF or the cluster resources have custom SELinux options"
 task "selinux_options" do |_, args|
   CNFManager::Task.task_runner(args) do |args, config|
-    Log.for("verbose").info { "selinux_options" }
+    task_start_time = Time.utc
+    testsuite_task = "selinux_options"
+    Log.for(testsuite_task).info { "Starting test" }
+
     Kyverno.install
 
     emoji_security = "🔓🔑"
@@ -117,9 +120,9 @@ task "selinux_options" do |_, args|
       failures = Kyverno.filter_failures_for_cnf_resources(resource_keys, disallow_failures)
 
       if failures.size == 0
-        resp = upsert_passed_task("selinux_options", "✔️  🏆 PASSED: Pods are not using custom SELinux options that can be used for privilege escalations #{emoji_security}", Time.utc)
+        resp = upsert_passed_task(testsuite_task, "✔️  🏆 PASSED: Pods are not using custom SELinux options that can be used for privilege escalations #{emoji_security}", task_start_time)
       else
-        resp = upsert_failed_task("selinux_options", "✖️  🏆 FAILED: Pods are using custom SELinux options that can be used for privilege escalations #{emoji_security}", Time.utc)
+        resp = upsert_failed_task(testsuite_task, "✖️  🏆 FAILED: Pods are using custom SELinux options that can be used for privilege escalations #{emoji_security}", task_start_time)
         failures.each do |failure|
           failure.resources.each do |resource|
             puts "#{resource.kind} #{resource.name} in #{resource.namespace} namespace failed. #{failure.message}".colorize(:red)

--- a/src/tasks/workload/security.cr
+++ b/src/tasks/workload/security.cr
@@ -337,7 +337,10 @@ end
 desc "Check if potential attackers may gain access to a POD and inherit access to the entire host network. For example, in AWS case, they will have access to the entire VPC."
 task "host_network", ["kubescape_scan"] do |_, args|
   CNFManager::Task.task_runner(args) do |args, config|
-    VERBOSE_LOGGING.info "host_network" if check_verbose(args)
+    task_start_time = Time.utc
+    testsuite_task = "host_network"
+    Log.for(testsuite_task).info { "Starting test" }
+
     results_json = Kubescape.parse
     test_json = Kubescape.test_by_test_name(results_json, "HostNetwork access")
     test_report = Kubescape.parse_test_report(test_json)
@@ -346,9 +349,9 @@ task "host_network", ["kubescape_scan"] do |_, args|
 
     emoji_security="🔓🔑"
     if test_report.failed_resources.size == 0
-      upsert_passed_task("host_network", "✔️  PASSED: No host network attached to pod #{emoji_security}", Time.utc)
+      upsert_passed_task(testsuite_task, "✔️  PASSED: No host network attached to pod #{emoji_security}", task_start_time)
     else
-      resp = upsert_failed_task("host_network", "✖️  FAILED: Found host network attached to pod #{emoji_security}", Time.utc)
+      resp = upsert_failed_task(testsuite_task, "✖️  FAILED: Found host network attached to pod #{emoji_security}", task_start_time)
       test_report.failed_resources.map {|r| stdout_failure(r.alert_message) }
       stdout_failure("Remediation: #{test_report.remediation}")
       resp
@@ -359,7 +362,10 @@ end
 desc "Potential attacker may gain access to a POD and steal its service account token. Therefore, it is recommended to disable automatic mapping of the service account tokens in service account configuration and enable it only for PODs that need to use them."
 task "service_account_mapping", ["kubescape_scan"] do |_, args|
   CNFManager::Task.task_runner(args) do |args, config|
-    VERBOSE_LOGGING.info "service_account_mapping" if check_verbose(args)
+    task_start_time = Time.utc
+    testsuite_task = "service_account_mapping"
+    Log.for(testsuite_task).info { "Starting test" }
+
     results_json = Kubescape.parse
     test_json = Kubescape.test_by_test_name(results_json, "Automatic mapping of service account")
     test_report = Kubescape.parse_test_report(test_json)
@@ -368,9 +374,9 @@ task "service_account_mapping", ["kubescape_scan"] do |_, args|
 
     emoji_security="🔓🔑"
     if test_report.failed_resources.size == 0 
-      upsert_passed_task("service_account_mapping", "✔️  PASSED: No service accounts automatically mapped #{emoji_security}", Time.utc)
+      upsert_passed_task(testsuite_task, "✔️  PASSED: No service accounts automatically mapped #{emoji_security}", task_start_time)
     else
-      resp = upsert_failed_task("service_account_mapping", "✖️  FAILED: Service accounts automatically mapped #{emoji_security}", Time.utc)
+      resp = upsert_failed_task(testsuite_task, "✖️  FAILED: Service accounts automatically mapped #{emoji_security}", task_start_time)
       test_report.failed_resources.map {|r| stdout_failure(r.alert_message) }
       stdout_failure("Remediation: #{test_report.remediation}")
       resp
@@ -383,7 +389,10 @@ task "linux_hardening", ["kubescape_scan"] do |_, args|
   next if args.named["offline"]?
 
   CNFManager::Task.task_runner(args) do |args, config|
-    Log.for("verbose").info { "linux_hardening" } if check_verbose(args)
+    task_start_time = Time.utc
+    testsuite_task = "linux_hardening"
+    Log.for(testsuite_task).info { "Starting test" }
+
     results_json = Kubescape.parse
     test_json = Kubescape.test_by_test_name(results_json, "Linux hardening")
     test_report = Kubescape.parse_test_report(test_json)
@@ -392,9 +401,9 @@ task "linux_hardening", ["kubescape_scan"] do |_, args|
 
     emoji_security = "🔓🔑"
     if test_report.failed_resources.size == 0
-      upsert_passed_task("linux_hardening", "✔️  ✨PASSED: Security services are being used to harden applications #{emoji_security}", Time.utc)
+      upsert_passed_task(testsuite_task, "✔️  ✨PASSED: Security services are being used to harden applications #{emoji_security}", task_start_time)
     else
-      resp = upsert_failed_task("linux_hardening", "✖️  ✨FAILED: Found resources that do not use security services #{emoji_security}", Time.utc)
+      resp = upsert_failed_task(testsuite_task, "✖️  ✨FAILED: Found resources that do not use security services #{emoji_security}", task_start_time)
         test_report.failed_resources.map {|r| stdout_failure(r.alert_message) }
         stdout_failure("Remediation: #{test_report.remediation}")
       resp
@@ -407,7 +416,10 @@ task "insecure_capabilities", ["kubescape_scan"] do |_, args|
   next if args.named["offline"]?
 
   CNFManager::Task.task_runner(args) do |args, config|
-    Log.for("verbose").info { "insecure_capabilities" } if check_verbose(args)
+    task_start_time = Time.utc
+    testsuite_task = "insecure_capabilities"
+    Log.for(testsuite_task).info { "Starting test" }
+
     results_json = Kubescape.parse
     test_json = Kubescape.test_by_test_name(results_json, "Insecure capabilities")
     test_report = Kubescape.parse_test_report(test_json)
@@ -416,9 +428,9 @@ task "insecure_capabilities", ["kubescape_scan"] do |_, args|
 
     emoji_security = "🔓🔑"
     if test_report.failed_resources.size == 0
-      upsert_passed_task("insecure_capabilities", "✔️  PASSED: Containers with insecure capabilities were not found #{emoji_security}", Time.utc)
+      upsert_passed_task(testsuite_task, "✔️  PASSED: Containers with insecure capabilities were not found #{emoji_security}", task_start_time)
     else
-      resp = upsert_failed_task("insecure_capabilities", "✖️  FAILED: Found containers with insecure capabilities #{emoji_security}", Time.utc)
+      resp = upsert_failed_task(testsuite_task, "✖️  FAILED: Found containers with insecure capabilities #{emoji_security}", task_start_time)
       test_report.failed_resources.map {|r| stdout_failure(r.alert_message) }
       stdout_failure("Remediation: #{test_report.remediation}")
       resp
@@ -431,7 +443,10 @@ task "resource_policies", ["kubescape_scan"] do |_, args|
   next if args.named["offline"]?
 
   CNFManager::Task.task_runner(args) do |args, config|
-    Log.for("verbose").info { "resource_policies" } if check_verbose(args)
+    task_start_time = Time.utc
+    testsuite_task = "resource_policies"
+    Log.for(testsuite_task).info { "Starting test" }
+
     results_json = Kubescape.parse
     test_json = Kubescape.test_by_test_name(results_json, "Resource policies")
     test_report = Kubescape.parse_test_report(test_json)
@@ -440,9 +455,9 @@ task "resource_policies", ["kubescape_scan"] do |_, args|
 
     emoji_security = "🔓🔑"
     if test_report.failed_resources.size == 0
-      upsert_passed_task("resource_policies", "✔️  🏆 PASSED: Containers have resource limits defined #{emoji_security}", Time.utc)
+      upsert_passed_task(testsuite_task, "✔️  🏆 PASSED: Containers have resource limits defined #{emoji_security}", task_start_time)
     else
-      resp = upsert_failed_task("resource_policies", "✖️  🏆 FAILED: Found containers without resource limits defined #{emoji_security}", Time.utc)
+      resp = upsert_failed_task(testsuite_task, "✖️  🏆 FAILED: Found containers without resource limits defined #{emoji_security}", task_start_time)
       test_report.failed_resources.map {|r| stdout_failure(r.alert_message) }
       stdout_failure("Remediation: #{test_report.remediation}")
       resp
@@ -455,7 +470,10 @@ task "ingress_egress_blocked", ["kubescape_scan"] do |_, args|
   next if args.named["offline"]?
 
   CNFManager::Task.task_runner(args) do |args, config|
-    Log.for("verbose").info { "ingress_egress_blocked" } if check_verbose(args)
+    task_start_time = Time.utc
+    testsuite_task = "ingress_egress_blocked"
+    Log.for(testsuite_task).info { "Starting test" }
+
     results_json = Kubescape.parse
     test_json = Kubescape.test_by_test_name(results_json, "Ingress and Egress blocked")
     test_report = Kubescape.parse_test_report(test_json)
@@ -464,9 +482,9 @@ task "ingress_egress_blocked", ["kubescape_scan"] do |_, args|
 
     emoji_security = "🔓🔑"
     if test_report.failed_resources.size == 0
-      upsert_passed_task("ingress_egress_blocked", "✔️  ✨PASSED: Ingress and Egress traffic blocked on pods #{emoji_security}", Time.utc)
+      upsert_passed_task(testsuite_task, "✔️  ✨PASSED: Ingress and Egress traffic blocked on pods #{emoji_security}", task_start_time)
     else
-      resp = upsert_failed_task("ingress_egress_blocked", "✖️  ✨FAILED: Ingress and Egress traffic not blocked on pods #{emoji_security}", Time.utc)
+      resp = upsert_failed_task(testsuite_task, "✖️  ✨FAILED: Ingress and Egress traffic not blocked on pods #{emoji_security}", task_start_time)
       test_report.failed_resources.map {|r| stdout_failure(r.alert_message) }
       stdout_failure("Remediation: #{test_report.remediation}")
       resp
@@ -479,7 +497,10 @@ task "host_pid_ipc_privileges", ["kubescape_scan"] do |_, args|
   next if args.named["offline"]?
 
   CNFManager::Task.task_runner(args) do |args, config|
-    Log.for("verbose").info { "host_pid_ipc_privileges" } if check_verbose(args)
+    task_start_time = Time.utc
+    testsuite_task = "host_pid_ipc_privileges"
+    Log.for(testsuite_task).info { "Starting test" }
+
     results_json = Kubescape.parse
     test_json = Kubescape.test_by_test_name(results_json, "Host PID/IPC privileges")
     test_report = Kubescape.parse_test_report(test_json)
@@ -488,9 +509,9 @@ task "host_pid_ipc_privileges", ["kubescape_scan"] do |_, args|
 
     emoji_security = "🔓🔑"
     if test_report.failed_resources.size == 0
-      upsert_passed_task("host_pid_ipc_privileges", "✔️  PASSED: No containers with hostPID and hostIPC privileges #{emoji_security}", Time.utc)
+      upsert_passed_task(testsuite_task, "✔️  PASSED: No containers with hostPID and hostIPC privileges #{emoji_security}", task_start_time)
     else
-      resp = upsert_failed_task("host_pid_ipc_privileges", "✖️  FAILED: Found containers with hostPID and hostIPC privileges #{emoji_security}", Time.utc)
+      resp = upsert_failed_task(testsuite_task, "✖️  FAILED: Found containers with hostPID and hostIPC privileges #{emoji_security}", task_start_time)
       test_report.failed_resources.map {|r| stdout_failure(r.alert_message) }
       stdout_failure("Remediation: #{test_report.remediation}")
       resp
@@ -503,7 +524,10 @@ task "non_root_containers", ["kubescape_scan"] do |_, args|
   next if args.named["offline"]?
 
   CNFManager::Task.task_runner(args) do |args, config|
-    Log.for("verbose").info { "non_root_containers" } if check_verbose(args)
+    task_start_time = Time.utc
+    testsuite_task = "non_root_containers"
+    Log.for(testsuite_task).info { "Starting test" }
+
     results_json = Kubescape.parse
     test_json = Kubescape.test_by_test_name(results_json, "Non-root containers")
     test_report = Kubescape.parse_test_report(test_json)
@@ -512,9 +536,9 @@ task "non_root_containers", ["kubescape_scan"] do |_, args|
 
     emoji_security = "🔓🔑"
     if test_report.failed_resources.size == 0
-      upsert_passed_task("non_root_containers", "✔️  🏆 PASSED: Containers are running with non-root user with non-root group membership #{emoji_security}", Time.utc)
+      upsert_passed_task(testsuite_task, "✔️  🏆 PASSED: Containers are running with non-root user with non-root group membership #{emoji_security}", task_start_time)
     else
-      resp = upsert_failed_task("non_root_containers", "✖️  🏆 FAILED: Found containers running with root user or user with root group membership #{emoji_security}", Time.utc)
+      resp = upsert_failed_task(testsuite_task, "✖️  🏆 FAILED: Found containers running with root user or user with root group membership #{emoji_security}", task_start_time)
       test_report.failed_resources.map {|r| stdout_failure(r.alert_message) }
       stdout_failure("Remediation: #{test_report.remediation}")
       resp
@@ -527,7 +551,10 @@ task "privileged_containers", ["kubescape_scan" ] do |_, args|
   next if args.named["offline"]?
 
   CNFManager::Task.task_runner(args) do |args, config|
-    Log.for("verbose").info { "privileged_containers" } if check_verbose(args)
+    task_start_time = Time.utc
+    testsuite_task = "privileged_containers"
+    Log.for(testsuite_task).info { "Starting test" }
+
     results_json = Kubescape.parse
     test_json = Kubescape.test_by_test_name(results_json, "Privileged container")
     test_report = Kubescape.parse_test_report(test_json)
@@ -537,9 +564,9 @@ task "privileged_containers", ["kubescape_scan" ] do |_, args|
     emoji_security = "🔓🔑"
     #todo whitelist
     if test_report.failed_resources.size == 0
-      upsert_passed_task("privileged_containers", "✔️  🏆 PASSED: No privileged containers were found #{emoji_security}", Time.utc)
+      upsert_passed_task(testsuite_task, "✔️  🏆 PASSED: No privileged containers were found #{emoji_security}", task_start_time)
     else
-      resp = upsert_failed_task("privileged_containers", "✖️  🏆 FAILED: Found privileged containers #{emoji_security}", Time.utc)
+      resp = upsert_failed_task(testsuite_task, "✖️  🏆 FAILED: Found privileged containers #{emoji_security}", task_start_time)
       test_report.failed_resources.map {|r| stdout_failure(r.alert_message) }
       stdout_failure("Remediation: #{test_report.remediation}")
       resp
@@ -552,7 +579,10 @@ task "immutable_file_systems", ["kubescape_scan"] do |_, args|
   next if args.named["offline"]?
 
   CNFManager::Task.task_runner(args) do |args, config|
-    Log.for("verbose").info { "immutable_file_systems" } if check_verbose(args)
+    task_start_time = Time.utc
+    testsuite_task = "immutable_file_systems"
+    Log.for(testsuite_task).info { "Starting test" }
+
     results_json = Kubescape.parse
     test_json = Kubescape.test_by_test_name(results_json, "Immutable container filesystem")
     test_report = Kubescape.parse_test_report(test_json)
@@ -561,9 +591,9 @@ task "immutable_file_systems", ["kubescape_scan"] do |_, args|
 
     emoji_security = "🔓🔑"
     if test_report.failed_resources.size == 0
-      upsert_passed_task("immutable_file_systems", "✔️  ✨PASSED: Containers have immutable file systems #{emoji_security}", Time.utc)
+      upsert_passed_task(testsuite_task, "✔️  ✨PASSED: Containers have immutable file systems #{emoji_security}", task_start_time)
     else
-      resp = upsert_failed_task("immutable_file_systems", "✖️  ✨FAILED: Found containers with mutable file systems #{emoji_security}", Time.utc)
+      resp = upsert_failed_task(testsuite_task, "✖️  ✨FAILED: Found containers with mutable file systems #{emoji_security}", task_start_time)
       test_report.failed_resources.map {|r| stdout_failure(r.alert_message) }
       stdout_failure("Remediation: #{test_report.remediation}")
       resp
@@ -576,7 +606,10 @@ task "hostpath_mounts", ["kubescape_scan"] do |_, args|
   next if args.named["offline"]?
 
   CNFManager::Task.task_runner(args) do |args, config|
-    Log.for("verbose").info { "hostpath_mounts" } if check_verbose(args)
+    task_start_time = Time.utc
+    testsuite_task = "hostpath_mounts"
+    Log.for(testsuite_task).info { "Starting test" }
+
     results_json = Kubescape.parse
     test_json = Kubescape.test_by_test_name(results_json, "Allowed hostPath")
     test_report = Kubescape.parse_test_report(test_json)
@@ -585,9 +618,9 @@ task "hostpath_mounts", ["kubescape_scan"] do |_, args|
 
     emoji_security = "🔓🔑"
     if test_report.failed_resources.size == 0
-      upsert_passed_task("hostpath_mounts", "✔️  PASSED: Containers do not have hostPath mounts #{emoji_security}", Time.utc)
+      upsert_passed_task(testsuite_task, "✔️  PASSED: Containers do not have hostPath mounts #{emoji_security}", task_start_time)
     else
-      resp = upsert_failed_task("hostpath_mounts", "✖️  FAILED: Found containers with hostPath mounts #{emoji_security}", Time.utc)
+      resp = upsert_failed_task(testsuite_task, "✖️  FAILED: Found containers with hostPath mounts #{emoji_security}", task_start_time)
       test_report.failed_resources.map {|r| stdout_failure(r.alert_message) }
       stdout_failure("Remediation: #{test_report.remediation}")
       resp

--- a/src/tasks/workload/security.cr
+++ b/src/tasks/workload/security.cr
@@ -246,7 +246,8 @@ end
 desc "Check if any containers are running in privileged mode"
 task "privilege_escalation", ["kubescape_scan"] do |_, args|
   CNFManager::Task.task_runner(args) do |args, config|
-    VERBOSE_LOGGING.info "privilege_escalation" if check_verbose(args)
+    testsuite_task = "privilege_escalation"
+    Log.for(testsuite_task).info { "Starting test" }
     results_json = Kubescape.parse
     test_json = Kubescape.test_by_test_name(results_json, "Allow privilege escalation")
     test_report = Kubescape.parse_test_report(test_json)
@@ -255,9 +256,9 @@ task "privilege_escalation", ["kubescape_scan"] do |_, args|
 
     emoji_security="🔓🔑"
     if test_report.failed_resources.size == 0 
-      upsert_passed_task("privilege_escalation", "✔️  PASSED: No containers that allow privilege escalation were found #{emoji_security}", Time.utc)
+      upsert_passed_task(testsuite_task, "✔️  PASSED: No containers that allow privilege escalation were found #{emoji_security}", Time.utc)
     else
-      resp = upsert_failed_task("privilege_escalation", "✖️  FAILED: Found containers that allow privilege escalation #{emoji_security}", Time.utc)
+      resp = upsert_failed_task(testsuite_task, "✖️  FAILED: Found containers that allow privilege escalation #{emoji_security}", Time.utc)
       test_report.failed_resources.map {|r| stdout_failure(r.alert_message) }
       stdout_failure("Remediation: #{test_report.remediation}")
       resp

--- a/src/tasks/workload/security.cr
+++ b/src/tasks/workload/security.cr
@@ -211,7 +211,8 @@ end
 desc "Check if any containers are running in privileged mode"
 task "privileged" do |_, args|
   CNFManager::Task.task_runner(args) do |args, config|
-    Log.for("verbose").info { "privileged" } if check_verbose(args)
+    testsuite_task = "privileged"
+    Log.for(testsuite_task).info { "Starting test" }
     white_list_container_names = config.cnf_config[:white_list_container_names]
     VERBOSE_LOGGING.info "white_list_container_names #{white_list_container_names.inspect}" if check_verbose(args)
     violation_list = [] of NamedTuple(kind: String, name: String, container: String, namespace: String)
@@ -229,12 +230,12 @@ task "privileged" do |_, args|
         true
       end
     end
-    LOGGING.debug "violator list: #{violation_list.flatten}"
+    Log.debug { "violator list: #{violation_list.flatten}" }
     emoji_security="🔓🔑"
     if task_response 
-      upsert_passed_task("privileged", "✔️  PASSED: No privileged containers #{emoji_security}", Time.utc)
+      upsert_passed_task(testsuite_task, "✔️  PASSED: No privileged containers #{emoji_security}", Time.utc)
     else
-      upsert_failed_task("privileged", "✖️  FAILED: Found #{violation_list.size} privileged containers #{emoji_security}", Time.utc)
+      upsert_failed_task(testsuite_task, "✖️  FAILED: Found #{violation_list.size} privileged containers #{emoji_security}", Time.utc)
       violation_list.each do |violation|
         stdout_failure("Privileged container #{violation[:container]} in #{violation[:kind]}/#{violation[:name]} in the #{violation[:namespace]} namespace")
       end

--- a/src/tasks/workload/security.cr
+++ b/src/tasks/workload/security.cr
@@ -292,7 +292,8 @@ end
 desc "Check if applications credentials are in configuration files."
 task "application_credentials", ["kubescape_scan"] do |_, args|
   CNFManager::Task.task_runner(args) do |args, config|
-    VERBOSE_LOGGING.info "application_credentials" if check_verbose(args)
+    testsuite_task = "application_credentials"
+    Log.for(testsuite_task).info { "Starting test" }
     results_json = Kubescape.parse
     test_json = Kubescape.test_by_test_name(results_json, "Applications credentials in configuration files")
     test_report = Kubescape.parse_test_report(test_json)
@@ -301,9 +302,9 @@ task "application_credentials", ["kubescape_scan"] do |_, args|
 
     emoji_security="🔓🔑"
     if test_report.failed_resources.size == 0
-      upsert_passed_task("application_credentials", "✔️  PASSED: No applications credentials in configuration files #{emoji_security}", Time.utc)
+      upsert_passed_task(testsuite_task, "✔️  PASSED: No applications credentials in configuration files #{emoji_security}", Time.utc)
     else
-      resp = upsert_failed_task("application_credentials", "✖️  FAILED: Found applications credentials in configuration files #{emoji_security}", Time.utc)
+      resp = upsert_failed_task(testsuite_task, "✖️  FAILED: Found applications credentials in configuration files #{emoji_security}", Time.utc)
       test_report.failed_resources.map {|r| stdout_failure(r.alert_message) }
       stdout_failure("Remediation: #{test_report.remediation}")
       resp

--- a/src/tasks/workload/security.cr
+++ b/src/tasks/workload/security.cr
@@ -138,16 +138,19 @@ end
 desc "Check if the CNF is running containers with container sock mounts"
 task "container_sock_mounts" do |_, args|
   CNFManager::Task.task_runner(args) do |args, config|
-    Log.for("verbose").info { "container_sock_mounts" }
+    task_start_time = Time.utc
+    testsuite_task = "container_sock_mounts"
+    Log.for(testsuite_task).info { "Starting test" }
+
     Kyverno.install
     emoji_security = "🔓🔑"
     policy_path = Kyverno.best_practice_policy("disallow_cri_sock_mount/disallow_cri_sock_mount.yaml")
     failures = Kyverno::PolicyAudit.run(policy_path, EXCLUDE_NAMESPACES)
 
     if failures.size == 0
-      resp = upsert_passed_task("container_sock_mounts", "✔️  🏆 PASSED: Container engine daemon sockets are not mounted as volumes #{emoji_security}", Time.utc)
+      resp = upsert_passed_task(testsuite_task, "✔️  🏆 PASSED: Container engine daemon sockets are not mounted as volumes #{emoji_security}", task_start_time)
     else
-      resp = upsert_failed_task("container_sock_mounts", "✖️  🏆 FAILED: Container engine daemon sockets are mounted as volumes #{emoji_security}", Time.utc)
+      resp = upsert_failed_task(testsuite_task, "✖️  🏆 FAILED: Container engine daemon sockets are mounted as volumes #{emoji_security}", task_start_time)
       failures.each do |failure|
         failure.resources.each do |resource|
           puts "#{resource.kind} #{resource.name} in #{resource.namespace} namespace failed. #{failure.message}".colorize(:red)

--- a/src/tasks/workload/security.cr
+++ b/src/tasks/workload/security.cr
@@ -269,7 +269,8 @@ end
 desc "Check if an attacker can use symlink for arbitrary host file system access."
 task "symlink_file_system", ["kubescape_scan"] do |_, args|
   CNFManager::Task.task_runner(args) do |args, config|
-    VERBOSE_LOGGING.info "symlink_file_system" if check_verbose(args)
+    testsuite_task = "symlink_file_system"
+    Log.for(testsuite_task).info { "Starting test" }
     results_json = Kubescape.parse
     test_json = Kubescape.test_by_test_name(results_json, "CVE-2021-25741 - Using symlink for arbitrary host file system access.")
     test_report = Kubescape.parse_test_report(test_json)
@@ -278,9 +279,9 @@ task "symlink_file_system", ["kubescape_scan"] do |_, args|
 
     emoji_security="🔓🔑"
     if test_report.failed_resources.size == 0
-      upsert_passed_task("symlink_file_system", "✔️  PASSED: No containers allow a symlink attack #{emoji_security}", Time.utc)
+      upsert_passed_task(testsuite_task, "✔️  PASSED: No containers allow a symlink attack #{emoji_security}", Time.utc)
     else
-      resp = upsert_failed_task("symlink_file_system", "✖️  FAILED: Found containers that allow a symlink attack #{emoji_security}", Time.utc)
+      resp = upsert_failed_task(testsuite_task, "✖️  FAILED: Found containers that allow a symlink attack #{emoji_security}", Time.utc)
       test_report.failed_resources.map {|r| stdout_failure(r.alert_message) }
       stdout_failure("Remediation: #{test_report.remediation}")
       resp

--- a/src/tasks/workload/security.cr
+++ b/src/tasks/workload/security.cr
@@ -115,7 +115,7 @@ task "selinux_options" do |_, args|
 
     if check_failures.size == 0
       # upsert_skipped_task("selinux_options", "⏭️  🏆 SKIPPED: Pods are not using SELinux options #{emoji_security}", Time.utc)
-      upsert_na_task("selinux_options", "⏭️  🏆 N/A: Pods are not using SELinux #{emoji_security}", Time.utc)
+      upsert_na_task(testsuite_task, "⏭️  🏆 N/A: Pods are not using SELinux #{emoji_security}", task_start_time)
     else
       failures = Kyverno.filter_failures_for_cnf_resources(resource_keys, disallow_failures)
 
@@ -169,7 +169,7 @@ task "non_root_user", ["install_falco"] do |_, args|
     
     unless KubectlClient::Get.resource_wait_for_install("Daemonset", "falco", namespace: TESTSUITE_NAMESPACE)
       Log.info { "Falco Failed to Start" }
-      upsert_skipped_task("non_root_user", "⏭️  SKIPPED: Skipping non_root_user: Falco failed to install. Check Kernel Headers are installed on the Host Systems(K8s).", task_start_time)
+      upsert_skipped_task(testsuite_task, "⏭️  SKIPPED: Skipping non_root_user: Falco failed to install. Check Kernel Headers are installed on the Host Systems(K8s).", task_start_time)
       node_pods = KubectlClient::Get.pods_by_nodes(KubectlClient::Get.schedulable_nodes_list)
       pods = KubectlClient::Get.pods_by_label(node_pods, "app", "falco")
 

--- a/src/tasks/workload/security.cr
+++ b/src/tasks/workload/security.cr
@@ -225,8 +225,10 @@ end
 desc "Check if any containers are running in privileged mode"
 task "privileged" do |_, args|
   CNFManager::Task.task_runner(args) do |args, config|
+    task_start_time = Time.utc
     testsuite_task = "privileged"
     Log.for(testsuite_task).info { "Starting test" }
+
     white_list_container_names = config.cnf_config[:white_list_container_names]
     VERBOSE_LOGGING.info "white_list_container_names #{white_list_container_names.inspect}" if check_verbose(args)
     violation_list = [] of NamedTuple(kind: String, name: String, container: String, namespace: String)
@@ -247,9 +249,9 @@ task "privileged" do |_, args|
     Log.debug { "violator list: #{violation_list.flatten}" }
     emoji_security="🔓🔑"
     if task_response 
-      upsert_passed_task(testsuite_task, "✔️  PASSED: No privileged containers #{emoji_security}", Time.utc)
+      upsert_passed_task(testsuite_task, "✔️  PASSED: No privileged containers #{emoji_security}", task_start_time)
     else
-      upsert_failed_task(testsuite_task, "✖️  FAILED: Found #{violation_list.size} privileged containers #{emoji_security}", Time.utc)
+      upsert_failed_task(testsuite_task, "✖️  FAILED: Found #{violation_list.size} privileged containers #{emoji_security}", task_start_time)
       violation_list.each do |violation|
         stdout_failure("Privileged container #{violation[:container]} in #{violation[:kind]}/#{violation[:name]} in the #{violation[:namespace]} namespace")
       end
@@ -260,8 +262,10 @@ end
 desc "Check if any containers are running in privileged mode"
 task "privilege_escalation", ["kubescape_scan"] do |_, args|
   CNFManager::Task.task_runner(args) do |args, config|
+    task_start_time = Time.utc
     testsuite_task = "privilege_escalation"
     Log.for(testsuite_task).info { "Starting test" }
+
     results_json = Kubescape.parse
     test_json = Kubescape.test_by_test_name(results_json, "Allow privilege escalation")
     test_report = Kubescape.parse_test_report(test_json)
@@ -270,9 +274,9 @@ task "privilege_escalation", ["kubescape_scan"] do |_, args|
 
     emoji_security="🔓🔑"
     if test_report.failed_resources.size == 0 
-      upsert_passed_task(testsuite_task, "✔️  PASSED: No containers that allow privilege escalation were found #{emoji_security}", Time.utc)
+      upsert_passed_task(testsuite_task, "✔️  PASSED: No containers that allow privilege escalation were found #{emoji_security}", task_start_time)
     else
-      resp = upsert_failed_task(testsuite_task, "✖️  FAILED: Found containers that allow privilege escalation #{emoji_security}", Time.utc)
+      resp = upsert_failed_task(testsuite_task, "✖️  FAILED: Found containers that allow privilege escalation #{emoji_security}", task_start_time)
       test_report.failed_resources.map {|r| stdout_failure(r.alert_message) }
       stdout_failure("Remediation: #{test_report.remediation}")
       resp
@@ -283,8 +287,10 @@ end
 desc "Check if an attacker can use symlink for arbitrary host file system access."
 task "symlink_file_system", ["kubescape_scan"] do |_, args|
   CNFManager::Task.task_runner(args) do |args, config|
+    task_start_time = Time.utc
     testsuite_task = "symlink_file_system"
     Log.for(testsuite_task).info { "Starting test" }
+
     results_json = Kubescape.parse
     test_json = Kubescape.test_by_test_name(results_json, "CVE-2021-25741 - Using symlink for arbitrary host file system access.")
     test_report = Kubescape.parse_test_report(test_json)
@@ -293,9 +299,9 @@ task "symlink_file_system", ["kubescape_scan"] do |_, args|
 
     emoji_security="🔓🔑"
     if test_report.failed_resources.size == 0
-      upsert_passed_task(testsuite_task, "✔️  PASSED: No containers allow a symlink attack #{emoji_security}", Time.utc)
+      upsert_passed_task(testsuite_task, "✔️  PASSED: No containers allow a symlink attack #{emoji_security}", task_start_time)
     else
-      resp = upsert_failed_task(testsuite_task, "✖️  FAILED: Found containers that allow a symlink attack #{emoji_security}", Time.utc)
+      resp = upsert_failed_task(testsuite_task, "✖️  FAILED: Found containers that allow a symlink attack #{emoji_security}", task_start_time)
       test_report.failed_resources.map {|r| stdout_failure(r.alert_message) }
       stdout_failure("Remediation: #{test_report.remediation}")
       resp
@@ -306,8 +312,10 @@ end
 desc "Check if applications credentials are in configuration files."
 task "application_credentials", ["kubescape_scan"] do |_, args|
   CNFManager::Task.task_runner(args) do |args, config|
+    task_start_time = Time.utc
     testsuite_task = "application_credentials"
     Log.for(testsuite_task).info { "Starting test" }
+
     results_json = Kubescape.parse
     test_json = Kubescape.test_by_test_name(results_json, "Applications credentials in configuration files")
     test_report = Kubescape.parse_test_report(test_json)
@@ -316,9 +324,9 @@ task "application_credentials", ["kubescape_scan"] do |_, args|
 
     emoji_security="🔓🔑"
     if test_report.failed_resources.size == 0
-      upsert_passed_task(testsuite_task, "✔️  PASSED: No applications credentials in configuration files #{emoji_security}", Time.utc)
+      upsert_passed_task(testsuite_task, "✔️  PASSED: No applications credentials in configuration files #{emoji_security}", task_start_time)
     else
-      resp = upsert_failed_task(testsuite_task, "✖️  FAILED: Found applications credentials in configuration files #{emoji_security}", Time.utc)
+      resp = upsert_failed_task(testsuite_task, "✖️  FAILED: Found applications credentials in configuration files #{emoji_security}", task_start_time)
       test_report.failed_resources.map {|r| stdout_failure(r.alert_message) }
       stdout_failure("Remediation: #{test_report.remediation}")
       resp

--- a/src/tasks/workload/security.cr
+++ b/src/tasks/workload/security.cr
@@ -38,7 +38,9 @@ end
 desc "Check if pods in the CNF use sysctls with restricted values"
 task "sysctls" do |_, args|
   CNFManager::Task.task_runner(args) do |args, config|
-    Log.for("verbose").info { "sysctls" }
+    task_start_time = Time.utc
+    testsuite_task = "sysctls"
+    Log.for(testsuite_task).info { "Starting test" }
     Kyverno.install
 
     emoji_security = "🔓🔑"
@@ -48,9 +50,9 @@ task "sysctls" do |_, args|
     failures = Kyverno.filter_failures_for_cnf_resources(resource_keys, failures)
 
     if failures.size == 0
-      resp = upsert_passed_task("sysctls", "✔️  PASSED: No restricted values found for sysctls #{emoji_security}", Time.utc)
+      resp = upsert_passed_task(testsuite_task, "✔️  PASSED: No restricted values found for sysctls #{emoji_security}", task_start_time)
     else
-      resp = upsert_failed_task("sysctls", "✖️  FAILED: Restricted values for are being used for sysctls #{emoji_security}", Time.utc)
+      resp = upsert_failed_task(testsuite_task, "✖️  FAILED: Restricted values for are being used for sysctls #{emoji_security}", task_start_time)
       failures.each do |failure|
         failure.resources.each do |resource|
           puts "#{resource.kind} #{resource.name} in #{resource.namespace} namespace failed. #{failure.message}".colorize(:red)

--- a/src/tasks/workload/security.cr
+++ b/src/tasks/workload/security.cr
@@ -163,10 +163,13 @@ end
 desc "Check if any containers are running in as root"
 task "non_root_user", ["install_falco"] do |_, args|
    CNFManager::Task.task_runner(args) do |args,config|
-
+    task_start_time = Time.utc
+    testsuite_task = "non_root_user"
+    Log.for(testsuite_task).info { "Starting test" }
+    
      unless KubectlClient::Get.resource_wait_for_install("Daemonset", "falco", namespace: TESTSUITE_NAMESPACE)
        Log.info { "Falco Failed to Start" }
-       upsert_skipped_task("non_root_user", "⏭️  SKIPPED: Skipping non_root_user: Falco failed to install. Check Kernel Headers are installed on the Host Systems(K8s).", Time.utc)
+       upsert_skipped_task("non_root_user", "⏭️  SKIPPED: Skipping non_root_user: Falco failed to install. Check Kernel Headers are installed on the Host Systems(K8s).", task_start_time)
        node_pods = KubectlClient::Get.pods_by_nodes(KubectlClient::Get.schedulable_nodes_list)
        pods = KubectlClient::Get.pods_by_label(node_pods, "app", "falco")
 
@@ -212,9 +215,9 @@ task "non_root_user", ["install_falco"] do |_, args|
      emoji_root="√"
 
      if task_response
-       upsert_passed_task("non_root_user", "✔️  PASSED: Root user not found #{emoji_no_root}", Time.utc)
+       upsert_passed_task(testsuite_task, "✔️  PASSED: Root user not found #{emoji_no_root}", task_start_time)
      else
-       upsert_failed_task("non_root_user", "✖️  FAILED: Root user found #{emoji_root}", Time.utc)
+       upsert_failed_task(testsuite_task, "✖️  FAILED: Root user found #{emoji_root}", task_start_time)
      end
    end
 end

--- a/src/tasks/workload/state.cr
+++ b/src/tasks/workload/state.cr
@@ -222,7 +222,6 @@ task "node_drain", ["install_litmus"] do |t, args|
     testsuite_task = "node_drain"
     Log.for(testsuite_task).info { "Starting test" }
 
-    Log.for(test_name).info { "Starting test" } if check_verbose(args)
     skipped = false
     Log.debug { "cnf_config: #{config}" }
     destination_cnf_dir = config.cnf_config[:destination_cnf_dir]
@@ -320,10 +319,10 @@ task "node_drain", ["install_litmus"] do |t, args|
             # rbac_url = "https://hub.litmuschaos.io/api/chaos/#{LitmusManager::Version}?file=charts/generic/node-drain/rbac.yaml"
             rbac_url = "https://raw.githubusercontent.com/litmuschaos/chaos-charts/#{LitmusManager::Version}/charts/generic/node-drain/rbac.yaml"
 
-            experiment_path = LitmusManager.download_template(experiment_url, "#{test_name}_experiment.yaml")
+            experiment_path = LitmusManager.download_template(experiment_url, "#{testsuite_task}_experiment.yaml")
             KubectlClient::Apply.file(experiment_path, namespace: app_namespace)
   
-            rbac_path = LitmusManager.download_template(rbac_url, "#{test_name}_rbac.yaml")
+            rbac_path = LitmusManager.download_template(rbac_url, "#{testsuite_task}_rbac.yaml")
             rbac_yaml = File.read(rbac_path)
             rbac_yaml = rbac_yaml.gsub("namespace: default", "namespace: #{app_namespace}")
             File.write(rbac_path, rbac_yaml)
@@ -560,7 +559,7 @@ task "no_local_volume_configuration" do |_, args|
         if resource["spec"].as_h["template"].as_h["spec"].as_h["volumes"]?
             volumes = resource["spec"].as_h["template"].as_h["spec"].as_h["volumes"].as_a 
         end
-        Log.for(testsuite_task).debug "volumes: #{volumes}"
+        Log.for(testsuite_task).debug { "volumes: #{volumes}" }
         persistent_volume_claim_names = volumes.map do |volume|
           # get persistent volume claim that matches persistent volume claim name
           if volume.as_h["persistentVolumeClaim"]? && volume.as_h["persistentVolumeClaim"].as_h["claimName"]?
@@ -569,7 +568,7 @@ task "no_local_volume_configuration" do |_, args|
             nil 
           end
         end.compact
-        Log.debug.for(testsuite_task) { "persistent volume claim names: #{persistent_volume_claim_names}" }
+        Log.for(testsuite_task).debug { "persistent volume claim names: #{persistent_volume_claim_names}" }
 
         # TODO (optional) check storage class of persistent volume claim
         # loop through all pvc names


### PR DESCRIPTION
## Issues: #1841

## Description

* Publish a log message when a task is started. This helps identify when test starts running for a particular CNF.
* The task timestamps are now published to the info log irrespective of `TASK_TIMESTAMPS=true` being set.
* For log messages directly within the test task, publish log messages with Log.for instead of the top-level log (Log).

## How has this been tested:
 - [x] Covered by existing integration testing
 - [ ] Added integration testing to cover
 - [ ] Verified all A/C passes
     * [ ] develop
     * [ ] master
     * [ ] tag/other branch
 - [ ] Test environment
    * [ ] Shared Packet K8s cluster
    * [ ] New Packet K8s cluster
    * [ ] Kind cluster
 - [ ] Have not tested

## Types of changes:
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [ ] Documentation update

## Checklist:
**Documentation**
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] No updates required.

**Code Review**
- [ ] Does the test handle fatal exceptions, ie. rescue block

**Issue**
- [ ] Tasks in issue are checked off
