### PR TITLE
results and points.yml: Fix unnecessary creation and add exceptions

### DIFF
--- a/src/cnf-testsuite.cr
+++ b/src/cnf-testsuite.cr
@@ -131,7 +131,7 @@ begin
   # See issue #426 for exit code requirement
   Sam.process_tasks(ARGV.clone)
 
-  if File.exists?("#{CNFManager::Points::Results.file}")
+  if CNFManager::Points::Results.file_exists?
     yaml = File.open("#{CNFManager::Points::Results.file}") do |file|
       YAML.parse(file)
     end

--- a/src/tasks/cleanup.cr
+++ b/src/tasks/cleanup.cr
@@ -64,7 +64,7 @@ task "cleanup_all", ["samples_cleanup", "tools_cleanup"] do  |_, args|
 end
 
 task "results_yml_cleanup" do |_, args|
-  if File.exists?("#{CNFManager::Points::Results.file}")
+  if CNFManager::Points::Results.file_exists?
     File.delete(CNFManager::Points::Results.file)
     Log.for("verbose").info { "Deleted results file at #{CNFManager::Points::Results.file}" } if check_verbose(args)
   end

--- a/src/tasks/cnf_conformance_setup.cr
+++ b/src/tasks/cnf_conformance_setup.cr
@@ -10,8 +10,13 @@ end
 
 desc "Sets up initial directories for the cnf-testsuite suite"
 task "cnf_directory_setup" do |_, args|
-  FileUtils.mkdir_p("cnfs")
-  FileUtils.mkdir_p("tools")
+  begin
+    FileUtils.mkdir_p("cnfs")
+    FileUtils.mkdir_p("tools")
+  rescue File::AccessDeniedError
+    Log.error {"ERROR: missing write permission in current directory"}
+    exit 1
+  end
   stdout_success "Successfully created directories for cnf-testsuite"
 end
 

--- a/src/tasks/constants.cr
+++ b/src/tasks/constants.cr
@@ -32,7 +32,6 @@ EmbeddedFileManager.chaos_network_loss
 EmbeddedFileManager.chaos_cpu_hog
 EmbeddedFileManager.chaos_container_kill
 EmbeddedFileManager.points_yml
-EmbeddedFileManager.points_yml_write_file
 EmbeddedFileManager.enforce_image_tag
 EmbeddedFileManager.constraint_template
 EmbeddedFileManager.disable_cni

--- a/src/tasks/utils/embedded_file_manager.cr
+++ b/src/tasks/utils/embedded_file_manager.cr
@@ -44,6 +44,11 @@ module EmbeddedFileManager
     UERANSIM_HELMCONFIG = Base64.decode_string("{{ `cat ./embedded_files/ue.yaml | base64`}}")
   end
   def self.points_yml_write_file
-    File.write("points.yml", POINTSFILE)
+    begin
+      File.write("points.yml", POINTSFILE)
+    rescue File::AccessDeniedError
+      Log.error {"ERROR: missing write permission in current directory"}
+      exit 1
+    end
   end
 end


### PR DESCRIPTION
## Description
Fix creation of results file and folder during class definition. Now, they are created only on-demand via updated getter. Fix creation of points.yml file during the definition of constants. Add meaningful error messages if these files could not be created due to insuficcient user permissions in current directory.

Tested: results folder and points.yml are not created on "help" and "version" commands. If user does not have permissions in workdir - other commands still fail due to not sufficient permissions (but i suppose, that covering them with meaningful error messages should be done in another change). Workload tests are running without issues with this change, so any functionality shouldn't be lost. 

## Issues:
Refs: #1802

## How has this been tested:
 - [ ] Covered by existing integration testing
 - [ ] Added integration testing to cover
 - [ ] Verified all A/C passes
     * [ ] develop
     * [ ] master
     * [ ] tag/other branch
 - [ ] Test environment
    * [ ] Shared Packet K8s cluster
    * [ ] New Packet K8s cluster
    * [ ] Kind cluster
 - [ ] Have not tested

## Types of changes:
 - [*] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [ ] Documentation update

## Checklist:
**Documentation**
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [*] No updates required.

**Code Review**
- [*] Does the test handle fatal exceptions, ie. rescue block

**Issue**
- [ ] Tasks in issue are checked off
